### PR TITLE
ci: remove gcc-8 builds

### DIFF
--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -51,6 +51,5 @@ jobs:
         id: build
         with:
           preset-name: gcc8-release
-          do-package: ${{ inputs.do_package }}
-          retention-days: ${{ env.retention_days }}
-
+          do-package: false
+          upload-testlog: false


### PR DESCRIPTION
## Description
Ubuntu 18.04 comes with node 16 which hab been deprecated by Github Actions. Therfor we remove the gcc-8 builds on PRs for now! THIS IS AN EMERGENCY FIX FOR NOW!

## Instructions for review / testing
<!--
    - Hilight some of the important changes, which reviewers should focus on
    - Which parts should be reviewed in detail? For example: content of console output, correct semantics of changes
    - Test steps and test setup description. For example: which programs or configs to use
-->

## Developer checklist (address before review)

- [ ] Changelog.md updated
- [ ] Prepared update for depending repositories
- [ ] Documentation updated (public API changes only)
- [ ] API docstrings updated (public API changes only)
- [ ] Rebase &rarr; commit history clean
- [ ] Squash and merge &rarr; proper PR title
