### PR TITLE
-- ci: Pass x86 to build action for win32 builds

### DIFF
--- a/.github/workflows/build-win.yml
+++ b/.github/workflows/build-win.yml
@@ -41,6 +41,7 @@ jobs:
         preset-name: vs141-x64-release
         do-package: ${{ inputs.do_package }}
         retention-days: ${{ inputs.retention_days }}
+        build-arch: x64
 
   build-win-x32:
     runs-on: windows-2019
@@ -56,3 +57,4 @@ jobs:
         preset-name: vs141-x86-release
         do-package: ${{ inputs.do_package }}
         retention-days: ${{ inputs.retention_days }}
+        build-arch: x86


### PR DESCRIPTION
For the build-win workflow, the build-arch: x86 was missing for the win32 job. This parameter is passed to https://github.com/ilammy/msvc-dev-cmd to set up the developer console.