### PR TITLE
Fix win builds

### DIFF
--- a/SilKit/source/config/Configuration.hpp
+++ b/SilKit/source/config/Configuration.hpp
@@ -212,7 +212,7 @@ bool operator==(const Sink& lhs, const Sink& rhs)
 
 bool operator<(const Sink& lhs, const Sink& rhs)
 {
-    return lhs.logName.compare(rhs.logName);
+    return lhs.logName.compare(rhs.logName) < 0;
 }
 
 bool operator>(const Sink& lhs, const Sink& rhs)

--- a/SilKit/source/util/FileHelpers.cpp
+++ b/SilKit/source/util/FileHelpers.cpp
@@ -25,7 +25,8 @@
 
 #include <sstream>
 
-#ifdef _WIN32
+// Check if MSVC is used, since MINGW32/64 don't need these workarounds
+#ifdef _MSC_VER
 #    define NOMINMAX
 #    define WIN32_LEAN_AND_MEAN
 #    include "Windows.h"
@@ -34,7 +35,7 @@
 namespace SilKit {
 namespace Util {
 
-#ifdef _WIN32
+#ifdef _MSC_VER
 
 auto OpenIFStream(const std::string& path) -> std::ifstream
 {


### PR DESCRIPTION
## Subject
Windows build + tests were broken due to

* Wrong comparison operator
* Suboptimal platform detection in FileHelpers.cpp


## Description
No ticket available

## Developer checklist (address before review)

- [ ] Changelog.md updated
- [ ] Prepared update for depending repositories
- [ ] Documentation updated (public API changes only)
- [ ] API docstrings updated (public API changes only)
- [ ] Rebase &rarr; commit history clean
- [ ] Squash and merge &rarr; proper PR title
