### PR TITLE
-- cmake on mingw: use big-obj with gcc and clang

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -74,6 +74,9 @@ add_compile_definitions(
     ASIO_DISABLE_VISIBILITY=1
 )
 
+if(MINGW AND (CMAKE_CXX_COMPILER_ID MATCHES GNU OR CMAKE_CXX_COMPILER_ID MATCHES Clang))
+    add_compile_options("-Wa,-mbig-obj")
+endif()
 
 list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR}/cmake ${CMAKE_CURRENT_LIST_DIR}/SilKit/cmake)
 include(SilKitInstall)


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2023 Vector Informatik GmbH

SPDX-License-Identifier: MIT
-->

## Subject
<!--
    - What kind of changes does this pull request comprise?
    - Add a label like "Bugfix", "docs", etc. to this PR to give context.
 -->

Use `-Wa,-mbig-obj` to allow bigger object files generated by the assembler. This solved an issue that occured during testing of the MinGW builds.

## Instructions for review / testing
<!--
    - Hilight some of the important changes, which reviewers should focus on
    - Which parts should be reviewed in detail? For example: content of console output, correct semantics of changes
    - Test steps and test setup description. For example: which programs or configs to use
-->

## Developer checklist (address before review)

- [ ] Changelog.md updated
- [ ] Prepared update for depending repositories
- [ ] Documentation updated (public API changes only)
- [ ] API docstrings updated (public API changes only)
- [ ] Rebase &rarr; commit history clean
- [x] Squash and merge &rarr; proper PR title
