### PR TITLE
-- add editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,5 @@
+root = true
+
+[*.{cpp,ipp,hpp,h,c}]
+indent_style = space
+indent_size = 4


### PR DESCRIPTION
This fixes that Visual Studio ignores the indent settings in the .clang-format file.
