### PR TITLE
ci: don't run CI for repo metadata changes

### DIFF
--- a/.github/workflows/sil-kit-ci.yml
+++ b/.github/workflows/sil-kit-ci.yml
@@ -3,8 +3,12 @@ name: "CI for Pull Requests"
 on:
   pull_request:
     branches: [ 'main' ]
-  push:
-    branches: [ 'main' ]
+    paths:
+      - '!README.rst'
+      - '!CONTRIBUTING.md'
+      - '!LICENSE'
+      - '!SECURITY.md'
+      - '!SilKit/CHANGELOG.md'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}


### PR DESCRIPTION

## Subject
We do not need to run the CI for changes to files that have no impact on the CI's status such as the README and the CHANGELOG

## Developer checklist (address before review)

- [ ] Changelog.md updated
- [ ] Prepared update for depending repositories
- [ ] Documentation updated (public API changes only)
- [ ] API docstrings updated (public API changes only)
- [ ] Rebase &rarr; commit history clean
- [ ] Squash and merge &rarr; proper PR title
