### PR TITLE
ParticipantConfig: add Include Semantics support

### DIFF
--- a/SilKit/IntegrationTests/Hourglass/MockCapi.cpp
+++ b/SilKit/IntegrationTests/Hourglass/MockCapi.cpp
@@ -779,6 +779,13 @@ extern "C"
                                                                       participantConfigurationString);
     }
 
+    SilKit_ReturnCode SilKitCALL SilKit_ParticipantConfiguration_FromFile(
+        SilKit_ParticipantConfiguration** outParticipantConfiguration, const char* participantConfigurationFilename)
+    {
+        return globalCapi->SilKit_ParticipantConfiguration_FromFile(outParticipantConfiguration,
+                                                                      participantConfigurationFilename);
+    }
+
     SilKit_ReturnCode SilKitCALL
     SilKit_ParticipantConfiguration_Destroy(SilKit_ParticipantConfiguration* participantConfiguration)
     {

--- a/SilKit/IntegrationTests/Hourglass/MockCapi.hpp
+++ b/SilKit/IntegrationTests/Hourglass/MockCapi.hpp
@@ -422,6 +422,10 @@ public:
                 (SilKit_ParticipantConfiguration * *outParticipantConfiguration,
                  const char* participantConfigurationString));
 
+    MOCK_METHOD(SilKit_ReturnCode, SilKit_ParticipantConfiguration_FromFile,
+                (SilKit_ParticipantConfiguration * *outParticipantConfiguration,
+                 const char* participantConfigurationFilename));
+
     MOCK_METHOD(SilKit_ReturnCode, SilKit_ParticipantConfiguration_Destroy,
                 (SilKit_ParticipantConfiguration * participantConfiguration));
 

--- a/SilKit/IntegrationTests/Hourglass/Test_HourglassParticipantLogger.cpp
+++ b/SilKit/IntegrationTests/Hourglass/Test_HourglassParticipantLogger.cpp
@@ -54,6 +54,8 @@ public:
             .WillByDefault(DoAll(SetArgPointee<0>(mockLogger), Return(SilKit_ReturnCode_SUCCESS)));
         ON_CALL(capi, SilKit_ParticipantConfiguration_FromString(_, _))
             .WillByDefault(DoAll(SetArgPointee<0>(mockConfiguration), Return(SilKit_ReturnCode_SUCCESS)));
+        ON_CALL(capi, SilKit_ParticipantConfiguration_FromFile(_, _))
+            .WillByDefault(DoAll(SetArgPointee<0>(mockConfiguration), Return(SilKit_ReturnCode_SUCCESS)));
     }
 };
 
@@ -64,6 +66,15 @@ TEST_F(Test_HourglassParticipantLogger, SilKit_ParticipantConfiguration_FromStri
     EXPECT_CALL(capi, SilKit_ParticipantConfiguration_FromString(testing::_, testing::StrEq(configString.c_str())))
         .Times(1);
     SilKit::Config::ParticipantConfigurationFromString(configString);
+}
+
+TEST_F(Test_HourglassParticipantLogger, SilKit_ParticipantConfiguration_FromFile)
+{
+    std::string configFilename = "";
+
+    EXPECT_CALL(capi, SilKit_ParticipantConfiguration_FromFile(testing::_, testing::StrEq(configFilename.c_str())))
+        .Times(1);
+    SilKit::Config::ParticipantConfigurationFromFile(configFilename);
 }
 
 TEST_F(Test_HourglassParticipantLogger, SilKit_ParticipantConfiguration_Destroy)

--- a/SilKit/include/silkit/detail/impl/config/IParticipantConfiguration.ipp
+++ b/SilKit/include/silkit/detail/impl/config/IParticipantConfiguration.ipp
@@ -26,10 +26,6 @@
 #include "silkit/detail/impl/ThrowOnError.hpp"
 #include "silkit/detail/impl/config/ParticipantConfiguration.hpp"
 
-#include <sstream>
-#include <fstream>
-
-
 namespace SilKit {
 DETAIL_SILKIT_DETAIL_VN_NAMESPACE_BEGIN
 namespace Config {

--- a/SilKit/source/capi/CapiParticipant.cpp
+++ b/SilKit/source/capi/CapiParticipant.cpp
@@ -34,17 +34,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE. */
 #include <memory>
 #include <map>
 #include <mutex>
-
-#ifdef _WIN32
-#    define NOMINMAX
-#    define WIN32_LEAN_AND_MEAN
-#    include "Windows.h"
-#endif
-
-
-namespace {
-auto OpenTextFile(const std::string& path) -> std::ifstream;
-} // namespace
+#include <fstream>
 
 
 SilKit_ReturnCode SilKitCALL SilKit_Participant_Create(SilKit_Participant** outParticipant,
@@ -148,18 +138,21 @@ try
     ASSERT_VALID_OUT_PARAMETER(outParticipantConfiguration);
     ASSERT_VALID_POINTER_PARAMETER(participantConfigurationPath);
 
-    std::stringstream ss;
-
-    // read the whole configuration file
+    // create the configuration using the C++ API function
+    auto cppSharedParticipantConfiguration = std::dynamic_pointer_cast<SilKit::Config::ParticipantConfiguration>(
+        SilKit::Config::ParticipantConfigurationFromFileImpl(participantConfigurationPath));
+    if (cppSharedParticipantConfiguration == nullptr)
     {
-        const auto fs = OpenTextFile(participantConfigurationPath);
-        ss << fs.rdbuf();
+        SilKit_error_string = "Participant configuration could not be created.";
+        return SilKit_ReturnCode_UNSPECIFIEDERROR;
     }
 
-    const auto string = ss.str();
+    // since it is not possible to release the "raw" pointer from a shared_ptr, we copy it into our own raw pointer
+    auto* cppParticipantConfiguration =
+        new SilKit::Config::ParticipantConfiguration(*cppSharedParticipantConfiguration);
 
-    // dispatch to the function reading the configuration from a string
-    return SilKit_ParticipantConfiguration_FromString(outParticipantConfiguration, string.c_str());
+    *outParticipantConfiguration = reinterpret_cast<SilKit_ParticipantConfiguration*>(cppParticipantConfiguration);
+    return SilKit_ReturnCode_SUCCESS;
 }
 CAPI_CATCH_EXCEPTIONS
 
@@ -183,47 +176,3 @@ try
     return SilKit_ReturnCode_SUCCESS;
 }
 CAPI_CATCH_EXCEPTIONS
-
-
-namespace {
-
-#ifdef _WIN32
-
-auto OpenTextFile(const std::string& path) -> std::ifstream
-{
-    std::wstring widePath;
-
-    constexpr DWORD MB2WC_FLAGS = 0;
-
-    const auto pathSize = static_cast<int>(path.size());
-
-    // determine the size of the required wide-character string
-    const int widePathSize = ::MultiByteToWideChar(CP_UTF8, MB2WC_FLAGS, path.c_str(), pathSize, NULL, 0);
-    if (widePathSize <= 0)
-    {
-        throw SilKit::ConfigurationError{"conversion from UTF-8 to UTF-16 failed"};
-    }
-
-    widePath.resize(static_cast<size_t>(widePathSize));
-
-    // actually convert the path into a wide-character string
-    const int realWidePathSize =
-        ::MultiByteToWideChar(CP_UTF8, MB2WC_FLAGS, path.c_str(), pathSize, &widePath[0], widePathSize);
-    if (realWidePathSize != widePathSize)
-    {
-        throw SilKit::ConfigurationError{"conversion from UTF-8 to UTF-16 failed"};
-    }
-
-    return std::ifstream{widePath.c_str()};
-}
-
-#else
-
-auto OpenTextFile(const std::string& path) -> std::ifstream
-{
-    return std::ifstream{path};
-}
-
-#endif
-
-} // namespace

--- a/SilKit/source/capi/Test_CapiSilKit.cpp
+++ b/SilKit/source/capi/Test_CapiSilKit.cpp
@@ -88,6 +88,11 @@ const auto SILKIT_MALFORMED_CONFIG_STRING = R"aw(
         EXPECT_EQ(returnCode, SilKit_ReturnCode_SUCCESS);
         EXPECT_NE(participantConfiguration, nullptr);
 
+        SilKit_ParticipantConfiguration* participantConfigurationFromFile = nullptr;
+        returnCode = SilKit_ParticipantConfiguration_FromFile(&participantConfigurationFromFile, "ParticipantConfiguration_FullIncludes.yaml");
+        EXPECT_EQ(returnCode, SilKit_ReturnCode_SUCCESS);
+        EXPECT_NE(participantConfigurationFromFile, nullptr);
+
         SilKit_Participant* participant = nullptr;
         returnCode = SilKit_Participant_Create(&participant, participantConfiguration, "Participant1", "42");
         // since there is no SIL Kit Registry, the call should fail
@@ -100,6 +105,8 @@ const auto SILKIT_MALFORMED_CONFIG_STRING = R"aw(
 
         // destory the participant configuration to satisfy ASAN
         returnCode = SilKit_ParticipantConfiguration_Destroy(participantConfiguration);
+        EXPECT_EQ(returnCode, SilKit_ReturnCode_SUCCESS);
+        returnCode = SilKit_ParticipantConfiguration_Destroy(participantConfigurationFromFile);
         EXPECT_EQ(returnCode, SilKit_ReturnCode_SUCCESS);
     }
 
@@ -114,6 +121,14 @@ const auto SILKIT_MALFORMED_CONFIG_STRING = R"aw(
         EXPECT_EQ(returnCode, SilKit_ReturnCode_SUCCESS);
         EXPECT_NE(participantConfiguration, nullptr);
 
+        SilKit_ParticipantConfiguration* participantConfigurationFromAFile = nullptr;
+        returnCode = SilKit_ParticipantConfiguration_FromFile(&participantConfigurationFromAFile, "ParticipantConfiguration_FullIncludes.yaml");
+        EXPECT_EQ(returnCode, SilKit_ReturnCode_SUCCESS);
+        EXPECT_NE(participantConfigurationFromAFile, nullptr);
+        returnCode = SilKit_ParticipantConfiguration_Destroy(participantConfigurationFromAFile);
+        EXPECT_EQ(returnCode, SilKit_ReturnCode_SUCCESS);
+
+
         SilKit_Participant* participant = nullptr;
         returnCode = SilKit_Participant_Create(nullptr, participantConfiguration, "Participant1", "42");
         EXPECT_EQ(returnCode, SilKit_ReturnCode_BADPARAMETER);
@@ -122,6 +137,18 @@ const auto SILKIT_MALFORMED_CONFIG_STRING = R"aw(
         returnCode = SilKit_Participant_Create(&participant, participantConfiguration, nullptr, "42");
         EXPECT_EQ(returnCode, SilKit_ReturnCode_BADPARAMETER);
         returnCode = SilKit_Participant_Create(&participant, participantConfiguration, "Participant1", nullptr);
+        EXPECT_EQ(returnCode, SilKit_ReturnCode_BADPARAMETER);
+
+        // Bad Parameter ParticipantConfiguration_FromString
+        returnCode = SilKit_ParticipantConfiguration_FromString(&participantConfiguration, nullptr);
+        EXPECT_EQ(returnCode, SilKit_ReturnCode_BADPARAMETER);
+        returnCode = SilKit_ParticipantConfiguration_FromString(nullptr, SILKIT_CONFIG_STRING);
+        EXPECT_EQ(returnCode, SilKit_ReturnCode_BADPARAMETER);
+
+        // Bad Parameter ParticipantConfiguration_FromFile
+        returnCode = SilKit_ParticipantConfiguration_FromFile(&participantConfigurationFromAFile, nullptr);
+        EXPECT_EQ(returnCode, SilKit_ReturnCode_BADPARAMETER);
+        returnCode = SilKit_ParticipantConfiguration_FromFile(nullptr, "ParticipantConfiguration_FullIncludes.yaml");
         EXPECT_EQ(returnCode, SilKit_ReturnCode_BADPARAMETER);
 
         returnCode =
@@ -135,8 +162,13 @@ const auto SILKIT_MALFORMED_CONFIG_STRING = R"aw(
         EXPECT_EQ(returnCode, SilKit_ReturnCode_BADPARAMETER);
 
         participantConfiguration = nullptr;
+        participantConfigurationFromAFile = nullptr;
 
         returnCode = SilKit_ParticipantConfiguration_FromString(&participantConfiguration, SILKIT_MALFORMED_CONFIG_STRING);
+        EXPECT_EQ(returnCode, SilKit_ReturnCode_UNSPECIFIEDERROR);
+        EXPECT_EQ(participantConfiguration, nullptr);
+
+        returnCode = SilKit_ParticipantConfiguration_FromFile(&participantConfiguration, "this_file_does_not_exist.yaml");
         EXPECT_EQ(returnCode, SilKit_ReturnCode_UNSPECIFIEDERROR);
         EXPECT_EQ(participantConfiguration, nullptr);
 

--- a/SilKit/source/capi/Test_CapiSilKit.cpp
+++ b/SilKit/source/capi/Test_CapiSilKit.cpp
@@ -162,7 +162,6 @@ const auto SILKIT_MALFORMED_CONFIG_STRING = R"aw(
         EXPECT_EQ(returnCode, SilKit_ReturnCode_BADPARAMETER);
 
         participantConfiguration = nullptr;
-        participantConfigurationFromAFile = nullptr;
 
         returnCode = SilKit_ParticipantConfiguration_FromString(&participantConfiguration, SILKIT_MALFORMED_CONFIG_STRING);
         EXPECT_EQ(returnCode, SilKit_ReturnCode_UNSPECIFIEDERROR);

--- a/SilKit/source/capi/Test_CapiSymbols.cpp
+++ b/SilKit/source/capi/Test_CapiSymbols.cpp
@@ -129,6 +129,7 @@ SilKit_HandlerId id;
 (void) SilKit_LifecycleService_StartLifecycle(nullptr);
 (void) SilKit_LifecycleService_WaitForLifecycleToComplete(nullptr, nullptr);
 (void) SilKit_ParticipantConfiguration_FromString(nullptr, "");
+(void) SilKit_ParticipantConfiguration_FromFile(nullptr, "");
 (void) SilKit_ParticipantConfiguration_Destroy(nullptr);
 (void) SilKit_Participant_Create(nullptr, nullptr, "", "");
 (void) SilKit_Participant_Destroy(nullptr);

--- a/SilKit/source/config/CMakeLists.txt
+++ b/SilKit/source/config/CMakeLists.txt
@@ -133,7 +133,6 @@ function(copy_participant_configs CopyTarget Configs ConfigsDir)
     add_custom_command(TARGET ${CopyTarget} POST_BUILD
         COMMAND
             ${CMAKE_COMMAND} -E copy
-            #$<TARGET_PROPERTY:${CopyTarget},TEST_CONFIGS>
             "${TEST_CONFIGS}"
             ${CMAKE_BINARY_DIR}/$<CONFIG>/ConfigSnippets/${ConfigsDir}
         COMMAND_EXPAND_LISTS

--- a/SilKit/source/config/CMakeLists.txt
+++ b/SilKit/source/config/CMakeLists.txt
@@ -54,7 +54,7 @@ target_link_libraries(O_SilKit_Config
     PUBLIC I_SilKit_Config
 
     PRIVATE SilKitInterface
-    PUBLIC I_SilKit_Util
+    PRIVATE O_SilKit_Util_Filesystem
     PUBLIC yaml-cpp
     PRIVATE I_SilKit_Util_FileHelpers
 )
@@ -65,7 +65,7 @@ target_include_directories(O_SilKit_Config
 
 add_silkit_test_to_executable(SilKitUnitTests
     SOURCES Test_Validation.cpp
-    LIBS O_SilKit_Config
+    LIBS O_SilKit_Config S_SilKitImpl
 )
 
 add_silkit_test_to_executable(SilKitUnitTests
@@ -75,6 +75,22 @@ add_silkit_test_to_executable(SilKitUnitTests
         ParticipantConfiguration_Minimal.json
         ParticipantConfiguration_Full.json
         ParticipantConfiguration_Full.yaml
+
+        TestParticipantConfigs/ParticipantConfiguration_FullIncludes.yaml
+        TestParticipantConfigs/ParticipantConfiguration_FullIncludes_Reference.yaml
+
+        TestParticipantConfigs/ExtensionsIncludes.yaml
+
+        TestParticipantConfigs/LoggingIncludes.yaml
+
+        TestParticipantConfigs/ParticipantConfiguration_MultipleAcceptorUris.yaml
+        TestParticipantConfigs/MultipleAcceptorUrisInclude.yaml
+
+        TestParticipantConfigs/ParticipantConfiguration_DuplicateControllerNames.yaml
+        TestParticipantConfigs/DuplicateEthernetControllerNames.yaml
+
+        TestParticipantConfigs/ParticipantConfiguration_FromString_Reference.yaml
+
         ParticipantConfiguration_Logging_Without_File.json
 )
 
@@ -87,6 +103,46 @@ add_silkit_test_to_executable(SilKitUnitTests
     SOURCES Test_YamlValidator.cpp
     LIBS O_SilKit_Config yaml-cpp
 )
+
+set(ParticipantTestCanConfigs
+    TestParticipantConfigs/CanIncludes.yaml
+    TestParticipantConfigs/CanInclude2.yaml
+    TestParticipantConfigs/CanInclude3.yaml
+    TestParticipantConfigs/CanInclude4.yaml
+    TestParticipantConfigs/CanInclude5.yaml
+    TestParticipantConfigs/CanInclude6.yaml
+)
+set(ParticipantTestMiddlewareConfigs
+    TestParticipantConfigs/MiddlewareInclude.yaml
+    TestParticipantConfigs/MoreMiddlewareIncludes.yaml
+)
+
+add_custom_target(CopyTestConfigs)
+
+function(copy_participant_configs CopyTarget Configs ConfigsDir)
+    foreach(config ${Configs})
+        get_filename_component(configPath "${config}" ABSOLUTE)
+        list(APPEND TEST_CONFIGS "${configPath}")
+    endforeach()
+
+    add_custom_command(TARGET ${CopyTarget} POST_BUILD
+        COMMAND
+            ${CMAKE_COMMAND} -E make_directory
+            ${CMAKE_BINARY_DIR}/$<CONFIG>/ConfigSnippets/${ConfigsDir}
+    )
+    add_custom_command(TARGET ${CopyTarget} POST_BUILD
+        COMMAND
+            ${CMAKE_COMMAND} -E copy
+            #$<TARGET_PROPERTY:${CopyTarget},TEST_CONFIGS>
+            "${TEST_CONFIGS}"
+            ${CMAKE_BINARY_DIR}/$<CONFIG>/ConfigSnippets/${ConfigsDir}
+        COMMAND_EXPAND_LISTS
+    )
+endfunction()
+
+copy_participant_configs(CopyTestConfigs "${ParticipantTestCanConfigs}" "CAN")
+copy_participant_configs(CopyTestConfigs "${ParticipantTestMiddlewareConfigs}" "Middleware")
+add_dependencies(SilKitUnitTests CopyTestConfigs)
 
 if(SILKIT_BUILD_TESTS)
     add_library(I_SilKit_Config_TestUtils INTERFACE)

--- a/SilKit/source/config/Configuration.hpp
+++ b/SilKit/source/config/Configuration.hpp
@@ -156,6 +156,8 @@ struct SimulatedNetwork
 };
 
 inline bool operator==(const Sink& lhs, const Sink& rhs);
+inline bool operator<(const Sink& lhs, const Sink& rhs);
+inline bool operator>(const Sink& lhs, const Sink& rhs);
 inline bool operator==(const Logging& lhs, const Logging& rhs);
 inline bool operator==(const TraceSink& lhs, const TraceSink& rhs);
 inline bool operator==(const TraceSource& lhs, const TraceSource& rhs);
@@ -206,6 +208,16 @@ bool operator==(const Sink& lhs, const Sink& rhs)
     return lhs.type == rhs.type
         && lhs.level == rhs.level
         && lhs.logName == rhs.logName;
+}
+
+bool operator<(const Sink& lhs, const Sink& rhs)
+{
+    return lhs.logName.compare(rhs.logName);
+}
+
+bool operator>(const Sink& lhs, const Sink& rhs)
+{
+    return rhs < lhs;
 }
 
 bool operator==(const Logging& lhs, const Logging& rhs)

--- a/SilKit/source/config/ParticipantConfigurationFromXImpl.cpp
+++ b/SilKit/source/config/ParticipantConfigurationFromXImpl.cpp
@@ -292,7 +292,7 @@ void CacheMiddleware(const YAML::Node& root, MiddlewareCache& cache)
     PopulateCacheField(root, "Middleware", "RegistryUri", cache.registryUri);
     PopulateCacheField(root, "Middleware", "ExperimentalRemoteParticipantConnection",
                        cache.experimentalRemoteParticipantConnection);
-    PopulateCacheField(root, "Middleware", "connectTimeoutSeconds", cache.connectTimeoutSeconds);
+    PopulateCacheField(root, "Middleware", "ConnectTimeoutSeconds", cache.connectTimeoutSeconds);
 }
 
 void CacheLoggingOptions(const YAML::Node& root, GlobalLogCache& cache)
@@ -338,7 +338,7 @@ void CacheLoggingSinks(const YAML::Node& config, GlobalLogCache& cache)
         }
         else
         {
-            if (cache.fileNames.find(sink.logName) == cache.fileNames.end())
+            if (cache.fileNames.count(sink.logName) == 0)
             {
                 cache.fileSinks.insert(sink);
                 cache.fileNames.insert(sink.logName);

--- a/SilKit/source/config/ParticipantConfigurationFromXImpl.cpp
+++ b/SilKit/source/config/ParticipantConfigurationFromXImpl.cpp
@@ -20,11 +20,18 @@ OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE. */
 
 #include "ParticipantConfiguration.hpp"
+#include "Filesystem.hpp"
 
 #include <fstream>
 #include <sstream>
 #include <iomanip>
+#include <set>
+#include <utility>
+#include <vector>
 
+#include "FileHelpers.hpp"
+#include "ParticipantConfigurationFromXImpl.hpp"
+#include "silkit/services/logging/string_utils.hpp"
 #include "YamlParser.hpp"
 #include "YamlValidator.hpp"
 
@@ -33,25 +40,60 @@ namespace Config {
 
 inline namespace v1 {
 
-// ================================================================================
-//  Helper functions
-// ================================================================================
 namespace {
 
-auto ReadFile(const std::string& filename) -> std::string
+// =================================================================================
+//  Helper structs to keep metadata when processing/merging included config snippets
+// =================================================================================
+using ConfigInclude = std::pair<std::string, SilKit::Config::v1::ParticipantConfiguration>;
+struct MiddlewareCache
 {
-    std::ifstream fs(filename);
+    std::vector<std::string> acceptorUris;
+    SilKit::Util::Optional<std::string> registryUri;
+    SilKit::Util::Optional<double> connectTimeoutSeconds;
+    SilKit::Util::Optional<int> connectAttempts;
+    SilKit::Util::Optional<int> tcpReceiveBufferSize;
+    SilKit::Util::Optional<int> tcpSendBufferSize;
+    SilKit::Util::Optional<bool> tcpNoDelay;
+    SilKit::Util::Optional<bool> tcpQuickAck;
+    SilKit::Util::Optional<bool> enableDomainSockets;
+    SilKit::Util::Optional<bool> registryAsFallbackProxy;
+    SilKit::Util::Optional<bool> experimentalRemoteParticipantConnection;
+};
 
-    if (!fs.is_open())
-        throw SilKit::ConfigurationError("the file could not be opened");
+struct GlobalLogCache
+{
+    SilKit::Util::Optional<bool> logFromRemotes;
+    SilKit::Util::Optional<Services::Logging::Level> flushLevel;
+    std::set<Sink> fileSinks;
+    std::set<Sink> sinks;
+    std::set<std::string> fileNames;
+};
 
-    std::stringstream buffer;
-    buffer << fs.rdbuf();
+struct ConfigIncludeData
+{
+    std::set<std::string> searchPaths;
+    std::set<std::string> includeSet;
+    std::vector<ConfigInclude> configBuffer;
+    MiddlewareCache middlewareCache;
+    GlobalLogCache logCache;
+    std::map<std::string, SilKit::Config::CanController> canCache;
+    std::map<std::string, SilKit::Config::LinController> linCache;
+    std::map<std::string, SilKit::Config::EthernetController> ethCache;
+    std::map<std::string, SilKit::Config::FlexrayController> flexrayCache;
+    std::map<std::string, SilKit::Config::DataSubscriber> subCache;
+    std::map<std::string, SilKit::Config::DataPublisher> pubCache;
+    std::map<std::string, SilKit::Config::RpcServer> rpcServerCache;
+    std::map<std::string, SilKit::Config::RpcClient> rpcClientCache;
+    std::map<std::string, SilKit::Config::TraceSink> traceSinkCache;
+    std::map<std::string, SilKit::Config::TraceSource> traceSourceCache;
+};
 
-    return buffer.str();
-}
 
-auto Parse(const std::string& text) -> SilKit::Config::ParticipantConfiguration
+// ================================================================================
+//  Helper functions to work with text and YAML
+// ================================================================================
+void Validate(const std::string& text)
 {
     std::stringstream warnings;
     SilKit::Config::YamlValidator validator;
@@ -63,14 +105,465 @@ auto Parse(const std::string& text) -> SilKit::Config::ParticipantConfiguration
     {
         std::cout << "YAML validation returned warnings: \n" << warnings.str() << std::endl;
     }
-    YAML::Node doc = YAML::Load(text);
+}
+
+auto Parse(const YAML::Node& doc) -> SilKit::Config::ParticipantConfiguration
+{
 
     auto configuration = !doc.IsNull() ? SilKit::Config::from_yaml<SilKit::Config::v1::ParticipantConfiguration>(doc)
                                        : SilKit::Config::v1::ParticipantConfiguration{};
     configuration.configurationFilePath.clear();
-
     return configuration;
 }
+
+void CollectIncludes(const YAML::Node& config, std::vector<std::string>& levelIncludes)
+{
+
+    if(config["Includes"])
+    {
+        for (const auto& include : config["Includes"]["Files"])
+        {
+            levelIncludes.push_back(include.as<std::string>());
+        }
+    }
+}
+
+// ================================================================================
+//  Helper functions to find and open config snippets
+//  TODO: Put into the Filesystem Layer?
+// ================================================================================
+std::string GetConfigParentPath(const std::string& configFile)
+{
+    namespace fs = SilKit::Filesystem;
+    auto filePath = fs::concatenate_paths(fs::current_path().string(), configFile);
+    return fs::parent_path(filePath).string();
+}
+
+void AppendToSearchPaths(const YAML::Node& doc, ConfigIncludeData &configData)
+{
+    if(doc["Includes"])
+    {
+        for(auto& searchPath : doc["Includes"]["SearchPathHints"])
+        {
+            auto tmpString = searchPath.as<std::string>();
+
+            if(tmpString.empty())
+            {
+                std::cout << "Warning: Got empty SearchPathHint!";
+                continue;
+            }
+
+            std::string suffix = "";
+            auto lastChar = tmpString.back();
+            // We assume that the user provides a Path
+            // Make sure they have a seperator
+            if (lastChar != '/' && lastChar != '\\')
+            {
+                suffix = SilKit::Filesystem::path::preferred_separator;
+            }
+            configData.searchPaths.insert(searchPath.as<std::string>() + suffix);
+        }
+    }
+}
+
+std::string OpenFileWithSearchHints(const std::string& configFile, const std::set<std::string> &searchPathHints)
+{
+    std::stringstream buffer;
+    std::string text;
+
+    auto ifs = Util::OpenIFStream(configFile);
+    // Try cwd first
+    if(ifs.is_open())
+    {
+        buffer << ifs.rdbuf();
+        return buffer.str();
+    }
+
+    for(auto& searchPathHint : searchPathHints)
+    {
+        auto completePath = searchPathHint + configFile;
+
+        ifs = Util::OpenIFStream(completePath);
+
+        if(ifs.is_open())
+        {
+            buffer << ifs.rdbuf();
+            return buffer.str();
+        }
+    }
+
+    std::stringstream error_msg;
+    error_msg << "The config file " << configFile << " could not be opened!";
+    throw SilKit::ConfigurationError(error_msg.str());
+}
+
+// ================================================================================
+//  Helper functions to merge config fields/vectors/sets
+// ================================================================================
+template <typename FieldT>
+void MergeCacheField(const SilKit::Util::Optional<FieldT>& includeObject, FieldT& rootObject)
+{
+    if (includeObject.has_value())
+    {
+        rootObject = includeObject.value();
+    }
+}
+
+template <typename ConfigT>
+void MergeNamedVector(const std::vector<ConfigT>& child, const std::string& field_name, std::vector<ConfigT>& parent,
+                      std::map<std::string, ConfigT>& cache)
+{
+    std::map<std::string, unsigned> parentState;
+
+    for (const auto& element : child)
+    {
+        auto duplicate = cache.find(element.name);
+        if (duplicate == cache.end())
+        {
+            parent.push_back(element);
+            cache[element.name] = element;
+        }
+        else
+        {
+            if (duplicate->second == element)
+            {
+                std::cout << "Warning: exact duplicate of " << element.name << " found already!" << std::endl;
+            }
+            else
+            {
+                std::stringstream error_msg;
+                error_msg << "Config element " << field_name << " with name " << element.name << " but different config already exists!";
+                throw SilKit::ConfigurationError(error_msg.str());
+            }
+        }
+    }
+}
+
+template <typename T>
+void MergeCacheSet(const std::set<T>& cache, std::vector<T>& root)
+{
+    for(auto& element: cache)
+    {
+        root.push_back(element);
+    }
+}
+
+// ================================================================================
+//  Helper functions to cache config entries with complicated merge strategies
+// ================================================================================
+template <typename FieldT>
+void PopulateCacheField(const YAML::Node& root, std::string rootname, const std::string& field,
+                        SilKit::Util::Optional<FieldT>& obj)
+{
+    SilKit::Util::Optional<FieldT> tmpObj;
+    optional_decode(tmpObj, root, field);
+
+    if (tmpObj.has_value())
+    {
+        if (obj.has_value() && (obj != tmpObj))
+        {
+            std::stringstream error_msg;
+            error_msg << "Config element " << field << "(" << tmpObj << ") for " << rootname << " already set to \'"
+                      << obj.value() << "\'!";
+            throw SilKit::ConfigurationError(error_msg.str());
+        }
+        obj = tmpObj;
+    }
+}
+
+void CacheMiddleware(const YAML::Node& root, MiddlewareCache& cache)
+{
+    if (root["AcceptorUris"])
+    {
+        if (cache.acceptorUris.size() > 0)
+        {
+            throw SilKit::ConfigurationError{"AccepoorUris already defined!"};
+        }
+        optional_decode(cache.acceptorUris, root, "AcceptorUris");
+    }
+
+    PopulateCacheField(root, "Middleware", "ConnectAttempts", cache.connectAttempts);
+    PopulateCacheField(root, "Middleware", "TcpNoDelay", cache.tcpNoDelay);
+    PopulateCacheField(root, "Middleware", "TcpQuickAck", cache.tcpQuickAck);
+    PopulateCacheField(root, "Middleware", "TcpReceiveBufferSize", cache.tcpReceiveBufferSize);
+    PopulateCacheField(root, "Middleware", "TcpSendBufferSize", cache.tcpSendBufferSize);
+    PopulateCacheField(root, "Middleware", "EnableDomainSockets", cache.enableDomainSockets);
+    PopulateCacheField(root, "Middleware", "RegistryAsFallbackProxy", cache.registryAsFallbackProxy);
+    PopulateCacheField(root, "Middleware", "RegistryUri", cache.registryUri);
+    PopulateCacheField(root, "Middleware", "ExperimentalRemoteParticipantConnection",
+                       cache.experimentalRemoteParticipantConnection);
+    PopulateCacheField(root, "Middleware", "connectTimeoutSeconds", cache.connectTimeoutSeconds);
+}
+
+void CacheLoggingOptions(const YAML::Node& root, GlobalLogCache& cache)
+{
+    PopulateCacheField(root, "Logging", "FlushLevel", cache.flushLevel);
+    PopulateCacheField(root, "Logging", "LogFromRemotes", cache.logFromRemotes);
+}
+
+void CacheLoggingSinks(const YAML::Node& config, GlobalLogCache& cache)
+{
+    for (const auto& sinkNode : config["Sinks"])
+    {
+        auto sink = parse_as<Sink>(sinkNode);
+        if (sink.type == Sink::Type::Stdout)
+        {
+            if (cache.sinks.count(sink) == 0)
+            {
+                // Replace the already included sink with this one
+                // since we have not set it yet
+                cache.sinks.insert(sink);
+            }
+            else
+            {
+                std::stringstream error_msg;
+                error_msg << "Stdout Sink already exists!";
+                throw SilKit::ConfigurationError(error_msg.str());
+            }
+        }
+        else if (sink.type == Sink::Type::Remote)
+        {
+            if (cache.sinks.count(sink) == 0)
+            {
+                // Replace the already included sink with this one
+                // since we have not set it yet
+                cache.sinks.insert(sink);
+            }
+            else
+            {
+                std::stringstream error_msg;
+                error_msg << "Remote Sink already exists!";
+                throw SilKit::ConfigurationError(error_msg.str());
+            }
+        }
+        else
+        {
+            if (cache.fileNames.find(sink.logName) == cache.fileNames.end())
+            {
+                cache.fileSinks.insert(sink);
+                cache.fileNames.insert(sink.logName);
+            }
+            else
+            {
+                std::stringstream error_msg;
+                error_msg << "Filesink " << sink.logName << " already exists!";
+                throw SilKit::ConfigurationError(error_msg.str());
+            }
+        }
+    }
+}
+
+void PopulateCaches(const YAML::Node& config, ConfigIncludeData& configIncludeData)
+{
+    // Cache those config options that need to be default constructed, since we lose the information
+    // about default constructed vs. explicitly set to the default value later
+    if (config["Middleware"])
+    {
+        CacheMiddleware(config["Middleware"], configIncludeData.middlewareCache);
+    }
+
+    if (config["Logging"])
+    {
+        CacheLoggingOptions(config["Logging"], configIncludeData.logCache);
+        CacheLoggingSinks(config["Logging"], configIncludeData.logCache);
+    }
+}
+
+// =========================================================================================================================
+// Functions to merge the different fields
+// =========================================================================================================================
+void MergeExtensions(const SilKit::Config::v1::Extensions& child, SilKit::Config::v1::Extensions& parent)
+{
+    parent.searchPathHints.insert(parent.searchPathHints.end(), child.searchPathHints.begin(),
+                                  child.searchPathHints.end());
+}
+
+void MergeHealthCheck(const SilKit::Config::HealthCheck& include, SilKit::Config::HealthCheck& healthCheck)
+{
+    if (include.softResponseTimeout.has_value())
+    {
+        if (healthCheck.softResponseTimeout.has_value()
+            && (healthCheck.softResponseTimeout.value() == include.softResponseTimeout.value()))
+        {
+            std::stringstream error_msg;
+            error_msg << "HealthCheck.SoftResponseTimeout already set to: "
+                      << healthCheck.softResponseTimeout.value().count() << "ms";
+            throw SilKit::ConfigurationError(error_msg.str());
+        }
+
+        healthCheck.softResponseTimeout = include.softResponseTimeout;
+    }
+
+    if (include.hardResponseTimeout.has_value())
+    {
+        if (healthCheck.hardResponseTimeout.has_value()
+            && healthCheck.hardResponseTimeout.value() == include.hardResponseTimeout.value())
+        {
+            std::stringstream error_msg;
+            error_msg << "HealthCheck.HardResponseTimeout already set to: "
+                      << healthCheck.hardResponseTimeout.value().count() << "ms";
+            throw SilKit::ConfigurationError(error_msg.str());
+        }
+
+        healthCheck.hardResponseTimeout = include.hardResponseTimeout;
+    }
+}
+
+void MergeParticipantName(const SilKit::Config::ParticipantConfiguration& include,
+                          SilKit::Config::ParticipantConfiguration& config)
+{
+    if (include.participantName.size())
+    {
+        if (config.participantName.empty())
+        {
+            config.participantName = include.participantName;
+        }
+        else
+        {
+            throw SilKit::ConfigurationError("Participant Name already set to " + config.participantName);
+        }
+    }
+}
+
+void MergeMiddleware(const MiddlewareCache& cache, Middleware& middleware)
+{
+    MergeCacheField(cache.connectAttempts, middleware.connectAttempts);
+    MergeCacheField(cache.tcpNoDelay, middleware.tcpNoDelay);
+    MergeCacheField(cache.tcpQuickAck, middleware.tcpQuickAck);
+    MergeCacheField(cache.tcpSendBufferSize, middleware.tcpSendBufferSize);
+    MergeCacheField(cache.tcpReceiveBufferSize, middleware.tcpReceiveBufferSize);
+    MergeCacheField(cache.enableDomainSockets, middleware.enableDomainSockets);
+    MergeCacheField(cache.registryUri, middleware.registryUri);
+    MergeCacheField(cache.registryAsFallbackProxy, middleware.registryAsFallbackProxy);
+    MergeCacheField(cache.experimentalRemoteParticipantConnection, middleware.experimentalRemoteParticipantConnection);
+    MergeCacheField(cache.connectTimeoutSeconds, middleware.connectTimeoutSeconds);
+
+    middleware.acceptorUris = cache.acceptorUris;
+}
+
+void MergeLogCache(const GlobalLogCache& cache, Logging& logging)
+{
+    MergeCacheField(cache.flushLevel, logging.flushLevel);
+    MergeCacheField(cache.logFromRemotes, logging.logFromRemotes);
+    MergeCacheSet(cache.sinks, logging.sinks);
+    MergeCacheSet(cache.fileSinks, logging.sinks);
+}
+
+
+auto MergeConfigs(ConfigIncludeData& configIncludeData) -> SilKit::Config::ParticipantConfiguration
+{
+    SilKit::Config::ParticipantConfiguration config;
+    for (const auto& include : configIncludeData.configBuffer)
+    {
+        // Merge all vectors first!
+        MergeNamedVector<SilKit::Config::v1::CanController>(include.second.canControllers, "CanController",
+                                                            config.canControllers, configIncludeData.canCache);
+        MergeNamedVector<SilKit::Config::v1::LinController>(include.second.linControllers, "LinController",
+                                                            config.linControllers, configIncludeData.linCache);
+        MergeNamedVector<SilKit::Config::v1::EthernetController>(include.second.ethernetControllers, "EthernetController",
+                                                                 config.ethernetControllers, configIncludeData.ethCache);
+        MergeNamedVector<SilKit::Config::v1::FlexrayController>(include.second.flexrayControllers, "FlexRayController",
+                                                                config.flexrayControllers, configIncludeData.flexrayCache);
+        MergeNamedVector<SilKit::Config::v1::DataSubscriber>(include.second.dataSubscribers, "DataSubscriber",
+                                                             config.dataSubscribers, configIncludeData.subCache);
+        MergeNamedVector<SilKit::Config::v1::DataPublisher>(include.second.dataPublishers, "DataPublisher",
+                                                            config.dataPublishers, configIncludeData.pubCache);
+        MergeNamedVector<SilKit::Config::v1::RpcServer>(include.second.rpcServers, "RpcServer", config.rpcServers,
+                                                        configIncludeData.rpcServerCache);
+        MergeNamedVector<SilKit::Config::v1::RpcClient>(include.second.rpcClients, "RpcClient", config.rpcClients,
+                                                        configIncludeData.rpcClientCache);
+
+        MergeNamedVector<SilKit::Config::v1::TraceSink>(include.second.tracing.traceSinks, "TraceSink",
+                                                        config.tracing.traceSinks, configIncludeData.traceSinkCache);
+        MergeNamedVector<SilKit::Config::v1::TraceSource>(include.second.tracing.traceSources, "TraceSource",
+                                                          config.tracing.traceSources, configIncludeData.traceSourceCache);
+
+        // Merge "scalar" config fields
+        MergeExtensions(include.second.extensions, config.extensions);
+        MergeHealthCheck(include.second.healthCheck, config.healthCheck);
+        MergeParticipantName(include.second, config);
+    }
+
+    MergeMiddleware(configIncludeData.middlewareCache, config.middleware);
+    MergeLogCache(configIncludeData.logCache, config.logging);
+
+    return config;
+}
+
+// =========================================================================================================================
+// Include Logic
+// =========================================================================================================================
+void ProcessIncludes(const YAML::Node& config, ConfigIncludeData& configData)
+{
+    std::vector<std::string> levelIncludes;
+
+    CollectIncludes(config, levelIncludes);
+    PopulateCaches(config, configData);
+
+    // Breadth first traversal, which means we collect all includes per "level" first
+    // and then use the collected includes as the "next level"
+    const auto upperbound = 127u;
+
+    for(auto i = 0u; i < upperbound; ++i)
+    {
+        std::vector<std::string> tmpIncludes;
+        for (const auto& include : levelIncludes)
+        {
+            if (configData.includeSet.count(include) > 0)
+            {
+                std::cout << "Warning: Config " << include << " already included!" << std::endl;
+                continue;
+            }
+
+            // Get the next Include to be processed within this tree level
+            auto nextConfig= SilKit::Config::OpenFileWithSearchHints(include, configData.searchPaths);
+            SilKit::Config::Validate(nextConfig);
+
+            // Load and Parse the file as Yaml
+            auto nextConfigNode = YAML::Load(nextConfig);
+            configData.configBuffer.push_back((ConfigInclude(include, SilKit::Config::Parse(nextConfigNode))));
+
+            // Append the config to our metadata buffer, so we can make informed decisions whether the compiled config is valid
+            configData.includeSet.insert(include);
+            AppendToSearchPaths(nextConfigNode, configData);
+
+            // Collect Caches and Include for the next level within the tree
+            CollectIncludes(nextConfigNode, tmpIncludes);
+            PopulateCaches(nextConfigNode, configData);
+        }
+
+        // Goto next Level
+        levelIncludes = tmpIncludes;
+
+        if(levelIncludes.size() == 0)
+        {
+            break;
+        }
+    }
+}
+
+auto ParticipantConfigurationFromXImpl(const std::string& text, struct ConfigIncludeData& configData)
+    -> SilKit::Config::ParticipantConfiguration
+{
+    SilKit::Config::Validate(text);
+    YAML::Node doc = YAML::Load(text);
+
+    auto configuration = SilKit::Config::Parse(doc);
+    configData.configBuffer.push_back(ConfigInclude("root", configuration));
+
+    // Check search Paths
+    if(doc["Includes"])
+    {
+        AppendToSearchPaths(doc, configData);
+    }
+
+    // Get all configs
+    ProcessIncludes(doc, configData);
+    // Merge the root and included configs
+    return MergeConfigs(configData);
+}
+
+
 
 } // anonymous namespace
 
@@ -79,7 +572,8 @@ auto Parse(const std::string& text) -> SilKit::Config::ParticipantConfiguration
 // ================================================================================
 bool operator==(const CanController& lhs, const CanController& rhs)
 {
-    return lhs.name == rhs.name && lhs.network == rhs.network;
+    return lhs.name == rhs.name && lhs.network == rhs.network && lhs.replay == rhs.replay
+           && lhs.useTraceSinks == rhs.useTraceSinks;
 }
 
 bool operator==(const LinController& lhs, const LinController& rhs)
@@ -147,30 +641,52 @@ bool operator==(const Middleware& lhs, const Middleware& rhs)
 
 bool operator==(const ParticipantConfiguration& lhs, const ParticipantConfiguration& rhs)
 {
-    return lhs.participantName == rhs.participantName && lhs.canControllers == rhs.canControllers
-           && lhs.linControllers == rhs.linControllers && lhs.ethernetControllers == rhs.ethernetControllers
-           && lhs.flexrayControllers == rhs.flexrayControllers && lhs.dataPublishers == rhs.dataPublishers
-           && lhs.dataSubscribers == rhs.dataSubscribers && lhs.rpcClients == rhs.rpcClients
-           && lhs.rpcServers == rhs.rpcServers && lhs.logging == rhs.logging && lhs.healthCheck == rhs.healthCheck
-           && lhs.tracing == rhs.tracing && lhs.extensions == rhs.extensions;
+    return lhs.participantName == rhs.participantName
+           && lhs.canControllers == rhs.canControllers
+           && lhs.linControllers == rhs.linControllers
+           && lhs.ethernetControllers == rhs.ethernetControllers
+           && lhs.flexrayControllers == rhs.flexrayControllers
+           && lhs.dataPublishers == rhs.dataPublishers
+           && lhs.dataSubscribers == rhs.dataSubscribers
+           && lhs.rpcClients == rhs.rpcClients
+           && lhs.rpcServers == rhs.rpcServers
+           && lhs.logging == rhs.logging
+           && lhs.healthCheck == rhs.healthCheck
+           && lhs.tracing == rhs.tracing
+           && lhs.extensions == rhs.extensions;
 }
 
 } // inline namespace v1
 
+
+// ============================================================================
+// Interface Layer functions
+// ============================================================================
 auto ParticipantConfigurationFromStringImpl(const std::string& text)
 -> std::shared_ptr<SilKit::Config::IParticipantConfiguration>
 {
-    auto configuration = SilKit::Config::Parse(text);
-
+    auto configData = ConfigIncludeData();
+    auto configuration = SilKit::Config::ParticipantConfigurationFromXImpl(text, configData);
     return std::make_shared<SilKit::Config::ParticipantConfiguration>(std::move(configuration));
 }
 
 auto ParticipantConfigurationFromFileImpl(const std::string& filename)
 -> std::shared_ptr<SilKit::Config::IParticipantConfiguration>
 {
-    auto text = SilKit::Config::ReadFile(filename);
-    auto configuration = SilKit::Config::Parse(text);
+    auto configData = ConfigIncludeData();
+    configData.searchPaths.insert(SilKit::Config::GetConfigParentPath(filename));
 
+    // Parse the root config
+    std::string text;
+    try
+    {
+        text = SilKit::Config::OpenFileWithSearchHints(filename, configData.searchPaths);
+    } catch ( ... )
+    {
+        throw;
+    }
+
+    auto configuration = SilKit::Config::ParticipantConfigurationFromXImpl(text, configData);
     return std::make_shared<SilKit::Config::ParticipantConfiguration>(std::move(configuration));
 }
 

--- a/SilKit/source/config/ParticipantConfigurationFromXImpl.cpp
+++ b/SilKit/source/config/ParticipantConfigurationFromXImpl.cpp
@@ -130,7 +130,6 @@ void CollectIncludes(const YAML::Node& config, std::vector<std::string>& levelIn
 
 // ================================================================================
 //  Helper functions to find and open config snippets
-//  TODO: Put into the Filesystem Layer?
 // ================================================================================
 std::string GetConfigParentPath(const std::string& configFile)
 {
@@ -277,7 +276,7 @@ void CacheMiddleware(const YAML::Node& root, MiddlewareCache& cache)
     {
         if (cache.acceptorUris.size() > 0)
         {
-            throw SilKit::ConfigurationError{"AccepoorUris already defined!"};
+            throw SilKit::ConfigurationError{"AcceptorUris already defined!"};
         }
         optional_decode(cache.acceptorUris, root, "AcceptorUris");
     }

--- a/SilKit/source/config/TestParticipantConfigs/AdditionalSubIncludes.yaml
+++ b/SilKit/source/config/TestParticipantConfigs/AdditionalSubIncludes.yaml
@@ -1,0 +1,12 @@
+---
+Description: Additional Subs
+schemaVersion: 0
+DataSubscribers:
+- Name: Subscriber1
+  Topic: Temperature
+  UseTraceSinks:
+  - Sink1
+- Name: Subscriber2
+  Topic: Temperature
+  UseTraceSinks:
+  - Sink2

--- a/SilKit/source/config/TestParticipantConfigs/CanInclude2.yaml
+++ b/SilKit/source/config/TestParticipantConfigs/CanInclude2.yaml
@@ -1,0 +1,3 @@
+---
+Description: Example include configuration for CAN Controllers
+schemaVersion: 0

--- a/SilKit/source/config/TestParticipantConfigs/CanInclude3.yaml
+++ b/SilKit/source/config/TestParticipantConfigs/CanInclude3.yaml
@@ -1,0 +1,7 @@
+---
+Description: Example Level2 Include for CAN Controllers
+Includes:
+  Files:
+    - CanIncludes.yaml
+    - CanInclude4.yaml
+    - CanInclude5.yaml

--- a/SilKit/source/config/TestParticipantConfigs/CanInclude4.yaml
+++ b/SilKit/source/config/TestParticipantConfigs/CanInclude4.yaml
@@ -1,0 +1,5 @@
+---
+Description: Example Level3 Include for CAN Controllers
+Includes:
+  Files:
+    - CanInclude6.yaml

--- a/SilKit/source/config/TestParticipantConfigs/CanInclude5.yaml
+++ b/SilKit/source/config/TestParticipantConfigs/CanInclude5.yaml
@@ -1,0 +1,14 @@
+---
+Description: Example Level2 Include for CAN Controllers
+CanControllers:
+- Name: CAN64
+  Replay:
+    UseTraceSource: Source1
+    Direction: Both
+    MdfChannel:
+      ChannelName: MyTestChannel64
+      ChannelPath: path/to/myTestChannel64
+      ChannelSource: MyTestChannel
+      GroupName: MyTestGroup
+      GroupPath: path/to/myTestGroup64
+      GroupSource: MyTestGroup

--- a/SilKit/source/config/TestParticipantConfigs/CanInclude6.yaml
+++ b/SilKit/source/config/TestParticipantConfigs/CanInclude6.yaml
@@ -1,0 +1,2 @@
+---
+Description: Example Level4 configuration for CAN Controllers

--- a/SilKit/source/config/TestParticipantConfigs/CanIncludes.yaml
+++ b/SilKit/source/config/TestParticipantConfigs/CanIncludes.yaml
@@ -1,0 +1,23 @@
+---
+Description: Example include configuration for CAN Controllers
+Includes:
+  Files:
+    - CanIncludes.yaml
+    - CanInclude2.yaml
+    - CanInclude3.yaml
+CanControllers:
+- Name: CAN1
+  Replay:
+    UseTraceSource: Source1
+    Direction: Both
+    MdfChannel:
+      ChannelName: MyTestChannel1
+      ChannelPath: path/to/myTestChannel1
+      ChannelSource: MyTestChannel
+      GroupName: MyTestGroup
+      GroupPath: path/to/myTestGroup1
+      GroupSource: MyTestGroup
+  UseTraceSinks:
+  - Sink1
+- Name: MyCAN2
+  Network: CAN2

--- a/SilKit/source/config/TestParticipantConfigs/DuplicateEthernetControllerNames.yaml
+++ b/SilKit/source/config/TestParticipantConfigs/DuplicateEthernetControllerNames.yaml
@@ -1,0 +1,17 @@
+---
+Description: Example configuration EthernetControllers with name
+schemaVersion: 0
+EthernetControllers:
+- Name: ETH0
+  Replay:
+    UseTraceSource: Source1
+    Direction: Receive
+    MdfChannel:
+      ChannelName: MyTestChannel1
+      ChannelPath: path/to/myTestChannel1
+      ChannelSource: MyTestChannel
+      GroupName: MyTestGroup
+      GroupPath: path/to/myTestGroup1
+      GroupSource: MyTestGroup
+  UseTraceSinks:
+  - MyTraceSink1

--- a/SilKit/source/config/TestParticipantConfigs/ExtensionsIncludes.yaml
+++ b/SilKit/source/config/TestParticipantConfigs/ExtensionsIncludes.yaml
@@ -1,0 +1,8 @@
+---
+Description: Example included configs for Extension
+Extensions:
+  SearchPathHints:
+  - path/to/extensions1
+  - path/to/extensions3
+  - path/to/extensions4
+  - path/to/extensions5

--- a/SilKit/source/config/TestParticipantConfigs/LoggingIncludes.yaml
+++ b/SilKit/source/config/TestParticipantConfigs/LoggingIncludes.yaml
@@ -1,0 +1,9 @@
+---
+Description: Example include Logging configuration
+Logging:
+  Sinks:
+  - Type: File
+    Level: Critical
+    LogName: MyLog2
+  - Type: Stdout
+    Level: Trace

--- a/SilKit/source/config/TestParticipantConfigs/MiddlewareInclude.yaml
+++ b/SilKit/source/config/TestParticipantConfigs/MiddlewareInclude.yaml
@@ -1,0 +1,12 @@
+---
+Description: Example Middleware config include to test YAML Parser
+schemaVersion: 0
+Includes:
+  Files:
+    - MoreMiddlewareIncludes.yaml
+Middleware:
+  RegistryUri: silkit://example.com:1234
+  ConnectAttempts: 12
+  TcpNoDelay: true
+  TcpQuickAck: true
+  EnableDomainSockets: false

--- a/SilKit/source/config/TestParticipantConfigs/MoreMiddlewareIncludes.yaml
+++ b/SilKit/source/config/TestParticipantConfigs/MoreMiddlewareIncludes.yaml
@@ -1,0 +1,6 @@
+---
+Description: Example Middleware config include to test YAML Parser
+schemaVersion: 0
+Middleware:
+  TcpSendBufferSize: 3456
+  TcpReceiveBufferSize: 3456

--- a/SilKit/source/config/TestParticipantConfigs/MultipleAcceptorUrisInclude.yaml
+++ b/SilKit/source/config/TestParticipantConfigs/MultipleAcceptorUrisInclude.yaml
@@ -1,0 +1,7 @@
+---
+Description: Example configuration Middleware with AcceptorURIS
+Middleware:
+  AcceptorUris:
+    - The/Fourth/Uri/Found
+  ConnectAttempts: 9
+  EnableDomainSockets: false

--- a/SilKit/source/config/TestParticipantConfigs/ParticipantConfiguration_DuplicateControllerNames.yaml
+++ b/SilKit/source/config/TestParticipantConfigs/ParticipantConfiguration_DuplicateControllerNames.yaml
@@ -1,0 +1,20 @@
+---
+Description: Example configuration to test a broken configuration with duplicate Controller Names
+schemaVersion: 0
+Includes:
+  Files:
+    - DuplicateEthernetControllerNames.yaml
+EthernetControllers:
+- Name: ETH0
+  Replay:
+    UseTraceSource: Source2
+    Direction: Send
+    MdfChannel:
+      ChannelName: MyTestChannel1
+      ChannelPath: path/to/myTestChannel1
+      ChannelSource: MyTestChannel
+      GroupName: MyTestGroup
+      GroupPath: path/to/myTestGroup1
+      GroupSource: MyTestGroup
+  UseTraceSinks:
+  - MyTraceSink2

--- a/SilKit/source/config/TestParticipantConfigs/ParticipantConfiguration_FromString_Reference.yaml
+++ b/SilKit/source/config/TestParticipantConfigs/ParticipantConfiguration_FromString_Reference.yaml
@@ -1,0 +1,18 @@
+---
+Description: Example include configuration for CAN Controllers
+CanControllers:
+- Name: CAN1
+  Replay:
+    UseTraceSource: Source1
+    Direction: Both
+    MdfChannel:
+      ChannelName: MyTestChannel1
+      ChannelPath: path/to/myTestChannel1
+      ChannelSource: MyTestChannel
+      GroupName: MyTestGroup
+      GroupPath: path/to/myTestGroup1
+      GroupSource: MyTestGroup
+  UseTraceSinks:
+  - Sink1
+- Name: MyCAN2
+  Network: CAN2

--- a/SilKit/source/config/TestParticipantConfigs/ParticipantConfiguration_FullIncludes.yaml
+++ b/SilKit/source/config/TestParticipantConfigs/ParticipantConfiguration_FullIncludes.yaml
@@ -1,0 +1,160 @@
+---
+Description: Example configuration to test YAML Parser
+schemaVersion: 0
+Includes:
+  SearchPathHints:
+    - ConfigSnippets/CAN
+    - ConfigSnippets/Middleware
+  Files:
+    - CanIncludes.yaml
+    - ExtensionsIncludes.yaml
+    - LoggingIncludes.yaml
+    - MiddlewareInclude.yaml
+ParticipantName: Node0
+LinControllers:
+- Name: SimpleEcu1_LIN1
+  Network: LIN1
+  Replay:
+    UseTraceSource: Source1
+    Direction: Both
+    MdfChannel:
+      ChannelName: MyTestChannel1
+      ChannelPath: path/to/myTestChannel1
+      ChannelSource: MyTestChannel
+      GroupName: MyTestGroup
+      GroupPath: path/to/myTestGroup1
+      GroupSource: MyTestGroup
+  UseTraceSinks:
+  - MyTraceSink1
+EthernetControllers:
+- Name: ETH0
+  Replay:
+    UseTraceSource: Source1
+    Direction: Receive
+    MdfChannel:
+      ChannelName: MyTestChannel1
+      ChannelPath: path/to/myTestChannel1
+      ChannelSource: MyTestChannel
+      GroupName: MyTestGroup
+      GroupPath: path/to/myTestGroup1
+      GroupSource: MyTestGroup
+  UseTraceSinks:
+  - MyTraceSink1
+FlexrayControllers:
+- ClusterParameters:
+    gColdstartAttempts: 8
+    gCycleCountMax: 63
+    gListenNoise: 2
+    gMacroPerCycle: 3636
+    gMaxWithoutClockCorrectionFatal: 2
+    gMaxWithoutClockCorrectionPassive: 2
+    gNumberOfMiniSlots: 291
+    gNumberOfStaticSlots: 70
+    gPayloadLengthStatic: 16
+    gSyncFrameIDCountMax: 15
+    gdActionPointOffset: 2
+    gdDynamicSlotIdlePhase: 1
+    gdMiniSlot: 5
+    gdMiniSlotActionPointOffset: 2
+    gdStaticSlot: 31
+    gdSymbolWindow: 1
+    gdSymbolWindowActionPointOffset: 1
+    gdTSSTransmitter: 9
+    gdWakeupTxActive: 60
+    gdWakeupTxIdle: 180
+  Name: FlexRay1
+  NodeParameters:
+    pAllowHaltDueToClock: 1
+    pAllowPassiveToActive: 0
+    pChannels: AB
+    pClusterDriftDamping: 2
+    pKeySlotId: 10
+    pKeySlotOnlyEnabled: 0
+    pKeySlotUsedForStartup: 1
+    pKeySlotUsedForSync: 0
+    pLatestTx: 249
+    pMacroInitialOffsetA: 3
+    pMacroInitialOffsetB: 3
+    pMicroInitialOffsetA: 6
+    pMicroInitialOffsetB: 6
+    pMicroPerCycle: 200000
+    pOffsetCorrectionOut: 127
+    pOffsetCorrectionStart: 3632
+    pRateCorrectionOut: 81
+    pSamplesPerMicrotick: 2
+    pWakeupChannel: A
+    pWakeupPattern: 33
+    pdAcceptedStartupRange: 212
+    pdListenTimeout: 400162
+    pdMicrotick: 25ns
+  TxBufferConfigurations:
+  - channels: A
+    headerCrc: 0
+    offset: 0
+    PPindicator: false
+    repetition: 0
+    slotId: 0
+    transmissionMode: Continuous
+  Replay:
+    Direction: Send
+    MdfChannel:
+      ChannelName: MyTestChannel1
+      ChannelPath: path/to/myTestChannel1
+      ChannelSource: MyTestChannel
+      GroupName: MyTestGroup
+      GroupPath: path/to/myTestGroup1
+      GroupSource: MyTestGroup
+    UseTraceSource: Source1
+  UseTraceSinks:
+  - Sink1
+DataPublishers:
+- Name: Publisher1
+  Topic: Temperature
+  UseTraceSinks:
+  - Sink1
+DataSubscribers:
+- Name: Subscriber3
+  Topic: Temperature
+  UseTraceSinks:
+  - Sink1
+- Name: Subscriber1
+  Topic: Temperature
+  UseTraceSinks:
+  - Sink1
+- Name: Subscriber2
+  Topic: Temperature
+  UseTraceSinks:
+  - Sink2
+RpcServers:
+- Name: Server1
+  FunctionName: Function1
+  UseTraceSinks:
+  - Sink1
+RpcClients:
+- Name: Client1
+  FunctionName: Function1
+  UseTraceSinks:
+  - Sink1
+Logging:
+  Sinks:
+  - Type: File
+    Level: Critical
+    LogName: MyLog1
+  FlushLevel: Warn
+  LogFromRemotes: false
+HealthCheck:
+  SoftResponseTimeout: 500
+  HardResponseTimeout: 5000
+Tracing:
+  TraceSinks:
+  - Name: Sink1
+    OutputPath: FlexrayDemo_node0.mf4
+    Type: Mdf4File
+  TraceSources:
+  - Name: Source1
+    InputPath: path/to/Source1.mf4
+    Type: Mdf4File
+Extensions:
+  SearchPathHints:
+  - path/to/extensions1
+  - path/to/extensions2

--- a/SilKit/source/config/TestParticipantConfigs/ParticipantConfiguration_FullIncludes_Reference.yaml
+++ b/SilKit/source/config/TestParticipantConfigs/ParticipantConfiguration_FullIncludes_Reference.yaml
@@ -1,0 +1,195 @@
+---
+Description: Example configuration to test YAML Parser
+schemaVersion: 0
+ParticipantName: Node0
+CanControllers:
+- Name: CAN1
+  Replay:
+    UseTraceSource: Source1
+    Direction: Both
+    MdfChannel:
+      ChannelName: MyTestChannel1
+      ChannelPath: path/to/myTestChannel1
+      ChannelSource: MyTestChannel
+      GroupName: MyTestGroup
+      GroupPath: path/to/myTestGroup1
+      GroupSource: MyTestGroup
+  UseTraceSinks:
+  - Sink1
+- Name: MyCAN2
+  Network: CAN2
+- Name: CAN64
+  Replay:
+    UseTraceSource: Source1
+    Direction: Both
+    MdfChannel:
+      ChannelName: MyTestChannel64
+      ChannelPath: path/to/myTestChannel64
+      ChannelSource: MyTestChannel
+      GroupName: MyTestGroup
+      GroupPath: path/to/myTestGroup64
+      GroupSource: MyTestGroup
+LinControllers:
+- Name: SimpleEcu1_LIN1
+  Network: LIN1
+  Replay:
+    UseTraceSource: Source1
+    Direction: Both
+    MdfChannel:
+      ChannelName: MyTestChannel1
+      ChannelPath: path/to/myTestChannel1
+      ChannelSource: MyTestChannel
+      GroupName: MyTestGroup
+      GroupPath: path/to/myTestGroup1
+      GroupSource: MyTestGroup
+  UseTraceSinks:
+  - MyTraceSink1
+EthernetControllers:
+- Name: ETH0
+  Replay:
+    UseTraceSource: Source1
+    Direction: Receive
+    MdfChannel:
+      ChannelName: MyTestChannel1
+      ChannelPath: path/to/myTestChannel1
+      ChannelSource: MyTestChannel
+      GroupName: MyTestGroup
+      GroupPath: path/to/myTestGroup1
+      GroupSource: MyTestGroup
+  UseTraceSinks:
+  - MyTraceSink1
+FlexrayControllers:
+- ClusterParameters:
+    gColdstartAttempts: 8
+    gCycleCountMax: 63
+    gListenNoise: 2
+    gMacroPerCycle: 3636
+    gMaxWithoutClockCorrectionFatal: 2
+    gMaxWithoutClockCorrectionPassive: 2
+    gNumberOfMiniSlots: 291
+    gNumberOfStaticSlots: 70
+    gPayloadLengthStatic: 16
+    gSyncFrameIDCountMax: 15
+    gdActionPointOffset: 2
+    gdDynamicSlotIdlePhase: 1
+    gdMiniSlot: 5
+    gdMiniSlotActionPointOffset: 2
+    gdStaticSlot: 31
+    gdSymbolWindow: 1
+    gdSymbolWindowActionPointOffset: 1
+    gdTSSTransmitter: 9
+    gdWakeupTxActive: 60
+    gdWakeupTxIdle: 180
+  Name: FlexRay1
+  NodeParameters:
+    pAllowHaltDueToClock: 1
+    pAllowPassiveToActive: 0
+    pChannels: AB
+    pClusterDriftDamping: 2
+    pKeySlotId: 10
+    pKeySlotOnlyEnabled: 0
+    pKeySlotUsedForStartup: 1
+    pKeySlotUsedForSync: 0
+    pLatestTx: 249
+    pMacroInitialOffsetA: 3
+    pMacroInitialOffsetB: 3
+    pMicroInitialOffsetA: 6
+    pMicroInitialOffsetB: 6
+    pMicroPerCycle: 200000
+    pOffsetCorrectionOut: 127
+    pOffsetCorrectionStart: 3632
+    pRateCorrectionOut: 81
+    pSamplesPerMicrotick: 2
+    pWakeupChannel: A
+    pWakeupPattern: 33
+    pdAcceptedStartupRange: 212
+    pdListenTimeout: 400162
+    pdMicrotick: 25ns
+  TxBufferConfigurations:
+  - channels: A
+    headerCrc: 0
+    offset: 0
+    PPindicator: false
+    repetition: 0
+    slotId: 0
+    transmissionMode: Continuous
+  Replay:
+    Direction: Send
+    MdfChannel:
+      ChannelName: MyTestChannel1
+      ChannelPath: path/to/myTestChannel1
+      ChannelSource: MyTestChannel
+      GroupName: MyTestGroup
+      GroupPath: path/to/myTestGroup1
+      GroupSource: MyTestGroup
+    UseTraceSource: Source1
+  UseTraceSinks:
+  - Sink1
+DataPublishers:
+- Name: Publisher1
+  Topic: Temperature
+  UseTraceSinks:
+  - Sink1
+DataSubscribers:
+- Name: Subscriber3
+  Topic: Temperature
+  UseTraceSinks:
+  - Sink1
+- Name: Subscriber1
+  Topic: Temperature
+  UseTraceSinks:
+  - Sink1
+- Name: Subscriber2
+  Topic: Temperature
+  UseTraceSinks:
+  - Sink2
+RpcServers:
+- Name: Server1
+  FunctionName: Function1
+  UseTraceSinks:
+  - Sink1
+RpcClients:
+- Name: Client1
+  FunctionName: Function1
+  UseTraceSinks:
+  - Sink1
+Logging:
+  Sinks:
+  - Type: File
+    Level: Critical
+    LogName: MyLog1
+  - Type: Stdout
+    Level: Trace
+  - Type: File
+    Level: Critical
+    LogName: MyLog2
+  FlushLevel: Warn
+  LogFromRemotes: false
+HealthCheck:
+  SoftResponseTimeout: 500
+  HardResponseTimeout: 5000
+Tracing:
+  TraceSinks:
+  - Name: Sink1
+    OutputPath: FlexrayDemo_node0.mf4
+    Type: Mdf4File
+  TraceSources:
+  - Name: Source1
+    InputPath: path/to/Source1.mf4
+    Type: Mdf4File
+Extensions:
+  SearchPathHints:
+  - path/to/extensions1
+  - path/to/extensions2
+  - path/to/extensions1
+  - path/to/extensions3
+  - path/to/extensions4
+  - path/to/extensions5
+Middleware:
+  RegistryUri: silkit://example.com:1234
+  ConnectAttempts: 12
+  TcpNoDelay: true
+  TcpQuickAck: true
+  EnableDomainSockets: false
+  TcpSendBufferSize: 3456
+  TcpReceiveBufferSize: 3456

--- a/SilKit/source/config/TestParticipantConfigs/ParticipantConfiguration_MultipleAcceptorUris.yaml
+++ b/SilKit/source/config/TestParticipantConfigs/ParticipantConfiguration_MultipleAcceptorUris.yaml
@@ -1,0 +1,14 @@
+---
+Description: Example configuration to test a broken configuration with multiple AcceptorURIs
+schemaVersion: 0
+Includes:
+  Files:
+    - MultipleAcceptorUrisInclude.yaml
+Middleware:
+  AcceptorUris:
+    - The/First/Uri/Found
+    - The/Second/Uri/Found
+    - The/Third/Uri/Found
+  RegistryUri: silkit://example.com:1234
+  ConnectAttempts: 9
+  EnableDomainSockets: false

--- a/SilKit/source/config/Test_ParticipantConfiguration.cpp
+++ b/SilKit/source/config/Test_ParticipantConfiguration.cpp
@@ -77,6 +77,132 @@ TEST_F(Test_ParticipantConfiguration, full_configuration_file)
     CreateParticipantFromConfiguration(cfg);
 }
 
+TEST_F(Test_ParticipantConfiguration, full_configuration_file_with_includes)
+{
+    auto cfg = SilKit::Config::ParticipantConfigurationFromFileImpl("ParticipantConfiguration_FullIncludes.yaml");
+    auto ref_cfg = SilKit::Config::ParticipantConfigurationFromFileImpl("ParticipantConfiguration_FullIncludes_Reference.yaml");
+
+    // cast to ParticipantConfiguration to use right equal operator
+    auto participantConfig = *std::dynamic_pointer_cast<ParticipantConfiguration>(cfg);
+    auto participantConfigRef = *std::dynamic_pointer_cast<ParticipantConfiguration>(ref_cfg);
+
+    ASSERT_TRUE(participantConfig == participantConfigRef);
+}
+
+TEST_F(Test_ParticipantConfiguration, participant_config_multiple_acceptor_uris)
+{
+    EXPECT_THROW(SilKit::Config::ParticipantConfigurationFromFileImpl("ParticipantConfiguration_MultipleAcceptorUris.yaml"),
+                SilKit::ConfigurationError);
+}
+
+TEST_F(Test_ParticipantConfiguration, participant_config_duplicate_controller_names)
+{
+    EXPECT_THROW(SilKit::Config::ParticipantConfigurationFromFileImpl("ParticipantConfiguration_DuplicateControllerNames.yaml"),
+                SilKit::ConfigurationError);
+}
+
+TEST_F(Test_ParticipantConfiguration, participant_config_from_string)
+{
+    const auto configString = R"raw(
+---
+Description: Example include configuration for CAN Controllers
+CanControllers:
+- Name: CAN1
+  Replay:
+    UseTraceSource: Source1
+    Direction: Both
+    MdfChannel:
+      ChannelName: MyTestChannel1
+      ChannelPath: path/to/myTestChannel1
+      ChannelSource: MyTestChannel
+      GroupName: MyTestGroup
+      GroupPath: path/to/myTestGroup1
+      GroupSource: MyTestGroup
+  UseTraceSinks:
+  - Sink1
+- Name: MyCAN2
+  Network: CAN2
+    )raw";
+
+    auto cfg = SilKit::Config::ParticipantConfigurationFromStringImpl(configString);
+    auto ref_cfg = SilKit::Config::ParticipantConfigurationFromFileImpl("ParticipantConfiguration_FromString_Reference.yaml");
+
+    // cast to ParticipantConfiguration to use right equal operator
+    auto participantConfig = *std::dynamic_pointer_cast<ParticipantConfiguration>(cfg);
+    auto participantConfigRef = *std::dynamic_pointer_cast<ParticipantConfiguration>(ref_cfg);
+
+    ASSERT_TRUE(participantConfig == participantConfigRef);
+
+}
+TEST_F(Test_ParticipantConfiguration, participant_config_from_string_includes)
+{
+    const auto configString = R"raw(
+---
+Description: Example include configuration for CAN Controllers
+Includes:
+  SearchPathHints:
+    - ConfigSnippets/CAN
+  Files:
+      - CanInclude5.yaml
+CanControllers:
+- Name: CAN1
+  Replay:
+    UseTraceSource: Source1
+    Direction: Both
+    MdfChannel:
+      ChannelName: MyTestChannel1
+      ChannelPath: path/to/myTestChannel1
+      ChannelSource: MyTestChannel
+      GroupName: MyTestGroup
+      GroupPath: path/to/myTestGroup1
+      GroupSource: MyTestGroup
+  UseTraceSinks:
+  - Sink1
+- Name: MyCAN2
+  Network: CAN2
+    )raw";
+
+    const auto configStringRef = R"raw(
+---
+Description: Example include configuration for CAN Controllers
+CanControllers:
+- Name: CAN1
+  Replay:
+    UseTraceSource: Source1
+    Direction: Both
+    MdfChannel:
+      ChannelName: MyTestChannel1
+      ChannelPath: path/to/myTestChannel1
+      ChannelSource: MyTestChannel
+      GroupName: MyTestGroup
+      GroupPath: path/to/myTestGroup1
+      GroupSource: MyTestGroup
+  UseTraceSinks:
+  - Sink1
+- Name: MyCAN2
+  Network: CAN2
+- Name: CAN64
+  Replay:
+    UseTraceSource: Source1
+    Direction: Both
+    MdfChannel:
+      ChannelName: MyTestChannel64
+      ChannelPath: path/to/myTestChannel64
+      ChannelSource: MyTestChannel
+      GroupName: MyTestGroup
+      GroupPath: path/to/myTestGroup64
+      GroupSource: MyTestGroup
+    )raw";
+
+    auto cfg = SilKit::Config::ParticipantConfigurationFromStringImpl(configString);
+    auto cfgRef = SilKit::Config::ParticipantConfigurationFromStringImpl(configStringRef);
+
+    // cast to ParticipantConfiguration to use right equal operator
+    auto config = *std::dynamic_pointer_cast<ParticipantConfiguration>(cfg);
+    auto configRef = *std::dynamic_pointer_cast<ParticipantConfiguration>(cfgRef);
+    ASSERT_TRUE(config == configRef);
+}
+
 /*
     Test whether json and yaml configurations are parsed equivalently
 */

--- a/SilKit/source/config/Test_YamlValidator.cpp
+++ b/SilKit/source/config/Test_YamlValidator.cpp
@@ -27,6 +27,8 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE. */
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
+#include <fstream>
+
 namespace {
 
 class Test_YamlValidator : public testing::Test

--- a/SilKit/source/config/YamlSchema.cpp
+++ b/SilKit/source/config/YamlSchema.cpp
@@ -157,6 +157,11 @@ auto MakeYamlSchema() -> YamlSchemaElem
         {"schemaVersion"}, // should be removed in the future (deprecated)
         {"Description"},
         {"ParticipantName"},
+        {"Includes", {
+                {"SearchPathHints"},
+                {"Files"}
+            }
+        },
         {"CanControllers", {
                 {"Name"},
                 {"Network"},

--- a/SilKit/source/util/FileHelpers.cpp
+++ b/SilKit/source/util/FileHelpers.cpp
@@ -78,7 +78,7 @@ auto ReadTextFile(const std::string& path) -> std::string
     auto fs = OpenIFStream(path);
 
     if (!fs.is_open())
-        throw SilKit::ConfigurationError("the file could not be opened");
+        throw SilKit::ConfigurationError("File '" + path + "' could not be opened");
 
     std::stringstream buffer;
     buffer << fs.rdbuf();

--- a/SilKit/source/util/FileHelpers.cpp
+++ b/SilKit/source/util/FileHelpers.cpp
@@ -23,16 +23,59 @@
 
 #include "silkit/participant/exception.hpp"
 
-#include <fstream>
 #include <sstream>
 
+#ifdef _WIN32
+#    define NOMINMAX
+#    define WIN32_LEAN_AND_MEAN
+#    include "Windows.h"
+#endif
 
 namespace SilKit {
 namespace Util {
 
-auto ReadTextFile(const std::string& filename) -> std::string
+#ifdef _WIN32
+
+auto OpenIFStream(const std::string& path) -> std::ifstream
 {
-    std::ifstream fs(filename);
+    std::wstring widePath;
+
+    constexpr DWORD MB2WC_FLAGS = 0;
+
+    const auto pathSize = static_cast<int>(path.size());
+
+    // determine the size of the required wide-character string
+    const int widePathSize = ::MultiByteToWideChar(CP_UTF8, MB2WC_FLAGS, path.c_str(), pathSize, NULL, 0);
+    if (widePathSize <= 0)
+    {
+        throw SilKit::ConfigurationError{"conversion from UTF-8 to UTF-16 failed"};
+    }
+
+    widePath.resize(static_cast<size_t>(widePathSize));
+
+    // actually convert the path into a wide-character string
+    const int realWidePathSize =
+        ::MultiByteToWideChar(CP_UTF8, MB2WC_FLAGS, path.c_str(), pathSize, &widePath[0], widePathSize);
+    if (realWidePathSize != widePathSize)
+    {
+        throw SilKit::ConfigurationError{"conversion from UTF-8 to UTF-16 failed"};
+    }
+
+    return std::ifstream{widePath};
+}
+
+#else
+
+auto OpenIFStream(const std::string& path) -> std::ifstream
+{
+    return std::ifstream{path};
+}
+
+#endif
+
+auto ReadTextFile(const std::string& path) -> std::string
+{
+    auto fs = OpenIFStream(path);
 
     if (!fs.is_open())
         throw SilKit::ConfigurationError("the file could not be opened");

--- a/SilKit/source/util/FileHelpers.hpp
+++ b/SilKit/source/util/FileHelpers.hpp
@@ -20,12 +20,14 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 #include <string>
+#include <fstream>
 
 
 namespace SilKit {
 namespace Util {
 
-auto ReadTextFile(const std::string& filename) -> std::string;
+auto OpenIFStream(const std::string& path) -> std::ifstream;
+auto ReadTextFile(const std::string& path) -> std::string;
 
 } // namespace Util
 } // namespace SilKit

--- a/SilKit/source/util/Filesystem.cpp
+++ b/SilKit/source/util/Filesystem.cpp
@@ -144,5 +144,38 @@ bool create_directory(const path& where)
         return errno == EEXIST;
     }
 }
+
+path parent_path(const path& child)
+{
+    auto path_string = child.string();
+
+    const auto last_separator = path_string.rfind(SilKit::Filesystem::path::preferred_separator);
+
+    if(last_separator == std::string::npos)
+    {
+        return Filesystem::path();
+    }
+
+    return Filesystem::path(path_string.substr(0, last_separator));
+}
+
+path concatenate_paths(const path& root, const path& child)
+{
+    return concatenate_paths(root.string(), child.string());
+}
+path concatenate_paths(const std::string& root, const std::string& child)
+{
+    path tmpPath;
+    if (!(root.back() == path::preferred_separator) && !(child.front() == path::preferred_separator))
+    {
+        tmpPath =  path(root + path::preferred_separator + child);
+    }
+    else
+    {
+        tmpPath = path(root + child);
+    }
+    return tmpPath;
+}
+
 } // namespace Filesystem
 } // namespace SilKit

--- a/SilKit/source/util/Filesystem.hpp
+++ b/SilKit/source/util/Filesystem.hpp
@@ -80,5 +80,12 @@ bool remove(const path&);
 //! Rename a file.
 void rename(const path& old_p, const path& new_p);
 
+//! Get parent path
+path parent_path(const path& child);
+
+//! Append paths
+path concatenate_paths(const path& root, const path& child);
+path concatenate_paths(const std::string& root, const std::string& child);
+
 } // namespace Filesystem
 } // namespace SilKit

--- a/SilKit/source/util/Optional.hpp
+++ b/SilKit/source/util/Optional.hpp
@@ -90,5 +90,15 @@ bool operator==(const Optional<T>& lhs, const Optional<T>& rhs)
         && lhs.value() == rhs.value();
 }
 
+template<class T>
+bool operator!=(const Optional<T>& lhs, const Optional<T>& rhs)
+{
+    if (!lhs.has_value() || !rhs.has_value())
+        return lhs.has_value() != rhs.has_value();
+
+    return lhs.has_value() == rhs.has_value()
+        && lhs.value() != rhs.value();
+}
+
 } // namespace Util
 } // namespace SilKit

--- a/SilKit/source/util/Optional.hpp
+++ b/SilKit/source/util/Optional.hpp
@@ -96,8 +96,7 @@ bool operator!=(const Optional<T>& lhs, const Optional<T>& rhs)
     if (!lhs.has_value() || !rhs.has_value())
         return lhs.has_value() != rhs.has_value();
 
-    return lhs.has_value() == rhs.has_value()
-        && lhs.value() != rhs.value();
+    return lhs.value() != rhs.value();
 }
 
 } // namespace Util

--- a/SilKit/source/util/tests/CMakeLists.txt
+++ b/SilKit/source/util/tests/CMakeLists.txt
@@ -26,3 +26,4 @@ add_silkit_test_to_executable(SilKitUnitTests SOURCES Test_SynchronizedHandlers.
 add_silkit_test_to_executable(SilKitUnitTests SOURCES Test_Timer.cpp LIBS I_SilKit_Util O_SilKit_Util_SetThreadName)
 add_silkit_test_to_executable(SilKitUnitTests SOURCES Test_Util_FileHelpers.cpp LIBS O_SilKit_Util_FileHelpers)
 add_silkit_test_to_executable(SilKitUnitTests SOURCES Test_Uri.cpp)
+add_silkit_test_to_executable(SilKitUnitTests SOURCES Test_Filesystem.cpp LIBS O_SilKit_Util_Filesystem)

--- a/SilKit/source/util/tests/Test_Filesystem.cpp
+++ b/SilKit/source/util/tests/Test_Filesystem.cpp
@@ -1,0 +1,74 @@
+/* Copyright (c) 2023 Vector Informatik GmbH
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE. */
+#include "Filesystem.hpp"
+
+#include <iostream>
+
+#include "gtest/gtest.h"
+#include "gmock/gmock.h"
+
+namespace SilKit {
+namespace Util {
+namespace tests {
+
+TEST(UtilsFilesystemTest, get_parent_path)
+{
+    const auto some_path = Filesystem::path("/This/Is/Some/Path/To/A/File/");
+    auto parent_path = Filesystem::parent_path(some_path);
+
+    const auto parent_path_ref1 = std::string("/This/Is/Some/Path/To/A/File");
+    ASSERT_EQ(parent_path_ref1, parent_path.string());
+
+    parent_path = Filesystem::parent_path(parent_path.string());
+    const auto parent_path_ref2 = std::string("/This/Is/Some/Path/To/A");
+    ASSERT_EQ(parent_path_ref2, parent_path.string());
+
+    parent_path = Filesystem::parent_path(parent_path.string());
+    const auto parent_path_ref3 = std::string("/This/Is/Some/Path/To");
+    ASSERT_EQ(parent_path_ref3, parent_path.string());
+}
+
+TEST(UtilsFilesystemTest, test_root_parent)
+{
+    const Filesystem::path root_path{"RootFile"};
+    const auto parent_path = Filesystem::parent_path(root_path);
+
+    ASSERT_EQ("", parent_path.string());
+}
+
+TEST(UtilsFilesystemTest, test_concat_paths)
+{
+    const Filesystem::path file_name{"File"};
+    const Filesystem::path root_path{"/Path/To/"};
+    const auto file_path = Filesystem::concatenate_paths(root_path, file_name);
+
+    ASSERT_EQ("/Path/To/File", file_path.string());
+}
+
+TEST(UtilsFilesystemTest, test_concat_path_strings)
+{
+    const auto file_path = Filesystem::concatenate_paths("/Path/To", "File");
+
+    ASSERT_EQ("/Path/To/File", file_path.string());
+}
+} // namespace tests
+} // namespace Util
+} // namespace SilKit

--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -7,6 +7,15 @@ All notable changes to the Vector SIL Kit project shall be documented in this fi
 The format is based on `Keep a Changelog (http://keepachangelog.com/en/1.0.0/) <http://keepachangelog.com/en/1.0.0/>`_.
 
 
+[4.0.49] - UNRELEASED
+---------------------
+
+Added
+~~~~~
+
+- Participant Configuration: support include semantics in participant configuration files/strings
+
+
 [4.0.48] - 2024-04-15
 ---------------------
 


### PR DESCRIPTION
## Subject

* Add support to include config snippets in configs provided via file
* Add support to include config snippets in configs provided as string
* Move file uitility functions to their own unit
* Add tests for all provided funtionality


## Description
Issues: SILKIT-1391, SILKIT-1495

## Developer checklist (address before review)

- [x] Changelog.md updated
- [ ] Prepared update for depending repositories
- [x] Documentation updated (public API changes only) (PR: https://github.com/vectorgrp/sil-kit/pull/21)
- [ ] API docstrings updated (public API changes only)
- [ ] Rebase &rarr; commit history clean
- [ ] Squash and merge &rarr; proper PR title
