### PR TITLE
-- utilities: signal monitor: do not call signal handler upon destruction

### DIFF
--- a/SilKit/source/util/SignalHandler.cpp
+++ b/SilKit/source/util/SignalHandler.cpp
@@ -45,6 +45,8 @@ BOOL WINAPI systemHandler(DWORD ctrlType);
 
 class SignalMonitor
 {
+    static constexpr int INVALID_SIGNAL_NUMBER = -1;
+
 public:
     SignalMonitor(SignalHandler handler)
     {
@@ -69,7 +71,7 @@ public:
     ~SignalMonitor()
     {
         SetConsoleCtrlHandler(systemHandler, false);
-        Notify(-1);
+        Notify(INVALID_SIGNAL_NUMBER);
         _worker.join();
         CloseHandle(_writeEnd);
         CloseHandle(_readEnd);
@@ -94,15 +96,16 @@ private:
             throw std::runtime_error("SignalMonitor::workerMain: Failed to read from pipe.");
         }
 
-        if (_handler)
+        if ((_signalNumber != INVALID_SIGNAL_NUMBER) && _handler)
         {
             _handler(_signalNumber);
         }
     }
+
     HANDLE _readEnd{INVALID_HANDLE_VALUE}, _writeEnd{INVALID_HANDLE_VALUE};
     SignalHandler _handler;
     std::thread _worker;
-    int _signalNumber{-1};
+    int _signalNumber{INVALID_SIGNAL_NUMBER};
 };
 
 BOOL WINAPI systemHandler(DWORD ctrlType)
@@ -140,6 +143,8 @@ void systemHandler(int sigNum);
 
 class SignalMonitor
 {
+    static constexpr int INVALID_SIGNAL_NUMBER = -1;
+
 public:
     SignalMonitor(SignalHandler handler)
     {
@@ -168,7 +173,7 @@ public:
         // Restore default actio0ns
         setSignalAction(SIGINT, SIG_DFL);
         setSignalAction(SIGTERM, SIG_DFL);
-        Notify(-1);
+        Notify(INVALID_SIGNAL_NUMBER);
         _worker.join();
         ::close(_pipe[0]);
         ::close(_pipe[1]);
@@ -194,7 +199,7 @@ private:
         {
             throw std::runtime_error("SignalMonitor::workerMain: Failed to read from pipe: " + ErrorMessage());
         }
-        if (_handler)
+        if ((_signalNumber != INVALID_SIGNAL_NUMBER) && _handler)
         {
             _handler(_signalNumber);
         }
@@ -203,7 +208,7 @@ private:
     int _pipe[2];
     SignalHandler _handler;
     std::thread _worker;
-    int _signalNumber{-1};
+    int _signalNumber{INVALID_SIGNAL_NUMBER};
 };
 
 static inline void setSignalAction(int sigNum, __sighandler_t action)


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2023 Vector Informatik GmbH

SPDX-License-Identifier: MIT
-->

## Subject
<!--
    - What kind of changes does this pull request comprise?
    - Add a label like "Bugfix", "docs", etc. to this PR to give context.
 -->

The `sil-kit-system-controller` currently crashes (SEGFAULT) if the simulation is stopped externally. This happens because the handler is called when the `SignalMonitor` instance is destroyed, and the handler calls the logging functions on a destroyed object.

The fix checks that the signal number is not the 'default' / 'invalid' signal number before calling the handler.

## Instructions for review / testing
<!--
    - Hilight some of the important changes, which reviewers should focus on
    - Which parts should be reviewed in detail? For example: content of console output, correct semantics of changes
    - Test steps and test setup description. For example: which programs or configs to use
-->

Please run the system controller and a participant that can be stopped 'by hand' without exiting the process. Then, when the participant stops, the system controller should exit normally. Check the exit code (PowerShell: `$LASTEXITCODE`, shell: `$?`).

## Developer checklist (address before review)

- [ ] Changelog.md updated
- [ ] Prepared update for depending repositories
- [ ] Documentation updated (public API changes only)
- [ ] API docstrings updated (public API changes only)
- [ ] Rebase &rarr; commit history clean
- [ ] Squash and merge &rarr; proper PR title
