### PR TITLE
ITest_Dashboard: delay Stop() in SimStepHandler

### DIFF
--- a/SilKit/IntegrationTests/ITest_Dashboard.cpp
+++ b/SilKit/IntegrationTests/ITest_Dashboard.cpp
@@ -496,9 +496,11 @@ TEST_F(ITest_Dashboard, dashboard_netsim_coordinated)
                     }
                 });
                 timeSyncService->SetSimulationStepHandler(
-                    [simParticipant](auto, auto) {
-                        Log() << simParticipant->Name() << ": stopping";
-                        simParticipant->Stop();
+                    [simParticipant](auto currentSimTime, auto duration) {
+                        if(currentSimTime > duration) {
+                            Log() << simParticipant->Name() << ": stopping";
+                            simParticipant->Stop();
+                        }
                     },
                     10ms);
             }


### PR DESCRIPTION
## **Subject**
The netsim_coordinated test would immediately call the stop function of the simulation participant which would result in the dashboard 'seeing' the stop state before the running state and the test would fail.

This delays the Stop() until at least on step duration has passed (1 step) which fixes the issue of dashboard missing states.
>

## Developer checklist (address before review)

- [ ] Changelog.md updated
- [ ] Prepared update for depending repositories
- [ ] Documentation updated (public API changes only)
- [ ] API docstrings updated (public API changes only)
- [ ] Rebase &rarr; commit history clean
- [ ] Squash and merge &rarr; proper PR title
