### PR TITLE
-- extensions: don't rely on __GNUC__ in clang builds

### DIFF
--- a/SilKit/source/extensions/SilKitExtensionApi/SilKitExtensionUtils.hpp
+++ b/SilKit/source/extensions/SilKitExtensionApi/SilKitExtensionUtils.hpp
@@ -92,6 +92,8 @@ constexpr uint32_t BuildinfoCompiler()
 #   if defined(_WIN32) && defined(__GNUC__)
     //MinGW
     return 0;
+#   elif defined( __clang__)
+    return __clang_major__;
 #   elif defined( __GNUC__)
     // the major version of a GNU compiler, the C++ macro _GLIBCXX_RELEASE defaults to this
     return __GNUC__;


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2023 Vector Informatik GmbH

SPDX-License-Identifier: MIT
-->

## Subject
<!--
    - What kind of changes does this pull request comprise?
    - Add a label like "Bugfix", "docs", etc. to this PR to give context.
 -->
The clang builds relied on __GNUC__ to be set for extension loading. Rather use __clang__major instead.
We need to rework the extension loading constraints in the future anyway

## Developer checklist (address before review)

- [ ] Changelog.md updated
- [ ] Prepared update for depending repositories
- [ ] Documentation updated (public API changes only)
- [ ] API docstrings updated (public API changes only)
- [ ] Rebase &rarr; commit history clean
- [ ] Squash and merge &rarr; proper PR title
