### PR TITLE
-- cmake: fix configuring without tests

### DIFF
--- a/SilKit/source/config/CMakeLists.txt
+++ b/SilKit/source/config/CMakeLists.txt
@@ -141,9 +141,10 @@ endfunction()
 
 copy_participant_configs(CopyTestConfigs "${ParticipantTestCanConfigs}" "CAN")
 copy_participant_configs(CopyTestConfigs "${ParticipantTestMiddlewareConfigs}" "Middleware")
-add_dependencies(SilKitUnitTests CopyTestConfigs)
 
 if(SILKIT_BUILD_TESTS)
+    add_dependencies(SilKitUnitTests CopyTestConfigs)
+
     add_library(I_SilKit_Config_TestUtils INTERFACE)
 
     target_include_directories(I_SilKit_Config_TestUtils


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2023 Vector Informatik GmbH

SPDX-License-Identifier: MIT
-->

## Subject
<!--
    - What kind of changes does this pull request comprise?
    - Add a label like "Bugfix", "docs", etc. to this PR to give context.
 -->

When tests are disabled (`SILKIT_BUILD_TESTS=OFF`) the `SilKitUnitTests` executable target does not exist.

## Developer checklist (address before review)

- [ ] Changelog.md updated
- [ ] Prepared update for depending repositories
- [ ] Documentation updated (public API changes only)
- [ ] API docstrings updated (public API changes only)
- [ ] Rebase &rarr; commit history clean
- [x] Squash and merge &rarr; proper PR title
