### PR TITLE
Fix push ci 

### DIFF
--- a/.github/workflows/sil-kit-ci.yml
+++ b/.github/workflows/sil-kit-ci.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     branches: [ 'main' ]
 
+  push:
+    branches: [ 'main' ]
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
@@ -27,52 +30,56 @@ jobs:
           sh ./SilKit/ci/check_licenses.sh
         shell: bash
 
-  check-files-changed:
+  check-run-builds:
     runs-on: ubuntu-22.04
     outputs:
-      run_builds: ${{ steps.files_check.outputs.run_builds }}
+      run_builds: ${{ steps.build_check.outputs.run_builds }}
     steps:
       - uses: actions/checkout@v4
         with:
           submodules: false
-      - name: Check changed files
-        id: files_check
+      - name: Check if build CI should run
+        id: build_check
         run: |
-          python3 ./SilKit/ci/check_files_changed.py ${{ github.repository }} ${{ github.event.number }}
+          if [[ ${{ github.event_name }} == 'push' ]];then \
+            echo "run_builds=true" >> $GITHUB_OUTPUT; \
+          else \
+            python3 ./SilKit/ci/check_files_changed.py ${{ github.repository }} ${{ github.event.number }}; \
+          fi
 
   clang14-tsan:
     name: Thread Sanitizer Tests
-    needs: [check-licenses, check-files-changed]
+    needs: [check-licenses, check-run-builds]
     uses: ./.github/workflows/linux-tsan.yml
     with:
-      run_build: ${{ needs.check-files-changed.outputs.run_builds == 'true' }}
+      run_build: ${{ needs.check-run-builds.outputs.run_builds == 'true' }}
 
   clang14-ubsan:
     name: Undefined Behavior Sanitizer Tests
-    needs: [check-licenses, check-files-changed]
+    needs: [check-licenses, check-run-builds]
     uses: ./.github/workflows/linux-ubsan.yml
     with:
-      run_build: ${{ needs.check-files-changed.outputs.run_builds == 'true' }}
+      run_build: ${{ needs.check-run-builds.outputs.run_builds == 'true' }}
 
   clang14-asan:
     name: Address Sanitizer Tests
-    needs: [check-licenses, check-files-changed]
+    needs: [check-licenses, check-run-builds]
     uses: ./.github/workflows/linux-asan.yml
     with:
-      run_build: ${{ needs.check-files-changed.outputs.run_builds == 'true' }}
+      run_build: ${{ needs.check-run-builds.outputs.run_builds == 'true' }}
 
   ubuntu-release-builds:
     uses: ./.github/workflows/build-linux.yml
-    needs: [check-licenses, check-files-changed]
+    needs: [check-licenses, check-run-builds]
     with:
       do_package: ${{ github.event_name == 'push' && true || false }}
       retention_days: ${{ github.event_name == 'push' && 90 || 14 }}
-      run_build: ${{ needs.check-files-changed.outputs.run_builds == 'true' }}
+      run_build: ${{ needs.check-run-builds.outputs.run_builds == 'true' }}
 
   windows-release-builds:
     uses: ./.github/workflows/build-win.yml
-    needs: [check-licenses, check-files-changed]
+    needs: [check-licenses, check-run-builds]
     with:
       do_package: ${{ github.event_name == 'push' && true || false }}
       retention_days: ${{ github.event_name == 'push' && 90 || 14 }}
-      run_build: ${{ needs.check-files-changed.outputs.run_builds == 'true' }}
+      run_build: ${{ needs.check-run-builds.outputs.run_builds == 'true' }}


### PR DESCRIPTION
~~DONT MERGE: DEPENDS ON https://github.com/vectorgrp/sil-kit/pull/39~~
UPDATE: Rebased on main instead of PR #39 . Can be merged now

## Description
Push CI was broken due to mismatched and missing filters in the CI yml for the workflows. This fixes the issue with hopefully minimal effort.
## Instructions for review / testing
Checked here, albeit with a minor change to use the feature branch as the `on: push` filter. Unfortunately in this PR we can only test it after we merged it.

## Developer checklist (address before review)

- [ ] Changelog.md updated
- [ ] Prepared update for depending repositories
- [ ] Documentation updated (public API changes only)
- [ ] API docstrings updated (public API changes only)
- [ ] Rebase &rarr; commit history clean
- [ ] Squash and merge &rarr; proper PR title
