### PR TITLE
-- ci: remove builds in CI for metadata changes

### DIFF
--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -14,21 +14,25 @@ on:
         required: false
         type: number
         default: 14
+      run_build:
+        required: true
+        type: boolean
 
 jobs:
   clang14-release:
     name: Clang 14 release Builds for Ubuntu 22.04
     environment: public-github-runners
     runs-on: ubuntu-22.04
+    if: inputs.run_build == true
     steps:
-    - uses: actions/checkout@v4
-      with:
-        submodules: true
-    - uses: ./.github/actions/build-cmake-preset
-      with:
-        preset-name: clang14-release
-        do-package: ${{ inputs.do_package }}
-        retention-days: ${{ inputs.retention_days }}
+      - uses: actions/checkout@v4
+        with:
+          submodules: true
+      - uses: ./.github/actions/build-cmake-preset
+        with:
+          preset-name: clang14-release
+          do-package: ${{ inputs.do_package }}
+          retention-days: ${{ inputs.retention_days }}
 
   gcc8-release:
     name: GCC 8 release Builds for Ubuntu 18.04
@@ -36,16 +40,17 @@ jobs:
     runs-on: ubuntu-latest
     container:
       image: ghcr.io/mariusbgm/sil-kit-ci-ubuntu-18.04:main
+    if: inputs.run_build == true
     steps:
-    - name: git checkout
-      uses: actions/checkout@v1
-      with:
-        submodules: true
-    - name: gcc8-release build
-      uses: ./.github/actions/build-cmake-preset
-      id: build
-      with:
-        preset-name: gcc8-release
-        do-package: ${{ inputs.do_package }}
-        retention-days: ${{ env.retention_days }}
+      - name: git checkout
+        uses: actions/checkout@v1
+        with:
+          submodules: true
+      - name: gcc8-release build
+        uses: ./.github/actions/build-cmake-preset
+        id: build
+        with:
+          preset-name: gcc8-release
+          do-package: ${{ inputs.do_package }}
+          retention-days: ${{ env.retention_days }}
 

--- a/.github/workflows/build-win.yml
+++ b/.github/workflows/build-win.yml
@@ -15,6 +15,9 @@ on:
         required: false
         type: number
         default: 14
+      run_build:
+        required: true
+        type: boolean
 
   push:
     branches: [ 'main' ]
@@ -27,6 +30,7 @@ jobs:
   build-win-x64:
     runs-on: windows-2019
     environment: public-github-runners
+    if: inputs.run_build == true
     steps:
     - uses: actions/checkout@v4
       with:
@@ -41,6 +45,7 @@ jobs:
   build-win-x32:
     runs-on: windows-2019
     environment: public-github-runners
+    if: inputs.run_build == true
     steps:
     - uses: actions/checkout@v4
       with:

--- a/.github/workflows/linux-asan.yml
+++ b/.github/workflows/linux-asan.yml
@@ -1,6 +1,10 @@
 name: 'Linux + Address Sanitizer'
 on:
   workflow_call:
+    inputs:
+      run_build:
+        required: true
+        type: boolean
 
   push:
     branches: [ 'main' ]
@@ -9,12 +13,13 @@ jobs:
   clang14-asan:
     environment: public-github-runners
     runs-on: ubuntu-22.04
+    if: inputs.run_build == true
     steps:
-    - uses: actions/checkout@v4
-      with:
-        submodules: true
-    - uses: ./.github/actions/build-cmake-preset
-      with:
-        preset-name: clang14-relwithdebinfo
-        cmake-args: "-D SILKIT_ENABLE_ASAN=ON -D SILKIT_BUILD_DASHBOARD=OFF"
-        do-package: false
+      - uses: actions/checkout@v4
+        with:
+          submodules: true
+      - uses: ./.github/actions/build-cmake-preset
+        with:
+          preset-name: clang14-relwithdebinfo
+          cmake-args: "-D SILKIT_ENABLE_ASAN=ON -D SILKIT_BUILD_DASHBOARD=OFF"
+          do-package: false

--- a/.github/workflows/linux-tsan.yml
+++ b/.github/workflows/linux-tsan.yml
@@ -1,6 +1,10 @@
 name: 'Linux + Thread Sanitizer'
 on:
   workflow_call:
+    inputs:
+      run_build:
+        required: true
+        type: boolean
 
   push:
     branches: [ 'main' ]
@@ -10,12 +14,13 @@ jobs:
     name: Thread Sanitizer Tests
     environment: public-github-runners
     runs-on: ubuntu-22.04
+    if: inputs.run_build == true
     steps:
-    - uses: actions/checkout@v4
-      with:
-        submodules: true
-    - uses: ./.github/actions/build-cmake-preset
-      with:
-        preset-name: clang14-relwithdebinfo
-        cmake-args: "-D SILKIT_ENABLE_THREADSAN=ON -D SILKIT_BUILD_DASHBOARD=OFF"
-        do-package: false
+      - uses: actions/checkout@v4
+        with:
+          submodules: true
+      - uses: ./.github/actions/build-cmake-preset
+        with:
+          preset-name: clang14-relwithdebinfo
+          cmake-args: "-D SILKIT_ENABLE_THREADSAN=ON -D SILKIT_BUILD_DASHBOARD=OFF"
+          do-package: false

--- a/.github/workflows/linux-ubsan.yml
+++ b/.github/workflows/linux-ubsan.yml
@@ -1,6 +1,10 @@
 name: 'Linux + UB Sanitizer'
 on:
   workflow_call:
+    inputs:
+      run_build:
+        required: true
+        type: boolean
 
   push:
     branches: [ 'main' ]
@@ -10,12 +14,13 @@ jobs:
     name: Undefined Behavior Sanitizer Tests
     environment: public-github-runners
     runs-on: ubuntu-22.04
+    if: inputs.run_build == true
     steps:
-    - uses: actions/checkout@v4
-      with:
-        submodules: true
-    - uses: ./.github/actions/build-cmake-preset
-      with:
-        preset-name: clang14-relwithdebinfo
-        cmake-args: "-D SILKIT_ENABLE_UBSAN=ON -D SILKIT_BUILD_DASHBOARD=OFF"
-        do-package: false
+      - uses: actions/checkout@v4
+        with:
+          submodules: true
+      - uses: ./.github/actions/build-cmake-preset
+        with:
+          preset-name: clang14-relwithdebinfo
+          cmake-args: "-D SILKIT_ENABLE_UBSAN=ON -D SILKIT_BUILD_DASHBOARD=OFF"
+          do-package: false

--- a/.github/workflows/sil-kit-ci.yml
+++ b/.github/workflows/sil-kit-ci.yml
@@ -27,32 +27,52 @@ jobs:
           sh ./SilKit/ci/check_licenses.sh
         shell: bash
 
+  check-files-changed:
+    runs-on: ubuntu-22.04
+    outputs:
+      run_builds: ${{ steps.files_check.outputs.run_builds }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: false
+      - name: Check changed files
+        id: files_check
+        run: |
+          python3 ./SilKit/ci/check_files_changed.py ${{ github.repository }} ${{ github.event.number }}
+
   clang14-tsan:
     name: Thread Sanitizer Tests
-    needs: check-licenses
+    needs: [check-licenses, check-files-changed]
     uses: ./.github/workflows/linux-tsan.yml
+    with:
+      run_build: ${{ needs.check-files-changed.outputs.run_builds == 'true' }}
 
   clang14-ubsan:
     name: Undefined Behavior Sanitizer Tests
-    needs: check-licenses
+    needs: [check-licenses, check-files-changed]
     uses: ./.github/workflows/linux-ubsan.yml
+    with:
+      run_build: ${{ needs.check-files-changed.outputs.run_builds == 'true' }}
 
   clang14-asan:
     name: Address Sanitizer Tests
-    needs: check-licenses
+    needs: [check-licenses, check-files-changed]
     uses: ./.github/workflows/linux-asan.yml
+    with:
+      run_build: ${{ needs.check-files-changed.outputs.run_builds == 'true' }}
 
   ubuntu-release-builds:
     uses: ./.github/workflows/build-linux.yml
-    needs: check-licenses
+    needs: [check-licenses, check-files-changed]
     with:
       do_package: ${{ github.event_name == 'push' && true || false }}
       retention_days: ${{ github.event_name == 'push' && 90 || 14 }}
+      run_build: ${{ needs.check-files-changed.outputs.run_builds == 'true' }}
 
   windows-release-builds:
     uses: ./.github/workflows/build-win.yml
-    needs: check-licenses
+    needs: [check-licenses, check-files-changed]
     with:
       do_package: ${{ github.event_name == 'push' && true || false }}
       retention_days: ${{ github.event_name == 'push' && 90 || 14 }}
-
+      run_build: ${{ needs.check-files-changed.outputs.run_builds == 'true' }}

--- a/SilKit/ci/check_files_changed.py
+++ b/SilKit/ci/check_files_changed.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+
+# SPDX-FileCopyrightText: 2024 Vector Informatik GmbH
+#
+# SPDX-License-Identifier: MIT
+
+import requests
+import argparse
+import os
+
+isCI = os.getenv('CI')
+INFO_PREFIX = "::notice ::" if isCI != None else "INFO: "
+WARN_PREFIX = "::warning ::" if isCI != None else "WARNING: "
+ERROR_PREFIX = "::error ::" if isCI != None else "ERROR: "
+
+## Convenience
+def log(fmt, *args):
+    print(fmt.format(*args))
+
+def info(fmt, *args):
+    log(INFO_PREFIX + fmt, *args)
+
+def warn(fmt, *args):
+    log(WARN_PREFIX + fmt, *args)
+
+def die(status, fmt, *args):
+    log(ERROR_PREFIX + fmt, *args)
+    sys.exit(status)
+
+# File Set
+exceptional_files = {'README.rst', 'CHANGELOG.rst', 'LICENSE', 'CONTRIBUTING.md'}
+
+parser = argparse.ArgumentParser(prog="JobStatusChecker",
+                                 description="Check Job Status of a specific github workflow run")
+parser.add_argument('repo', type=str)
+parser.add_argument('PR', type=str)
+args = parser.parse_args()
+
+run_builds = "false"
+
+url = 'https://api.github.com/repos/' + args.repo + '/pulls/' + args.PR + '/files'
+
+log("Checking at {}".format(url))
+
+r = requests.get(url, verify=False)
+
+for fileObject in r.json():
+
+    file_path = fileObject["filename"];
+    file = file_path.split(sep="/")[-1]
+
+    if file not in exceptional_files:
+        run_builds = "true"
+        break
+
+log("Builds should run: {}".format(run_builds))
+
+if isCI != None:
+    log("Setting GITHUB_OUTPUT!")
+    with open(os.environ["GITHUB_OUTPUT"], 'a') as f:
+        print("run_builds={}".format(run_builds), file=f)


### PR DESCRIPTION
We do not need to run the CI if we want to change the CHANGELOG or the README file. This is done mostly for the release process, where we want to make sure that the CHANGELOG is up-to-date without waiting for the CI to finish!

## Developer checklist (address before review)

- [ ] Changelog.md updated
- [ ] Prepared update for depending repositories
- [ ] Documentation updated (public API changes only)
- [ ] API docstrings updated (public API changes only)
- [ ] Rebase &rarr; commit history clean
- [ ] Squash and merge &rarr; proper PR title
