### PR TITLE
-- cmake on mingw: remove broken and obsolete code

### DIFF
--- a/SilKit/cmake/SilKitTest.cmake
+++ b/SilKit/cmake/SilKitTest.cmake
@@ -64,12 +64,6 @@ function(add_silkit_test_executable SILKIT_TEST_EXECUTABLE_NAME)
     if (MSVC)
         target_compile_options("${SILKIT_TEST_EXECUTABLE_NAME}" PRIVATE "/bigobj")
     endif(MSVC)
-
-    #ensure test execution has the MinGW libraries in PATH
-    if(MINGW)
-        get_filename_component(compilerDir ${CMAKE_CXX_COMPILER} DIRECTORY)
-        set_tests_properties(${SILKIT_TEST_EXECUTABLE_NAME} PROPERTIES ENVIRONMENT "PATH=${compilerDir};")
-    endif()
 endfunction()
 
 function(add_silkit_test_to_executable SILKIT_TEST_EXECUTABLE_NAME)


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2023 Vector Informatik GmbH

SPDX-License-Identifier: MIT
-->

## Subject
<!--
    - What kind of changes does this pull request comprise?
    - Add a label like "Bugfix", "docs", etc. to this PR to give context.
 -->

Due to the test consolidation, the individual test executables are added as tests in a different place in the CMake scripts. A piece of CMake script hidden behind an if caused the configuration step to fail for builds on MinGW. This PR removes this piece of code. Testing seems to work (at least for me) without the removed code.

## Instructions for review / testing
<!--
    - Hilight some of the important changes, which reviewers should focus on
    - Which parts should be reviewed in detail? For example: content of console output, correct semantics of changes
    - Test steps and test setup description. For example: which programs or configs to use
-->

## Developer checklist (address before review)

- [ ] Changelog.md updated
- [ ] Prepared update for depending repositories
- [ ] Documentation updated (public API changes only)
- [ ] API docstrings updated (public API changes only)
- [ ] Rebase &rarr; commit history clean
- [x] Squash and merge &rarr; proper PR title
