### PR TITLE
-- mingw: use ifstream constructor taking a const wchar_t *

### DIFF
--- a/SilKit/source/capi/CapiParticipant.cpp
+++ b/SilKit/source/capi/CapiParticipant.cpp
@@ -214,7 +214,7 @@ auto OpenTextFile(const std::string& path) -> std::ifstream
         throw SilKit::ConfigurationError{"conversion from UTF-8 to UTF-16 failed"};
     }
 
-    return std::ifstream{widePath};
+    return std::ifstream{widePath.c_str()};
 }
 
 #else


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2023 Vector Informatik GmbH

SPDX-License-Identifier: MIT
-->

## Subject
<!--
    - What kind of changes does this pull request comprise?
    - Add a label like "Bugfix", "docs", etc. to this PR to give context.
 -->

In the C-API `SilKit_ParticipantConfigurationFromFile` implementation for `_WIN32` platforms we use a non-standard overload of the `std::ifstream` constructor which takes a `std::wstring` (to allow unicode symbols in the path). This PR switches to the overload taking a `const wchar_t *` which is provided on MSVC as well as MinGW.

## Instructions for review / testing
<!--
    - Hilight some of the important changes, which reviewers should focus on
    - Which parts should be reviewed in detail? For example: content of console output, correct semantics of changes
    - Test steps and test setup description. For example: which programs or configs to use
-->

## Developer checklist (address before review)

- [ ] Changelog.md updated
- [ ] Prepared update for depending repositories
- [ ] Documentation updated (public API changes only)
- [ ] API docstrings updated (public API changes only)
- [ ] Rebase &rarr; commit history clean
- [x] Squash and merge &rarr; proper PR title
