### PR TITLE
SILKIT-1571 core: add ring buffer for storing data from byte stream

### DIFF
--- a/SilKit/source/core/vasio/CMakeLists.txt
+++ b/SilKit/source/core/vasio/CMakeLists.txt
@@ -104,6 +104,9 @@ add_library(O_SilKit_Core_VAsio OBJECT
     ConnectPeer.cpp
     ConnectKnownParticipants.cpp
     RemoteConnectionManager.cpp
+
+    RingBuffer.hpp
+    RingBuffer.cpp
 )
 
 target_link_libraries(O_SilKit_Core_VAsio
@@ -158,6 +161,8 @@ add_silkit_test_to_executable(SilKitUnitTests SOURCES Test_VAsioSerdes.cpp LIBS 
 add_silkit_test_to_executable(SilKitUnitTests SOURCES Test_SerializedMessage.cpp LIBS S_SilKitImpl)
 add_silkit_test_to_executable(SilKitUnitTests SOURCES Test_TransformAcceptorUris.cpp LIBS S_SilKitImpl)
 add_silkit_test_to_executable(SilKitUnitTests SOURCES Test_VAsioCapabilities.cpp LIBS S_SilKitImpl)
+
+add_silkit_test_to_executable(SilKitUnitTests SOURCES Test_RingBuffer.cpp LIBS S_SilKitImpl)
 
 add_silkit_test_to_executable(SilKitUnitTests SOURCES io/Test_IoContext.cpp LIBS S_SilKitImpl)
 add_silkit_test_to_executable(SilKitUnitTests SOURCES io/Test_AsioIoContext.cpp LIBS S_SilKitImpl)

--- a/SilKit/source/core/vasio/RingBuffer.cpp
+++ b/SilKit/source/core/vasio/RingBuffer.cpp
@@ -1,0 +1,166 @@
+// SPDX-FileCopyrightText: 2023 Vector Informatik GmbH
+//
+// SPDX-License-Identifier: MIT
+
+#include "RingBuffer.hpp"
+
+#include <algorithm>
+#include <iterator>
+
+#include "silkit/participant/exception.hpp"
+
+namespace SilKit {
+namespace Core {
+
+RingBuffer::RingBuffer(size_t capacity)
+{
+    _buffer.resize(capacity);
+}
+
+void RingBuffer::AdvanceWPos(size_t numBytes)
+{
+    _wPos = (_wPos + numBytes) % Capacity();
+    _size += numBytes;
+
+    SizeCheck();
+}
+
+void RingBuffer::AdvanceRPos(size_t numBytes)
+{
+    _rPos = (_rPos + numBytes) % Capacity();
+    _size -= numBytes;
+
+    SizeCheck();
+}
+
+bool RingBuffer::Peek(std::vector<uint8_t>& elem) const
+{
+    // make sure, we only copy as many bytes as are contained in the buffer
+    if (elem.size() > _size)
+    {
+        return false;
+    }
+
+    // copy data from first contiguous array (of occupied memory)
+    size_t numBytesArrayOne = std::min((Capacity() - _rPos), elem.size());
+    std::copy(std::next(_buffer.begin(), _rPos), std::next(_buffer.begin(), _rPos + numBytesArrayOne), elem.begin());
+
+    // copy data from second contiguous array (of occupied memory)
+    if (numBytesArrayOne < elem.size())
+    {
+        std::copy(_buffer.begin(), std::next(_buffer.begin(), elem.size() - numBytesArrayOne),
+                  std::next(elem.begin(), numBytesArrayOne));
+    }
+
+    return true;
+}
+
+bool RingBuffer::Read(std::vector<uint8_t>& elem)
+{
+    if (!Peek(elem))
+    {
+        return false;
+    }
+
+    AdvanceRPos(elem.size());
+
+    return true;
+}
+
+void RingBuffer::GetWritingBuffers(std::vector<MutableBuffer>& buffers)
+{
+    auto arrayOne = GetFreeMemoryArrayOne();
+    if (arrayOne.GetSize() > 0)
+    {
+        buffers.push_back(std::move(arrayOne));
+    }
+    
+    auto arrayTwo = GetFreeMemoryArrayTwo();
+    if (arrayTwo.GetSize() > 0)
+    {
+        buffers.push_back(std::move(arrayTwo));
+    }
+}
+
+size_t RingBuffer::GetFreeMemorySizeArrayOne() const
+{
+    size_t arrayOneSize = std::min(Capacity() - _wPos, Capacity() - _size);
+
+    // handle edge cases
+    if (Empty())
+    {
+        arrayOneSize = Capacity() - _wPos;
+    }
+
+    return arrayOneSize;
+}
+
+size_t RingBuffer::GetFreeMemorySizeArrayTwo() const
+{
+    size_t arrayTwoSize = (Capacity() - _size) - GetFreeMemorySizeArrayOne();
+
+    // handle edge cases
+    if (Empty())
+    {
+        arrayTwoSize = _wPos;
+    }
+
+    return arrayTwoSize;
+}
+
+// get first contiguous array contained in _buffer (free slots)
+MutableBuffer RingBuffer::GetFreeMemoryArrayOne()
+{
+    return MutableBuffer{_buffer.data() + _wPos, GetFreeMemorySizeArrayOne()};
+}
+
+// get second contiguous array contained in _buffer (free slots)
+MutableBuffer RingBuffer::GetFreeMemoryArrayTwo()
+{
+    return MutableBuffer{_buffer.data(), GetFreeMemorySizeArrayTwo()};
+}
+
+size_t RingBuffer::Capacity() const
+{
+    return _buffer.size();
+}
+
+size_t RingBuffer::Size() const
+{
+    return _size;
+}
+
+bool RingBuffer::Empty() const
+{
+    return _size == 0;
+}
+
+void RingBuffer::SizeCheck() const
+{
+    if (_size > Capacity())
+    {
+        throw SilKitError{"Buffer size must not exceed capacity!"};
+    }
+}
+
+void RingBuffer::Reserve(size_t newCapacity)
+{
+    // no need for increase if capacity is already large enough
+    if (newCapacity <= Capacity())
+    {
+        return;
+    }
+
+    // copy all data available to temporary vector (we aim at contiguous memory)
+    std::vector<uint8_t> newBuffer(_size);
+    Peek(newBuffer);
+
+    _buffer = std::move(newBuffer);
+    _buffer.resize(newCapacity);
+
+    _rPos = 0;
+    _wPos = _size;
+}
+
+} // namespace Core
+} // namespace SilKit

--- a/SilKit/source/core/vasio/RingBuffer.hpp
+++ b/SilKit/source/core/vasio/RingBuffer.hpp
@@ -1,0 +1,60 @@
+// SPDX-FileCopyrightText: 2023 Vector Informatik GmbH
+//
+// SPDX-License-Identifier: MIT
+
+#pragma once
+
+#include <vector>
+#include <stdint.h>
+
+#include "util/Buffer.hpp"
+
+namespace SilKit {
+namespace Core {
+
+class RingBuffer
+{
+public:
+    // constructors and destructors
+    RingBuffer(std::size_t capacity);
+
+public:
+    // public methods
+    std::size_t Capacity() const;
+    std::size_t Size() const;
+
+    bool Peek(std::vector<uint8_t>& elem) const;
+    bool Read(std::vector<uint8_t>& elem);
+
+    void GetWritingBuffers(std::vector<MutableBuffer>& buffers);
+
+    void AdvanceWPos(std::size_t numBytes); // public for access from VAsioPeer
+
+    void Reserve(std::size_t newCapacity);
+
+private:
+    // private methods
+    bool Empty() const;
+    void AdvanceRPos(std::size_t numBytes);
+    void SizeCheck() const;
+
+    // write perspective (size of arrays of free memory in ring buffer)
+    std::size_t GetFreeMemorySizeArrayOne() const;
+    std::size_t GetFreeMemorySizeArrayTwo() const;
+
+    // write perspective (arrays of free memory in ring buffer)
+    MutableBuffer GetFreeMemoryArrayOne(); // first physically contiguous array (starting at index _wPos)
+    MutableBuffer GetFreeMemoryArrayTwo(); // second physically contiguous array (starting at index 0)
+
+private:
+    // member variables
+    std::vector<uint8_t> _buffer;
+
+    std::size_t _size{0};
+
+    std::size_t _wPos{0};
+    std::size_t _rPos{0};
+};
+
+} // namespace Core
+} // namespace SilKit

--- a/SilKit/source/core/vasio/Test_RingBuffer.cpp
+++ b/SilKit/source/core/vasio/Test_RingBuffer.cpp
@@ -1,0 +1,207 @@
+// SPDX-FileCopyrightText: 2023 Vector Informatik GmbH
+//
+// SPDX-License-Identifier: MIT
+
+#include <random>
+#include <cstring>
+
+#include "RingBuffer.hpp"
+
+#include "gtest/gtest.h"
+
+using namespace SilKit::Core;
+
+static std::mt19937 generator{0}; // constant seed for deterministic behaviour 
+
+std::vector<std::vector<uint8_t> > GenerateDataBlocks(const size_t maxSize, const size_t numDataBlocks)
+{    
+    std::vector<std::vector<uint8_t> > dataBlocks;
+
+    // configure random number generators
+    std::uniform_int_distribution<size_t> distrSize(1, maxSize);
+    std::uniform_int_distribution<int> distrValue(0, std::numeric_limits<uint8_t>::max());
+
+    for (size_t i = 0; i < numDataBlocks; i++)
+    {
+        // random size
+        std::vector<uint8_t> block(distrSize(generator));
+
+        // random values
+        for (auto& elem : block)
+        {
+            elem = static_cast<uint8_t>(distrValue(generator));
+        }
+
+        dataBlocks.push_back(block);
+    }
+
+    return dataBlocks;
+}
+
+// mimic use of ring buffer in VAsioPeer (writing into ring buffer)
+void Write(RingBuffer& ringBuffer, const std::vector<uint8_t>& dataBlock)
+{
+    std::vector<MutableBuffer> bufferArrays;
+    ringBuffer.GetWritingBuffers(bufferArrays);
+
+    if (bufferArrays.empty())
+    {
+        return;
+    }
+
+    auto arrayOne = bufferArrays.front();
+    size_t numBytesForArrayOne = std::min(arrayOne.GetSize(), dataBlock.size());
+    memcpy(arrayOne.GetData(), dataBlock.data(), numBytesForArrayOne);
+
+    if (bufferArrays.size() > 1)
+    {
+        auto arrayTwo = bufferArrays.back();
+        memcpy(arrayTwo.GetData(), dataBlock.data() + numBytesForArrayOne, dataBlock.size() - numBytesForArrayOne);
+    }
+
+    ringBuffer.AdvanceWPos(dataBlock.size());
+}
+
+// alternating write and read
+TEST(Test_RingBuffer, writeSingle)
+{
+    const size_t capacity{1000};
+    RingBuffer ringBuffer(capacity);
+
+    const size_t numDataBlocks{500};
+    auto dataBlocks = GenerateDataBlocks(capacity, numDataBlocks);
+
+    for (const auto& elem : dataBlocks)
+    {
+        Write(ringBuffer, elem);
+
+        std::vector<uint8_t> readData(ringBuffer.Size());
+        ringBuffer.Read(readData);
+
+        ASSERT_EQ(elem, readData);
+    }
+}
+
+// resizing of ring buffer (via Reserve)
+TEST(Test_RingBuffer, resizeRingBuffer)
+{
+    const size_t capacity{1000};
+    RingBuffer ringBuffer(capacity);
+
+    const size_t numDataBlocks{500};
+    std::vector<size_t> blockSizes{2000, 3000, 4000, 5000};
+
+    for (const auto& maxSize : blockSizes)
+    {
+        auto dataBlocks = GenerateDataBlocks(maxSize, numDataBlocks);
+
+        for (const auto& elem : dataBlocks)
+        {
+            // resize if necessary
+            if (elem.size() > ringBuffer.Capacity())
+            {
+                ringBuffer.Reserve(elem.size());
+            }
+            Write(ringBuffer, elem);
+
+            std::vector<uint8_t> readData(ringBuffer.Size());
+            ringBuffer.Read(readData);
+
+            ASSERT_EQ(elem, readData);
+        }    
+    }
+}
+
+// write and read of multiple data blocks at once (resizing capacity allowed)
+TEST(Test_RingBuffer, writeMultiple_resizeAllowed)
+{
+    const size_t capacity{1000};
+    RingBuffer ringBuffer(capacity);
+
+    const size_t numBlockSets = 100;
+    const size_t numDataBlocks = 500; // same number of data blocks for every group
+
+    std::vector<uint8_t> currentDataBlock;
+
+    for (size_t i = 0; i < numBlockSets; i++)
+    {
+        auto dataBlocks = GenerateDataBlocks(capacity, numDataBlocks);
+
+        // write all data blocks at once (resize capacity if necessary)
+        for (const auto& elem : dataBlocks)
+        {
+            auto remainingSpace = ringBuffer.Capacity() - ringBuffer.Size(); 
+            if (elem.size() > remainingSpace)
+            {
+                ringBuffer.Reserve(ringBuffer.Size() + elem.size());
+            }
+
+            Write(ringBuffer, elem);
+
+            // append current data block for comparison
+            currentDataBlock.insert(currentDataBlock.end(), elem.begin(), elem.end());            
+        }
+
+        // read all data available 
+        std::vector<uint8_t> readData(ringBuffer.Size());
+        ringBuffer.Read(readData);
+
+        ASSERT_EQ(currentDataBlock, readData);
+
+        currentDataBlock.clear();
+    }
+}
+
+// write and read of multiple data blocks at once (fixed capacity)
+TEST(Test_RingBuffer, writeMultiple_fixedCapacity) 
+{
+    const size_t capacity{1000};
+    RingBuffer ringBuffer(capacity);
+
+    const size_t numBlockSets = 100;
+    const size_t numDataBlocks = 500; // same number of data blocks for every group
+    const size_t maxSizeDataBlock = 200; // size smaller than capacity reasonable in this case
+
+    std::vector<uint8_t> currentDataBlock;
+
+    for (size_t i = 0; i < numBlockSets; i++)
+    {
+        auto dataBlocks = GenerateDataBlocks(maxSizeDataBlock, numDataBlocks);
+
+        // iterate until all data blocks are consumed
+        while (dataBlocks.size() != 0)
+        {
+            size_t numWrittenBlocks{0};
+
+            // write as many data blocks as possible
+            for (const auto& elem : dataBlocks)
+            {
+                auto remainingSpace = ringBuffer.Capacity() - ringBuffer.Size();
+                
+                if (elem.size() <= remainingSpace) // write current block, if there is enough space
+                {
+                    Write(ringBuffer, elem);
+
+                    // append current data block for comparison
+                    currentDataBlock.insert(currentDataBlock.end(), elem.begin(), elem.end());
+
+                    numWrittenBlocks++;
+                }
+                else // stop writing
+                {
+                    break;
+                }                
+            }
+
+            dataBlocks.erase(dataBlocks.begin(), dataBlocks.begin() + numWrittenBlocks);
+
+            // read all data
+            std::vector<uint8_t> readData(ringBuffer.Size());
+            ringBuffer.Read(readData);
+
+            ASSERT_EQ(currentDataBlock, readData);
+
+            currentDataBlock.clear();
+        }
+    }
+}

--- a/SilKit/source/core/vasio/VAsioPeer.hpp
+++ b/SilKit/source/core/vasio/VAsioPeer.hpp
@@ -32,6 +32,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE. */
 #include "IVAsioPeer.hpp"
 #include "EndpointAddress.hpp"
 #include "MessageBuffer.hpp"
+#include "RingBuffer.hpp"
 #include "VAsioPeerInfo.hpp"
 #include "ProtocolVersion.hpp"
 
@@ -121,9 +122,8 @@ private:
 
     // receiving
     std::atomic<uint32_t> _currentMsgSize{0u};
-    std::vector<uint8_t> _msgBuffer;
-    size_t _wPos{0};
-    MutableBuffer _currentReceivingBuffer;
+    RingBuffer _msgBuffer;
+    std::vector<MutableBuffer> _currentReceivingBuffers;
 
     // sending
     mutable std::mutex _sendingQueueMutex;


### PR DESCRIPTION
## Subject
Use a ring buffer for storing data from byte stream. 

## Description
This change is introduced for two reasons. First, the message buffer operations w.r.t. reading (e.g. write position) are encapsulated, which results in an improved code readability. Second, a smaller number of copies is necessary when an entire message is passed to the VAsioConnection.

Note that this change does not affect the performance (latency, throughput).


## Instructions for review / testing
- Error handling for write/read: Currently, a boolean is returned (false, if the operation did not succeed). Hence, the class user is responsible for handling an unsuccessful write/read. Is that fine?
- Some member functions are currently unused, but have been useful for the development (write/read for single values, print function). Should those be deleted?
- Testing: Did I miss important corner cases?

## Developer checklist (address before review)

- [ ] Changelog.md updated
- [ ] Prepared update for depending repositories
- [ ] Documentation updated (public API changes only)
- [ ] API docstrings updated (public API changes only)
- [ ] Rebase &rarr; commit history clean
- [ ] Squash and merge &rarr; proper PR title
