### PR TITLE
SILKIT-1525: Use bulk-update endpoint of dashboard backend service

### DIFF
--- a/SilKit/source/dashboard/CMakeLists.txt
+++ b/SilKit/source/dashboard/CMakeLists.txt
@@ -95,6 +95,8 @@ if(SILKIT_BUILD_DASHBOARD)
         CreateDashboard.cpp
         Dashboard.cpp
         Dashboard.hpp
+        DashboardBulkUpdate.cpp
+        DashboardBulkUpdate.hpp
         DashboardParticipant.cpp
         DashboardParticipant.hpp
         IDashboard.hpp

--- a/SilKit/source/dashboard/Client/DashboardSystemApiClient.hpp
+++ b/SilKit/source/dashboard/Client/DashboardSystemApiClient.hpp
@@ -32,6 +32,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE. */
 #include "RpcClientDto.hpp"
 #include "RpcServerDto.hpp"
 #include "SimulationEndDto.hpp"
+#include "BulkUpdateDto.hpp"
 
 #include OATPP_CODEGEN_BEGIN(ApiClient)
 
@@ -155,6 +156,10 @@ class DashboardSystemApiClient : public oatpp::web::client::ApiClient
     // notify the end of a simulation
     API_CALL("POST", "system-service/v1.0/simulations/{simulationId}", setSimulationEnd, PATH(UInt64, simulationId),
              BODY_DTO(Object<SimulationEndDto>, simulation))
+
+    // bulk update of a simulation
+    API_CALL("POST", "system-service/v1.1/simulations/{simulationId}", updateSimulation,
+             PATH(UInt64, simulationId), BODY_DTO(Object<BulkSimulationDto>, simulation))
 };
 
 } // namespace Dashboard

--- a/SilKit/source/dashboard/Client/DashboardSystemServiceClient.cpp
+++ b/SilKit/source/dashboard/Client/DashboardSystemServiceClient.cpp
@@ -41,6 +41,13 @@ DashboardSystemServiceClient::DashboardSystemServiceClient(
 
 DashboardSystemServiceClient::~DashboardSystemServiceClient() {}
 
+void DashboardSystemServiceClient::UpdateSimulation(oatpp::UInt64 simulationId,
+                                                    oatpp::Object<BulkSimulationDto> bulkSimulation)
+{
+    auto response = _dashboardSystemApiClient->updateSimulation(simulationId, bulkSimulation);
+    Log(response, "updating simulation");
+}
+
 oatpp::Object<SimulationCreationResponseDto> DashboardSystemServiceClient::CreateSimulation(
     oatpp::Object<SimulationCreationRequestDto> simulation)
 {

--- a/SilKit/source/dashboard/Client/DashboardSystemServiceClient.hpp
+++ b/SilKit/source/dashboard/Client/DashboardSystemServiceClient.hpp
@@ -44,6 +44,8 @@ public:
     oatpp::Object<SimulationCreationResponseDto> CreateSimulation(
         oatpp::Object<SimulationCreationRequestDto> simulation) override;
 
+    void UpdateSimulation(oatpp::UInt64 simulationId, oatpp::Object<BulkSimulationDto> bulkSimulation) override;
+
     void AddParticipantToSimulation(oatpp::UInt64 simulationId, oatpp::String participantName) override;
 
     void AddParticipantStatusForSimulation(oatpp::UInt64 simulationId, oatpp::String participantName,

--- a/SilKit/source/dashboard/Client/IDashboardSystemServiceClient.hpp
+++ b/SilKit/source/dashboard/Client/IDashboardSystemServiceClient.hpp
@@ -31,6 +31,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE. */
 #include "RpcClientDto.hpp"
 #include "RpcServerDto.hpp"
 #include "SimulationEndDto.hpp"
+#include "BulkUpdateDto.hpp"
 
 namespace SilKit {
 namespace Dashboard {
@@ -42,6 +43,8 @@ public:
 
     virtual oatpp::Object<SimulationCreationResponseDto> CreateSimulation(
         oatpp::Object<SimulationCreationRequestDto> simulation) = 0;
+
+    virtual void UpdateSimulation(oatpp::UInt64 simulationId, oatpp::Object<BulkSimulationDto> bulkSimulation) = 0;
 
     virtual void AddParticipantToSimulation(oatpp::UInt64 simulationId, oatpp::String participantName) = 0;
 

--- a/SilKit/source/dashboard/Client/Mocks/MockDashboardSystemServiceClient.hpp
+++ b/SilKit/source/dashboard/Client/Mocks/MockDashboardSystemServiceClient.hpp
@@ -35,6 +35,8 @@ public:
     MOCK_METHOD(oatpp::Object<SimulationCreationResponseDto>, CreateSimulation,
                 (oatpp::Object<SimulationCreationRequestDto>), (override));
 
+    MOCK_METHOD(void, UpdateSimulation, (oatpp::UInt64, oatpp::Object<BulkSimulationDto>), (override));
+
     MOCK_METHOD(void, AddParticipantToSimulation, (oatpp::UInt64, oatpp::String), (override));
 
     MOCK_METHOD(void, AddParticipantStatusForSimulation,

--- a/SilKit/source/dashboard/DashboardBulkUpdate.cpp
+++ b/SilKit/source/dashboard/DashboardBulkUpdate.cpp
@@ -1,0 +1,5 @@
+// SPDX-FileCopyrightText: 2024 Vector Informatik GmbH
+//
+// SPDX-License-Identifier: MIT
+
+#include "DashboardBulkUpdate.hpp"

--- a/SilKit/source/dashboard/DashboardBulkUpdate.hpp
+++ b/SilKit/source/dashboard/DashboardBulkUpdate.hpp
@@ -1,0 +1,48 @@
+// SPDX-FileCopyrightText: 2024 Vector Informatik GmbH
+//
+// SPDX-License-Identifier: MIT
+
+#pragma once
+
+#include "silkit/services/orchestration/OrchestrationDatatypes.hpp"
+
+#include "SilKitEvent.hpp"
+
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <vector>
+
+namespace SilKit {
+namespace Dashboard {
+
+struct DashboardBulkUpdate
+{
+    using ParticipantConnectionInformation = SilKit::Services::Orchestration::ParticipantConnectionInformation;
+    using SystemState = SilKit::Services::Orchestration::SystemState;
+    using ParticipantStatus = SilKit::Services::Orchestration::ParticipantStatus;
+
+    std::unique_ptr<uint64_t> stopped;
+    std::vector<SystemState> systemStates;
+    std::vector<ParticipantConnectionInformation> participantConnectionInformations;
+    std::vector<ParticipantStatus> participantStatuses;
+    std::vector<ServiceData> serviceDatas;
+
+    auto Empty() const -> bool
+    {
+        return !stopped && systemStates.empty() && participantConnectionInformations.empty()
+               && participantStatuses.empty() && serviceDatas.empty();
+    }
+
+    void Clear()
+    {
+        stopped.reset();
+        participantConnectionInformations.clear();
+        systemStates.clear();
+        participantStatuses.clear();
+        serviceDatas.clear();
+    }
+};
+
+} // namespace Dashboard
+} // namespace SilKit

--- a/SilKit/source/dashboard/DashboardInstance.hpp
+++ b/SilKit/source/dashboard/DashboardInstance.hpp
@@ -37,7 +37,7 @@ class DashboardInstance final
     };
 
 public:
-    DashboardInstance();
+    explicit DashboardInstance();
 
     DashboardInstance(const DashboardInstance&) = delete;
     DashboardInstance(DashboardInstance&&) = delete;
@@ -56,6 +56,7 @@ private:
 
 private:
     void RunEventQueueWorkerThread();
+    void RunBulkUpdateEventQueueWorkerThread();
 
 private: // SilKit::Core::IRegistryEventListener
     void OnLoggerCreated(SilKit::Services::Logging::ILogger* logger) override;

--- a/SilKit/source/dashboard/Dto/BulkUpdateDto.hpp
+++ b/SilKit/source/dashboard/Dto/BulkUpdateDto.hpp
@@ -1,0 +1,133 @@
+// SPDX-FileCopyrightText: 2024 Vector Informatik GmbH
+//
+// SPDX-License-Identifier: MIT
+
+#pragma once
+
+#include "RpcSpecDto.hpp"
+#include "DataSpecDto.hpp"
+#include "ParticipantStatusDto.hpp"
+#include "SystemStatusDto.hpp"
+
+#include OATPP_CODEGEN_BEGIN(DTO)
+
+namespace SilKit {
+namespace Dashboard {
+
+class BulkSystemDto : public oatpp::DTO
+{
+    DTO_INIT(BulkSystemDto, DTO)
+
+    DTO_FIELD(Vector<Object<SystemStatusDto>>, statuses);
+
+    static auto CreateEmpty() -> Wrapper
+    {
+        auto dto = createShared();
+        dto->statuses = Vector<Object<SystemStatusDto>>::createShared();
+        return dto;
+    }
+};
+
+class BulkControllerDto : public oatpp::DTO
+{
+    DTO_INIT(BulkControllerDto, DTO)
+
+    DTO_FIELD(UInt64, id);
+    DTO_FIELD(String, name);
+    DTO_FIELD(String, networkName);
+};
+
+class BulkDataServiceDto : public oatpp::DTO
+{
+    DTO_INIT(BulkDataServiceDto, DTO)
+
+    DTO_FIELD(UInt64, id);
+    DTO_FIELD(String, name);
+    DTO_FIELD(String, networkName);
+    DTO_FIELD(Object<DataSpecDto>, spec);
+};
+
+class BulkRpcServiceDto : public oatpp::DTO
+{
+    DTO_INIT(BulkRpcServiceDto, DTO)
+
+    DTO_FIELD(UInt64, id);
+    DTO_FIELD(String, name);
+    DTO_FIELD(String, networkName);
+    DTO_FIELD(Object<RpcSpecDto>, spec);
+};
+
+class BulkServiceInternalDto : public oatpp::DTO
+{
+    DTO_INIT(BulkServiceInternalDto, DTO)
+
+    DTO_FIELD(UInt64, id);
+    DTO_FIELD(String, name);
+    DTO_FIELD(String, networkName);
+    DTO_FIELD(UInt64, parentId);
+};
+
+class BulkParticipantDto : public oatpp::DTO
+{
+    DTO_INIT(BulkParticipantDto, DTO)
+
+    DTO_FIELD(String, name);
+    DTO_FIELD(Vector<Object<ParticipantStatusDto>>, statuses);
+    DTO_FIELD(Vector<Object<BulkControllerDto>>, canControllers);
+    DTO_FIELD(Vector<Object<BulkControllerDto>>, ethernetControllers);
+    DTO_FIELD(Vector<Object<BulkControllerDto>>, flexrayControllers);
+    DTO_FIELD(Vector<Object<BulkControllerDto>>, linControllers);
+    DTO_FIELD(Vector<Object<BulkDataServiceDto>>, dataPublishers);
+    DTO_FIELD(Vector<Object<BulkDataServiceDto>>, dataSubscribers);
+    DTO_FIELD(Vector<Object<BulkServiceInternalDto>>, dataSubscriberInternals);
+    DTO_FIELD(Vector<Object<BulkRpcServiceDto>>, rpcClients);
+    DTO_FIELD(Vector<Object<BulkRpcServiceDto>>, rpcServers);
+    DTO_FIELD(Vector<Object<BulkServiceInternalDto>>, rpcServerInternals);
+    DTO_FIELD(Vector<String>, canNetworks);
+    DTO_FIELD(Vector<String>, ethernetNetworks);
+    DTO_FIELD(Vector<String>, flexrayNetworks);
+    DTO_FIELD(Vector<String>, linNetworks);
+
+    static auto CreateEmpty() -> Wrapper
+    {
+        auto dto = createShared();
+        dto->statuses = Vector<Object<ParticipantStatusDto>>::createShared();
+        dto->canControllers = Vector<Object<BulkControllerDto>>::createShared();
+        dto->ethernetControllers = Vector<Object<BulkControllerDto>>::createShared();
+        dto->flexrayControllers = Vector<Object<BulkControllerDto>>::createShared();
+        dto->linControllers = Vector<Object<BulkControllerDto>>::createShared();
+        dto->dataPublishers = Vector<Object<BulkDataServiceDto>>::createShared();
+        dto->dataSubscribers = Vector<Object<BulkDataServiceDto>>::createShared();
+        dto->dataSubscriberInternals = Vector<Object<BulkServiceInternalDto>>::createShared();
+        dto->rpcClients = Vector<Object<BulkRpcServiceDto>>::createShared();
+        dto->rpcServers = Vector<Object<BulkRpcServiceDto>>::createShared();
+        dto->rpcServerInternals = Vector<Object<BulkServiceInternalDto>>::createShared();
+        dto->canNetworks = Vector<String>::createShared();
+        dto->ethernetNetworks = Vector<String>::createShared();
+        dto->flexrayNetworks = Vector<String>::createShared();
+        dto->linNetworks = Vector<String>::createShared();
+        return dto;
+    }
+};
+
+class BulkSimulationDto : public oatpp::DTO
+{
+    DTO_INIT(BulkSimulationDto, DTO)
+
+    DTO_FIELD(Int64, stopped);
+    DTO_FIELD(Object<BulkSystemDto>, system);
+    DTO_FIELD(Vector<Object<BulkParticipantDto>>, participants);
+
+    static auto CreateEmpty() -> Wrapper
+    {
+        auto dto = createShared();
+        dto->system = BulkSystemDto::CreateEmpty();
+        dto->participants = Vector<Object<BulkParticipantDto>>::createShared();
+        return dto;
+    }
+};
+
+} // namespace Dashboard
+} // namespace SilKit
+
+#include OATPP_CODEGEN_END(DTO)

--- a/SilKit/source/dashboard/Service/ISilKitEventHandler.hpp
+++ b/SilKit/source/dashboard/Service/ISilKitEventHandler.hpp
@@ -21,11 +21,13 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE. */
 
 #pragma once
 
-#include "silkit/services/orchestration/OrchestrationDatatypes.hpp"
-#include "ServiceDatatypes.hpp"
+#include "DashboardBulkUpdate.hpp"
+
+#include <string>
 
 namespace SilKit {
 namespace Dashboard {
+
 class ISilKitEventHandler
 {
 public:
@@ -41,6 +43,9 @@ public:
     virtual void OnServiceDiscoveryEvent(uint64_t simulationId,
                                          Core::Discovery::ServiceDiscoveryEvent::Type discoveryType,
                                          const Core::ServiceDescriptor& serviceDescriptor) = 0;
+
+    virtual void OnBulkUpdate(uint64_t simulationId, const DashboardBulkUpdate& bulkUpdate) = 0;
 };
+
 } // namespace Dashboard
 } // namespace SilKit

--- a/SilKit/source/dashboard/Service/ISilKitToOatppMapper.hpp
+++ b/SilKit/source/dashboard/Service/ISilKitToOatppMapper.hpp
@@ -37,12 +37,20 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE. */
 #include "SimulationCreationRequestDto.hpp"
 #include "SimulationEndDto.hpp"
 #include "SystemStatusDto.hpp"
+#include "BulkUpdateDto.hpp"
+
+#include "DashboardBulkUpdate.hpp"
 
 
 namespace SilKit {
 namespace Dashboard {
 class ISilKitToOatppMapper
 {
+    using ServiceDescriptor = SilKit::Core::ServiceDescriptor;
+
+    template <typename T>
+    using Object = oatpp::Object<T>;
+
 public:
     virtual ~ISilKitToOatppMapper() = default;
     virtual oatpp::Object<SimulationCreationRequestDto> CreateSimulationCreationRequestDto(
@@ -58,6 +66,13 @@ public:
     virtual oatpp::Object<RpcClientDto> CreateRpcClientDto(const Core::ServiceDescriptor& serviceDescriptor) = 0;
     virtual oatpp::Object<RpcServerDto> CreateRpcServerDto(const Core::ServiceDescriptor& serviceDescriptor) = 0;
     virtual oatpp::Object<SimulationEndDto> CreateSimulationEndDto(uint64_t stop) = 0;
+
+    virtual auto CreateBulkControllerDto(const ServiceDescriptor& serviceDescriptor) -> Object<BulkControllerDto> = 0;
+    virtual auto CreateBulkDataServiceDto(const ServiceDescriptor& serviceDescriptor) -> Object<BulkDataServiceDto> = 0;
+    virtual auto CreateBulkRpcServiceDto(const ServiceDescriptor& serviceDescriptor) -> Object<BulkRpcServiceDto> = 0;
+    virtual auto CreateBulkServiceInternalDto(const ServiceDescriptor& serviceDescriptor)
+        -> Object<BulkServiceInternalDto> = 0;
+    virtual auto CreateBulkSimulationDto(const DashboardBulkUpdate& bulkUpdate) -> Object<BulkSimulationDto> = 0;
 };
 } // namespace Dashboard
 } // namespace SilKit

--- a/SilKit/source/dashboard/Service/Mocks/MockSilKitEventHandler.hpp
+++ b/SilKit/source/dashboard/Service/Mocks/MockSilKitEventHandler.hpp
@@ -39,6 +39,7 @@ public:
     MOCK_METHOD(void, OnSystemStateChanged, (uint64_t, Services::Orchestration::SystemState), (override));
     MOCK_METHOD(void, OnServiceDiscoveryEvent,
                 (uint64_t, Core::Discovery::ServiceDiscoveryEvent::Type, const Core::ServiceDescriptor&), (override));
+    MOCK_METHOD(void, OnBulkUpdate, (uint64_t, const DashboardBulkUpdate&), (override));
 };
 
 } // namespace Dashboard

--- a/SilKit/source/dashboard/Service/Mocks/MockSilKitToOatppMapper.hpp
+++ b/SilKit/source/dashboard/Service/Mocks/MockSilKitToOatppMapper.hpp
@@ -28,6 +28,11 @@ namespace SilKit {
 namespace Dashboard {
 class MockSilKitToOatppMapper : public ISilKitToOatppMapper
 {
+    using ServiceDescriptor = SilKit::Core::ServiceDescriptor;
+
+    template <typename T>
+    using Object = oatpp::Object<T>;
+
 public:
     MOCK_METHOD(oatpp::Object<SilKit::Dashboard::SimulationCreationRequestDto>, CreateSimulationCreationRequestDto,
                 (const std::string&, uint64_t), (override));
@@ -46,6 +51,12 @@ public:
     MOCK_METHOD(oatpp::Object<SilKit::Dashboard::RpcServerDto>, CreateRpcServerDto,
                 (const SilKit::Core::ServiceDescriptor&), (override));
     MOCK_METHOD(oatpp::Object<SimulationEndDto>, CreateSimulationEndDto, (uint64_t), (override));
+
+    MOCK_METHOD(Object<BulkControllerDto>, CreateBulkControllerDto, (const ServiceDescriptor&), (override));
+    MOCK_METHOD(Object<BulkDataServiceDto>, CreateBulkDataServiceDto, (const ServiceDescriptor&), (override));
+    MOCK_METHOD(Object<BulkRpcServiceDto>, CreateBulkRpcServiceDto, (const ServiceDescriptor&), (override));
+    MOCK_METHOD(Object<BulkServiceInternalDto>, CreateBulkServiceInternalDto, (const ServiceDescriptor&), (override));
+    MOCK_METHOD(Object<BulkSimulationDto>, CreateBulkSimulationDto, (const DashboardBulkUpdate&), (override));
 };
 } // namespace Dashboard
 } // namespace SilKit

--- a/SilKit/source/dashboard/Service/SilKitEventHandler.cpp
+++ b/SilKit/source/dashboard/Service/SilKitEventHandler.cpp
@@ -105,6 +105,12 @@ void SilKitEventHandler::OnServiceDiscoveryEvent(uint64_t simulationId,
     }
 }
 
+void SilKitEventHandler::OnBulkUpdate(uint64_t simulationId, const DashboardBulkUpdate& bulkUpdate)
+{
+    _dashboardSystemServiceClient->UpdateSimulation(simulationId,
+                                                    _silKitToOatppMapper->CreateBulkSimulationDto(bulkUpdate));
+}
+
 void SilKitEventHandler::OnControllerCreated(uint64_t simulationId, const Core::ServiceDescriptor& serviceDescriptor)
 {
     Services::Logging::Debug(_logger, "Dashboard: adding service for simulation {} {}", simulationId,

--- a/SilKit/source/dashboard/Service/SilKitEventHandler.hpp
+++ b/SilKit/source/dashboard/Service/SilKitEventHandler.hpp
@@ -52,6 +52,7 @@ public: //methods
     void OnSystemStateChanged(uint64_t simulationId, Services::Orchestration::SystemState systemState) override;
     void OnServiceDiscoveryEvent(uint64_t simulationId, Core::Discovery::ServiceDiscoveryEvent::Type discoveryType,
                                  const Core::ServiceDescriptor& serviceDescriptor) override;
+    void OnBulkUpdate(uint64_t simulationId, const DashboardBulkUpdate& bulkUpdate) override;
 
 private: //methods
     void OnControllerCreated(uint64_t simulationId, const Core::ServiceDescriptor& serviceDescriptor);

--- a/SilKit/source/dashboard/Service/SilKitToOatppMapper.hpp
+++ b/SilKit/source/dashboard/Service/SilKitToOatppMapper.hpp
@@ -28,6 +28,11 @@ namespace Dashboard {
 
 class SilKitToOatppMapper : public ISilKitToOatppMapper
 {
+    using ServiceDescriptor = SilKit::Core::ServiceDescriptor;
+
+    template <typename T>
+    using Object = oatpp::Object<T>;
+
 public:
     oatpp::Object<SimulationCreationRequestDto> CreateSimulationCreationRequestDto(const std::string& connectUri,
                                                                                    uint64_t start) override;
@@ -40,6 +45,18 @@ public:
     oatpp::Object<RpcClientDto> CreateRpcClientDto(const Core::ServiceDescriptor& serviceDescriptor) override;
     oatpp::Object<RpcServerDto> CreateRpcServerDto(const Core::ServiceDescriptor& serviceDescriptor) override;
     oatpp::Object<SimulationEndDto> CreateSimulationEndDto(uint64_t stop) override;
+
+    auto CreateBulkControllerDto(const ServiceDescriptor& serviceDescriptor) -> Object<BulkControllerDto> override;
+    auto CreateBulkDataServiceDto(const ServiceDescriptor& serviceDescriptor) -> Object<BulkDataServiceDto> override;
+    auto CreateBulkRpcServiceDto(const ServiceDescriptor& serviceDescriptor) -> Object<BulkRpcServiceDto> override;
+    auto CreateBulkServiceInternalDto(const ServiceDescriptor& serviceDescriptor)
+        -> Object<BulkServiceInternalDto> override;
+    auto CreateBulkSimulationDto(const DashboardBulkUpdate& bulkUpdate) -> Object<BulkSimulationDto> override;
+
+private:
+    void ProcessServiceDiscovery(BulkParticipantDto& dto, const ServiceDescriptor& serviceDescriptor);
+    void ProcessControllerDiscovery(BulkParticipantDto& dto, const ServiceDescriptor& serviceDescriptor);
+    void ProcessLinkDiscovery(BulkParticipantDto& dto, const ServiceDescriptor& serviceDescriptor);
 };
 
 } // namespace Dashboard

--- a/SilKit/source/dashboard/Service/Test_DashboardSilKitEventHandler.cpp
+++ b/SilKit/source/dashboard/Service/Test_DashboardSilKitEventHandler.cpp
@@ -691,5 +691,33 @@ TEST_F(Test_DashboardSilKitEventHandler, OnServiceDiscoveryEvent_Invalid_Ignore)
                                      descriptor);
 }
 
+TEST_F(Test_DashboardSilKitEventHandler, OnBulkUpdate)
+{
+    constexpr uint64_t expectedSimulationId{123};
+    const auto expectedBulkSimulationDto = SilKit::Dashboard::BulkSimulationDto::CreateEmpty();
+
+    // Arrange
+    const auto service = CreateService();
+
+    using testing::_;
+    EXPECT_CALL(*_mockSilKitToOatppMapper, CreateBulkSimulationDto(_)).WillOnce(Return(expectedBulkSimulationDto));
+
+    oatpp::UInt64 simulationId;
+    oatpp::Object<BulkSimulationDto> bulkSimulationDto;
+    EXPECT_CALL(*_mockDashboardSystemServiceClient, UpdateSimulation)
+        .WillOnce(WithArgs<0, 1>([&](oatpp::UInt64 simulationId_, oatpp::Object<BulkSimulationDto> bulkSimulation_) {
+        simulationId = std::move(simulationId_);
+        bulkSimulationDto = std::move(bulkSimulation_);
+    }));
+
+    // Act
+    service->OnBulkUpdate(expectedSimulationId, SilKit::Dashboard::DashboardBulkUpdate{});
+
+    // Assert
+    ASSERT_EQ(simulationId.getValue(0), expectedSimulationId);
+    ASSERT_NE(bulkSimulationDto.getPtr(), nullptr);
+    ASSERT_EQ(bulkSimulationDto, expectedBulkSimulationDto);
+}
+
 } // namespace Dashboard
 } // namespace SilKit

--- a/SilKit/source/dashboard/Service/Test_DashboardSilKitToOatppMapper.cpp
+++ b/SilKit/source/dashboard/Service/Test_DashboardSilKitToOatppMapper.cpp
@@ -26,6 +26,9 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE. */
 #include "YamlParser.hpp"
 
 #include "SilKitToOatppMapper.hpp"
+#include "fmt/core.h"
+
+#include <algorithm>
 
 
 namespace SilKit {
@@ -274,6 +277,349 @@ TEST_F(Test_DashboardSilKitToOatppMapper, CreateSimulationEndDto)
 
     // Assert
     ASSERT_EQ(dto->stopped, expectedStopTime);
+}
+
+TEST_F(Test_DashboardSilKitToOatppMapper, CreateBulkControllerDto)
+{
+    // Arrange
+    constexpr SilKit::Core::EndpointId expectedId{12345};
+    const std::string expectedName("myService");
+    const std::string expectedNetwork("myNetwork");
+    Core::ServiceDescriptor descriptor;
+    descriptor.SetServiceId(expectedId);
+    descriptor.SetServiceName(expectedName);
+    descriptor.SetNetworkName(expectedNetwork);
+
+    // Act
+    const auto dataMapper = CreateService();
+    const auto dto = dataMapper->CreateBulkControllerDto(descriptor);
+
+    // Assert
+    ASSERT_EQ(dto->id.getValue(0), expectedId);
+    ASSERT_STREQ(dto->name->c_str(), expectedName.c_str());
+    ASSERT_STREQ(dto->networkName->c_str(), expectedNetwork.c_str());
+}
+
+TEST_F(Test_DashboardSilKitToOatppMapper, CreateBulkDataServiceDto_MapNetworkNameAndTopicAndMediaTypeAndLabel)
+{
+    // Arrange
+    Core::ServiceDescriptor descriptor;
+
+    constexpr SilKit::Core::EndpointId expectedId{12345};
+    descriptor.SetServiceId(expectedId);
+
+    const std::string expectedNetwork("myNetwork");
+    descriptor.SetNetworkName(expectedNetwork);
+
+    const std::string expectedName("myService");
+    descriptor.SetServiceName(expectedName);
+
+    descriptor.SetSupplementalDataItem(SilKit::Core::Discovery::controllerType,
+                                       SilKit::Core::Discovery::controllerTypeDataSubscriber);
+
+    const std::string expectedTopic("myTopic");
+    descriptor.SetSupplementalDataItem(Core::Discovery::supplKeyDataSubscriberTopic, expectedTopic);
+
+    const std::string expectedMediaType("myMediaType");
+    descriptor.SetSupplementalDataItem(Core::Discovery::supplKeyDataSubscriberMediaType, expectedMediaType);
+
+    Services::MatchingLabel expectedLabel;
+    expectedLabel.key = "myKey";
+    expectedLabel.value = "myValue";
+    expectedLabel.kind = Services::MatchingLabel::Kind::Mandatory;
+    auto labels = std::vector<Services::MatchingLabel>{expectedLabel};
+    descriptor.SetSupplementalDataItem(Core::Discovery::supplKeyDataSubscriberSubLabels, Config::Serialize(labels));
+
+    // Act
+    const auto dataMapper = CreateService();
+    const auto dto = dataMapper->CreateBulkDataServiceDto(descriptor);
+
+    // Assert
+    ASSERT_EQ(dto->id.getValue(0), expectedId);
+    ASSERT_STREQ(dto->name->c_str(), expectedName.c_str());
+    ASSERT_STREQ(dto->networkName->c_str(), expectedNetwork.c_str());
+    ASSERT_STREQ(dto->spec->topic->c_str(), expectedTopic.c_str());
+    ASSERT_STREQ(dto->spec->mediaType->c_str(), expectedMediaType.c_str());
+    ASSERT_STREQ(dto->spec->labels->at(0)->key->c_str(), expectedLabel.key.c_str());
+    ASSERT_STREQ(dto->spec->labels->at(0)->value->c_str(), expectedLabel.value.c_str());
+    ASSERT_EQ(dto->spec->labels->at(0)->kind, LabelKind::Mandatory);
+}
+
+TEST_F(Test_DashboardSilKitToOatppMapper, CreateBulkRpcServiceDto_MapNetworkNameAndFunctionNameAndMediaTypeAndLabel)
+{
+    // Arrange
+    Core::ServiceDescriptor descriptor;
+    const SilKit::Core::EndpointId expectedId{12345};
+    const std::string expectedName("myService");
+    const std::string expectedNetwork("myNetwork");
+    descriptor.SetServiceId(expectedId);
+    descriptor.SetServiceName(expectedName);
+    descriptor.SetNetworkName(expectedNetwork);
+
+    descriptor.SetSupplementalDataItem(SilKit::Core::Discovery::controllerType,
+                                       SilKit::Core::Discovery::controllerTypeRpcClient);
+
+    const std::string expectedFunctionName("myFunctionName");
+    descriptor.SetSupplementalDataItem(Core::Discovery::supplKeyRpcClientFunctionName, expectedFunctionName);
+
+    const std::string expectedMediaType("myMediaType");
+    descriptor.SetSupplementalDataItem(Core::Discovery::supplKeyRpcClientMediaType, expectedMediaType);
+
+    Services::MatchingLabel expectedLabel;
+    expectedLabel.key = "myKey";
+    expectedLabel.value = "myValue";
+    expectedLabel.kind = Services::MatchingLabel::Kind::Mandatory;
+    auto labels = std::vector<Services::MatchingLabel>{expectedLabel};
+    descriptor.SetSupplementalDataItem(Core::Discovery::supplKeyRpcClientLabels, Config::Serialize(labels));
+
+    // Act
+    const auto dataMapper = CreateService();
+    const auto dto = dataMapper->CreateBulkRpcServiceDto(descriptor);
+
+    // Assert
+    ASSERT_EQ(dto->id.getValue(0), expectedId);
+    ASSERT_STREQ(dto->name->c_str(), expectedName.c_str());
+    ASSERT_STREQ(dto->networkName->c_str(), expectedNetwork.c_str());
+    ASSERT_STREQ(dto->spec->functionName->c_str(), expectedFunctionName.c_str());
+    ASSERT_STREQ(dto->spec->mediaType->c_str(), expectedMediaType.c_str());
+    ASSERT_STREQ(dto->spec->labels->at(0)->key->c_str(), expectedLabel.key.c_str());
+    ASSERT_STREQ(dto->spec->labels->at(0)->value->c_str(), expectedLabel.value.c_str());
+    ASSERT_EQ(dto->spec->labels->at(0)->kind, LabelKind::Mandatory);
+}
+
+TEST_F(Test_DashboardSilKitToOatppMapper, CreateBulkServiceInternalDto_RpcServerInternal)
+{
+    // Arrange
+    Core::ServiceDescriptor descriptor;
+    const SilKit::Core::EndpointId expectedId{12345};
+    const std::string expectedName("myService");
+    const std::string expectedNetwork("myNetwork");
+    descriptor.SetServiceId(expectedId);
+    descriptor.SetServiceName(expectedName);
+    descriptor.SetNetworkName(expectedNetwork);
+
+    const SilKit::Core::EndpointId expectedParentId{54321};
+    descriptor.SetSupplementalDataItem(SilKit::Core::Discovery::supplKeyRpcServerInternalParentServiceID,
+                                       std::to_string(expectedParentId));
+
+    descriptor.SetSupplementalDataItem(SilKit::Core::Discovery::controllerType,
+                                       SilKit::Core::Discovery::controllerTypeRpcServerInternal);
+
+    // Act
+    const auto dataMapper = CreateService();
+    const auto dto = dataMapper->CreateBulkServiceInternalDto(descriptor);
+
+    // Assert
+    ASSERT_EQ(dto->id.getValue(0), expectedId);
+    ASSERT_STREQ(dto->name->c_str(), expectedName.c_str());
+    ASSERT_STREQ(dto->networkName->c_str(), expectedNetwork.c_str());
+    ASSERT_EQ(dto->parentId.getValue(0), expectedParentId);
+}
+
+TEST_F(Test_DashboardSilKitToOatppMapper, CreateBulkSimulationDto)
+{
+    const auto to_ms = [](const auto tp) -> std::uint64_t {
+        return std::chrono::duration_cast<std::chrono::milliseconds>(tp.time_since_epoch()).count();
+    };
+
+    const auto makeControllerCreatedData = [](const std::string& participantName, const std::string& serviceName,
+                                              SilKit::Core::EndpointId serviceId, const std::string& networkName,
+                                              const std::string& controllerType) -> SilKit::Dashboard::ServiceData {
+        SilKit::Dashboard::ServiceData serviceData;
+        serviceData.discoveryType = Core::Discovery::ServiceDiscoveryEvent::Type::ServiceCreated;
+        serviceData.serviceDescriptor.SetParticipantNameAndComputeId(participantName);
+        serviceData.serviceDescriptor.SetServiceType(Core::ServiceType::Controller);
+        serviceData.serviceDescriptor.SetServiceName(serviceName);
+        serviceData.serviceDescriptor.SetServiceId(serviceId);
+        serviceData.serviceDescriptor.SetNetworkName(networkName);
+        serviceData.serviceDescriptor.SetSupplementalDataItem(SilKit::Core::Discovery::controllerType, controllerType);
+        return serviceData;
+    };
+
+    const auto makeLinkCreatedData = [](const std::string& participantName, SilKit::Config::NetworkType networkType,
+                                        const std::string& networkName) -> SilKit::Dashboard::ServiceData {
+        SilKit::Dashboard::ServiceData serviceData;
+        serviceData.discoveryType = Core::Discovery::ServiceDiscoveryEvent::Type::ServiceCreated;
+        serviceData.serviceDescriptor.SetParticipantNameAndComputeId(participantName);
+        serviceData.serviceDescriptor.SetServiceType(Core::ServiceType::Link);
+        serviceData.serviceDescriptor.SetNetworkType(networkType);
+        serviceData.serviceDescriptor.SetNetworkName(networkName);
+        return serviceData;
+    };
+
+    // Arrange
+    DashboardBulkUpdate expectedBulkUpdate;
+
+    expectedBulkUpdate.stopped = std::make_unique<std::uint64_t>(12345u);
+
+    const auto expectedSystemState0 = SilKit::Dashboard::SystemState::Shutdown;
+    expectedBulkUpdate.systemStates.emplace_back(SilKit::Services::Orchestration::SystemState::Shutdown);
+
+    const auto expectedSystemState1 = SilKit::Dashboard::SystemState::Running;
+    expectedBulkUpdate.systemStates.emplace_back(SilKit::Services::Orchestration::SystemState::Running);
+
+    const auto expectedSystemState2 = SilKit::Dashboard::SystemState::Paused;
+    expectedBulkUpdate.systemStates.emplace_back(SilKit::Services::Orchestration::SystemState::Paused);
+
+    constexpr auto expectedAParticipantState0 = SilKit::Dashboard::ParticipantState::Running;
+    const SilKit::Services::Orchestration::ParticipantStatus aParticipantStatus0{
+        "A", SilKit::Services::Orchestration::ParticipantState::Running, "A Reason 1",
+        std::chrono::system_clock::now() + std::chrono::seconds{1000},
+        std::chrono::system_clock::now() + std::chrono::seconds{2000}};
+
+    constexpr auto expectedAParticipantState1 = SilKit::Dashboard::ParticipantState::Shutdown;
+    const SilKit::Services::Orchestration::ParticipantStatus aParticipantStatus1{
+        "A", SilKit::Services::Orchestration::ParticipantState::Shutdown, "A Reason 2",
+        std::chrono::system_clock::now() + std::chrono::seconds{3000},
+        std::chrono::system_clock::now() + std::chrono::seconds{4000}};
+
+    constexpr auto expectedBParticipantState = SilKit::Dashboard::ParticipantState::Stopped;
+    const SilKit::Services::Orchestration::ParticipantStatus bParticipantStatus{
+        "B", SilKit::Services::Orchestration::ParticipantState::Stopped, "B Reason",
+        std::chrono::system_clock::now() + std::chrono::seconds{5000},
+        std::chrono::system_clock::now() + std::chrono::seconds{6000}};
+
+    expectedBulkUpdate.participantStatuses.emplace_back(aParticipantStatus0);
+    expectedBulkUpdate.participantStatuses.emplace_back(aParticipantStatus1);
+    expectedBulkUpdate.participantStatuses.emplace_back(bParticipantStatus);
+
+    expectedBulkUpdate.participantConnectionInformations.emplace_back(
+        SilKit::Services::Orchestration::ParticipantConnectionInformation{"C"});
+
+    expectedBulkUpdate.serviceDatas.emplace_back(
+        makeControllerCreatedData("A", "ACan0", 1001, "ACanNet0", SilKit::Core::Discovery::controllerTypeCan));
+    expectedBulkUpdate.serviceDatas.emplace_back(
+        makeControllerCreatedData("A", "ACan1", 1002, "ACanNet1", SilKit::Core::Discovery::controllerTypeCan));
+
+    expectedBulkUpdate.serviceDatas.emplace_back(
+        makeControllerCreatedData("A", "AEth0", 2001, "AEthNet0", SilKit::Core::Discovery::controllerTypeEthernet));
+    expectedBulkUpdate.serviceDatas.emplace_back(
+        makeControllerCreatedData("A", "AEth1", 2002, "AEthNet1", SilKit::Core::Discovery::controllerTypeEthernet));
+
+    expectedBulkUpdate.serviceDatas.emplace_back(
+        makeControllerCreatedData("A", "AFlr0", 2001, "AFlrNet0", SilKit::Core::Discovery::controllerTypeFlexray));
+    expectedBulkUpdate.serviceDatas.emplace_back(
+        makeControllerCreatedData("A", "AFlr1", 2002, "AFlrNet1", SilKit::Core::Discovery::controllerTypeFlexray));
+
+    expectedBulkUpdate.serviceDatas.emplace_back(
+        makeControllerCreatedData("A", "ALin0", 2001, "ALinNet0", SilKit::Core::Discovery::controllerTypeLin));
+    expectedBulkUpdate.serviceDatas.emplace_back(
+        makeControllerCreatedData("A", "ALin1", 2002, "ALinNet1", SilKit::Core::Discovery::controllerTypeLin));
+
+    expectedBulkUpdate.serviceDatas.emplace_back(makeLinkCreatedData("A", Config::NetworkType::CAN, "ACanNet0"));
+    expectedBulkUpdate.serviceDatas.emplace_back(makeLinkCreatedData("A", Config::NetworkType::CAN, "ACanNet1"));
+
+    expectedBulkUpdate.serviceDatas.emplace_back(makeLinkCreatedData("A", Config::NetworkType::Ethernet, "AEthNet0"));
+    expectedBulkUpdate.serviceDatas.emplace_back(makeLinkCreatedData("A", Config::NetworkType::Ethernet, "AEthNet1"));
+
+    expectedBulkUpdate.serviceDatas.emplace_back(makeLinkCreatedData("A", Config::NetworkType::FlexRay, "AFlrNet0"));
+    expectedBulkUpdate.serviceDatas.emplace_back(makeLinkCreatedData("A", Config::NetworkType::FlexRay, "AFlrNet1"));
+
+    expectedBulkUpdate.serviceDatas.emplace_back(makeLinkCreatedData("A", Config::NetworkType::LIN, "ALinNet0"));
+    expectedBulkUpdate.serviceDatas.emplace_back(makeLinkCreatedData("A", Config::NetworkType::LIN, "ALinNet1"));
+
+    // Act
+    const auto dataMapper = CreateService();
+    const auto dto = dataMapper->CreateBulkSimulationDto(expectedBulkUpdate);
+
+    // Assert
+    ASSERT_NE(dto->stopped.getPtr(), nullptr);
+    ASSERT_EQ(dto->stopped.getValue(0), *expectedBulkUpdate.stopped);
+
+    ASSERT_NE(dto->system.getPtr(), nullptr);
+    ASSERT_NE(dto->system->statuses.getPtr(), nullptr);
+    ASSERT_EQ(dto->system->statuses->size(), expectedBulkUpdate.systemStates.size());
+    ASSERT_NE(dto->system->statuses[0].getPtr(), nullptr);
+    ASSERT_NE(dto->system->statuses[0]->state.getPtr(), nullptr);
+    ASSERT_EQ(dto->system->statuses[0]->state, expectedSystemState0);
+    ASSERT_NE(dto->system->statuses[1].getPtr(), nullptr);
+    ASSERT_NE(dto->system->statuses[1]->state.getPtr(), nullptr);
+    ASSERT_EQ(dto->system->statuses[1]->state, expectedSystemState1);
+    ASSERT_NE(dto->system->statuses[2].getPtr(), nullptr);
+    ASSERT_NE(dto->system->statuses[2]->state.getPtr(), nullptr);
+    ASSERT_EQ(dto->system->statuses[2]->state, expectedSystemState2);
+
+    ASSERT_NE(dto->participants.getPtr(), nullptr);
+    ASSERT_EQ(dto->participants->size(), 3);
+
+    oatpp::Object<BulkParticipantDto> aParticipantDto;
+    oatpp::Object<BulkParticipantDto> bParticipantDto;
+    oatpp::Object<BulkParticipantDto> cParticipantDto;
+
+    for (const auto& participantDto : *dto->participants.get())
+    {
+        ASSERT_NE(participantDto.getPtr(), nullptr);
+        ASSERT_NE(participantDto->name.getPtr(), nullptr);
+
+        if (participantDto->name == "A")
+        {
+            aParticipantDto = participantDto;
+        }
+
+        if (participantDto->name == "B")
+        {
+            bParticipantDto = participantDto;
+        }
+
+        if (participantDto->name == "C")
+        {
+            cParticipantDto = participantDto;
+        }
+    }
+
+    ASSERT_NE(aParticipantDto.getPtr(), nullptr);
+    ASSERT_NE(aParticipantDto->statuses.getPtr(), nullptr);
+    ASSERT_EQ(aParticipantDto->statuses->size(), 2);
+    ASSERT_NE(aParticipantDto->statuses[0].getPtr(), nullptr);
+    ASSERT_EQ(aParticipantDto->statuses[0]->state, expectedAParticipantState0);
+    ASSERT_EQ(aParticipantDto->statuses[0]->enterReason, aParticipantStatus0.enterReason);
+    ASSERT_EQ(aParticipantDto->statuses[0]->enterTime, to_ms(aParticipantStatus0.enterTime));
+    ASSERT_NE(aParticipantDto->statuses[1].getPtr(), nullptr);
+    ASSERT_EQ(aParticipantDto->statuses[1]->state, expectedAParticipantState1);
+    ASSERT_EQ(aParticipantDto->statuses[1]->enterReason, aParticipantStatus1.enterReason);
+    ASSERT_EQ(aParticipantDto->statuses[1]->enterTime, to_ms(aParticipantStatus1.enterTime));
+
+    ASSERT_NE(aParticipantDto->canControllers.getPtr(), nullptr);
+    ASSERT_EQ(aParticipantDto->canControllers->size(), 2);
+    ASSERT_NE(aParticipantDto->canControllers[0].getPtr(), nullptr);
+    ASSERT_NE(aParticipantDto->canControllers[1].getPtr(), nullptr);
+
+    ASSERT_NE(aParticipantDto->ethernetControllers.getPtr(), nullptr);
+    ASSERT_EQ(aParticipantDto->ethernetControllers->size(), 2);
+    ASSERT_NE(aParticipantDto->ethernetControllers[0].getPtr(), nullptr);
+    ASSERT_NE(aParticipantDto->ethernetControllers[1].getPtr(), nullptr);
+
+    ASSERT_NE(aParticipantDto->flexrayControllers.getPtr(), nullptr);
+    ASSERT_EQ(aParticipantDto->flexrayControllers->size(), 2);
+    ASSERT_NE(aParticipantDto->flexrayControllers[0].getPtr(), nullptr);
+    ASSERT_NE(aParticipantDto->flexrayControllers[1].getPtr(), nullptr);
+
+    ASSERT_NE(aParticipantDto->linControllers.getPtr(), nullptr);
+    ASSERT_EQ(aParticipantDto->linControllers->size(), 2);
+    ASSERT_NE(aParticipantDto->linControllers[0].getPtr(), nullptr);
+    ASSERT_NE(aParticipantDto->linControllers[1].getPtr(), nullptr);
+
+    ASSERT_NE(aParticipantDto->canNetworks.getPtr(), nullptr);
+    ASSERT_EQ(aParticipantDto->canNetworks->size(), 2);
+
+    ASSERT_NE(aParticipantDto->ethernetNetworks.getPtr(), nullptr);
+    ASSERT_EQ(aParticipantDto->ethernetNetworks->size(), 2);
+
+    ASSERT_NE(aParticipantDto->flexrayNetworks.getPtr(), nullptr);
+    ASSERT_EQ(aParticipantDto->flexrayNetworks->size(), 2);
+
+    ASSERT_NE(aParticipantDto->linNetworks.getPtr(), nullptr);
+    ASSERT_EQ(aParticipantDto->linNetworks->size(), 2);
+
+    ASSERT_NE(bParticipantDto.getPtr(), nullptr);
+    ASSERT_NE(bParticipantDto->statuses.getPtr(), nullptr);
+    ASSERT_EQ(bParticipantDto->statuses->size(), 1);
+    ASSERT_NE(bParticipantDto->statuses[0].getPtr(), nullptr);
+    ASSERT_EQ(bParticipantDto->statuses[0]->state, expectedBParticipantState);
+    ASSERT_EQ(bParticipantDto->statuses[0]->enterReason, bParticipantStatus.enterReason);
+    ASSERT_EQ(bParticipantDto->statuses[0]->enterTime, to_ms(bParticipantStatus.enterTime));
+
+    ASSERT_NE(cParticipantDto.getPtr(), nullptr);
 }
 
 } // namespace Dashboard

--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -12,7 +12,8 @@ The format is based on `Keep a Changelog (http://keepachangelog.com/en/1.0.0/) <
 Added
 ~~~~~
 
-- Network Simulation event flow documentation 
+- Network Simulation event flow documentation
+- Registry (Dashboard): Automatically use bulk-endpoint if it is available
 
 
 [4.0.50] - 2024-05-15


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2023 Vector Informatik GmbH

SPDX-License-Identifier: MIT
-->

## Subject
<!--
    - What kind of changes does this pull request comprise?
    - Add a label like "Bugfix", "docs", etc. to this PR to give context.
 -->
These changes allow the dashboard client in SIL Kit to use the bulk-update endpoint (currently only available in a feature branch of the dashboard that is not publically available).

It allows for much larger simulations, as multiple changes can be combined into a single HTTP request.

## Instructions for review / testing
<!--
    - Hilight some of the important changes, which reviewers should focus on
    - Which parts should be reviewed in detail? For example: content of console output, correct semantics of changes
    - Test steps and test setup description. For example: which programs or configs to use
-->

## Developer checklist (address before review)

- [x] Changelog.md updated
- [ ] Prepared update for depending repositories
- [x] Documentation updated (public API changes only)
- [ ] API docstrings updated (public API changes only)
- [x] Squash and merge &rarr; proper PR title
