### PR TITLE
-- linux: add and use linker version script

### DIFF
--- a/SilKit/source/CMakeLists.txt
+++ b/SilKit/source/CMakeLists.txt
@@ -252,6 +252,7 @@ elseif(UNIX AND NOT APPLE)
 		    PRIVATE -Wl,--build-id=sha1)
 	    endif()
     endif()
+    target_link_options(SilKit PRIVATE "LINKER:--version-script=${CMAKE_CURRENT_SOURCE_DIR}/silkit.map")
 endif()
 
 if ((CMAKE_CXX_COMPILER_ID STREQUAL GNU OR CMAKE_CXX_COMPILER_ID STREQUAL Clang) AND NOT SILKIT_USE_SYSTEM_LIBRARIES)

--- a/SilKit/source/silkit.map
+++ b/SilKit/source/silkit.map
@@ -1,0 +1,38 @@
+/*
+ * SPDX-FileCopyrightText: 2024 Vector Informatik GmbH
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+
+/* This version script does not apply symbol versioning, it only changes symbol visibility! */
+{
+    global:
+        SilKit_*;
+
+        extern "C++" {
+            "SilKit::Config::ParticipantConfigurationFromString(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)";
+            "SilKit::Config::ParticipantConfigurationFromFile(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)";
+
+            "SilKit::CreateParticipant(std::shared_ptr<SilKit::Config::IParticipantConfiguration>, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)";
+            "SilKit::CreateParticipant(std::shared_ptr<SilKit::Config::IParticipantConfiguration>, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)";
+
+            "SilKit::Experimental::Participant::CreateSystemController(SilKit::IParticipant*)";
+
+            "SilKit::Experimental::Services::Lin::GetSlaveConfiguration(SilKit::Services::Lin::ILinController*)";
+            "SilKit::Experimental::Services::Lin::AddLinSlaveConfigurationHandler(SilKit::Services::Lin::ILinController*, std::function<void (SilKit::Services::Lin::ILinController*, SilKit::Experimental::Services::Lin::LinSlaveConfigurationEvent const&)>)";
+            "SilKit::Experimental::Services::Lin::RemoveLinSlaveConfigurationHandler(SilKit::Services::Lin::ILinController*, SilKit::Util::HandlerId)";
+
+            "SilKit::Vendor::Vector::CreateSilKitRegistry(std::shared_ptr<SilKit::Config::IParticipantConfiguration>)";
+
+            "SilKit::Version::Major()";
+            "SilKit::Version::Minor()";
+            "SilKit::Version::Patch()";
+            "SilKit::Version::BuildNumber()";
+            "SilKit::Version::String()";
+            "SilKit::Version::VersionSuffix()";
+            "SilKit::Version::GitHash()";
+        };
+    local:
+        *;
+};


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2023 Vector Informatik GmbH

SPDX-License-Identifier: MIT
-->

## Subject
<!--
    - What kind of changes does this pull request comprise?
    - Add a label like "Bugfix", "docs", etc. to this PR to give context.
 -->

Adds a version script to the linkage of the main SIL Kit library which only makes
- the C symbols (i.e., `SilKit_*`)
- and the 'legacy' C++ symbols (all functions defined in `SilKit/source/LegacyAbi.cpp`)
visible in the `.so`.

This works for both, the Release and Debug builds.

## Instructions for review / testing
<!--
    - Hilight some of the important changes, which reviewers should focus on
    - Which parts should be reviewed in detail? For example: content of console output, correct semantics of changes
    - Test steps and test setup description. For example: which programs or configs to use
-->

The resulting library was tested with the demos from this repository, the adapters, and the simulator.

## Developer checklist (address before review)

- [ ] Changelog.md updated
- [ ] Prepared update for depending repositories
- [ ] Documentation updated (public API changes only)
- [ ] API docstrings updated (public API changes only)
- [ ] Rebase &rarr; commit history clean
- [x] Squash and merge &rarr; proper PR title
