### PR TITLE
-- time sync: Couple virtual time to wall clock

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -3,3 +3,7 @@ root = true
 [*.{cpp,ipp,hpp,h,c}]
 indent_style = space
 indent_size = 4
+
+[*.{json,yml,yaml}]
+indent_style = space
+indent_size = 2

--- a/SilKit/IntegrationTests/CMakeLists.txt
+++ b/SilKit/IntegrationTests/CMakeLists.txt
@@ -154,6 +154,14 @@ add_silkit_test_to_executable(SilKitIntegrationTests
     SilKit
 )
 
+add_silkit_test_to_executable(SilKitFunctionalTests
+    SOURCES
+    FTest_WallClockCoupling.cpp
+
+    LIBS
+    S_ITests_STH
+)
+
 # Windows specific tests
 if(MSVC)
     add_silkit_test_to_executable(SilKitIntegrationTests

--- a/SilKit/IntegrationTests/FTest_WallClockCoupling.cpp
+++ b/SilKit/IntegrationTests/FTest_WallClockCoupling.cpp
@@ -1,0 +1,216 @@
+/* Copyright (c) 2022 Vector Informatik GmbH
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE. */
+
+#include <iostream>
+#include <atomic>
+#include <thread>
+#include <future>
+#include <mutex>
+#include <condition_variable>
+
+#include "silkit/services/all.hpp"
+#include "silkit/services/orchestration/all.hpp"
+
+#include "SimTestHarness.hpp"
+
+#include "GetTestPid.hpp"
+
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+
+namespace {
+using namespace std::chrono_literals;
+using namespace SilKit::Tests;
+
+
+TEST(FTest_WallClockCoupling, test_wallclock_sync_simtask)
+{
+    double animationFactor = 2.0;
+    std::string configWithAnimFactor =
+        R"({"Experimental": {"TimeSynchronization": { "AnimationFactor": 2.0 } }})";
+
+    SimTestHarness testHarness({"P1", "P2", "P3"}, MakeTestRegistryUri(), true);
+
+    auto wc_P1{0ns};
+    auto wc_P2{0ns};
+    auto wc_P3{0ns};
+
+    auto* P1 = testHarness.GetParticipant("P1", configWithAnimFactor);
+    auto* lifeCycleService_P1 = P1->GetOrCreateLifecycleService();
+    auto* timeSyncService_P1 = P1->GetOrCreateTimeSyncService();
+
+    auto* timeSyncService_P2 = testHarness.GetParticipant("P2")->GetOrCreateTimeSyncService();
+    auto* timeSyncService_P3 = testHarness.GetParticipant("P3")->GetOrCreateTimeSyncService();
+
+    auto stepSize = 50ms;
+    std::chrono::nanoseconds simDuration = 2s;
+
+    timeSyncService_P1->SetSimulationStepHandler(
+        [simDuration, &wc_P1, &lifeCycleService_P1](std::chrono::nanoseconds now,
+                                                    std::chrono::nanoseconds /*duration*/) {
+        static auto timeSimStart_P1 = std::chrono::system_clock::now();
+        if (now <= simDuration)
+        {
+            wc_P1 = std::chrono::system_clock::now() - timeSimStart_P1;
+        }
+
+        if (now == simDuration)
+            lifeCycleService_P1->Stop("Stopping Test");
+    },
+        stepSize);
+
+    timeSyncService_P2->SetSimulationStepHandler(
+        [simDuration, &wc_P2](std::chrono::nanoseconds now, std::chrono::nanoseconds /*duration*/) {
+        static auto timeSimStart_P2 = std::chrono::system_clock::now();
+        if (now <= simDuration)
+            wc_P2 = std::chrono::system_clock::now() - timeSimStart_P2;
+    }, stepSize);
+    timeSyncService_P3->SetSimulationStepHandler(
+        [simDuration, &wc_P3](std::chrono::nanoseconds now, std::chrono::nanoseconds /*duration*/) {
+        static auto timeSimStart_P3 = std::chrono::system_clock::now();
+        if (now <= simDuration)
+            wc_P3 = std::chrono::system_clock::now() - timeSimStart_P3;
+    }, stepSize);
+
+    ASSERT_TRUE(testHarness.Run(5s)) << "TestSim Harness should not reach timeout";
+
+    std::chrono::nanoseconds acceptedDeviation = 20ms;
+    auto evalWallClockDeviation = [animationFactor, acceptedDeviation, simDuration](std::chrono::nanoseconds wallClock) {
+        auto wallClockDeviationFromVirtualTime = std::abs(wallClock.count() / animationFactor - simDuration.count());
+        std::cout << "Wall clock deviation from virtual time: " << wallClockDeviationFromVirtualTime / 1e6 << "ms"
+                  << std::endl;
+        EXPECT_LT(wallClockDeviationFromVirtualTime, acceptedDeviation.count());
+    };
+
+    evalWallClockDeviation(wc_P1);
+    evalWallClockDeviation(wc_P2);
+    evalWallClockDeviation(wc_P3);
+}
+
+
+std::mutex mx;
+bool doStep = false;
+std::condition_variable cv;
+
+TEST(FTest_WallClockCoupling, test_wallclock_mixed_simtask)
+{
+    double animationFactor = 2.0;
+    std::string configWithAnimFactor =
+        R"({"Experimental": {"TimeSynchronization": { "AnimationFactor": 2.0 } }})";
+
+    SimTestHarness testHarness({"P1", "P2", "P3"}, MakeTestRegistryUri(), true);
+
+    auto wc_P1{0ns};
+    auto wc_P2{0ns};
+    auto wc_P3{0ns};
+
+    auto* P1 = testHarness.GetParticipant("P1", configWithAnimFactor);
+    auto* lifeCycleService_P1 = P1->GetOrCreateLifecycleService();
+    auto* timeSyncService_P1 = P1->GetOrCreateTimeSyncService();
+
+    auto* timeSyncService_P2 = testHarness.GetParticipant("P2")->GetOrCreateTimeSyncService();
+    auto* timeSyncService_P3 = testHarness.GetParticipant("P3")->GetOrCreateTimeSyncService();
+
+    auto stepSize = 50ms;
+    std::chrono::nanoseconds simDuration = 2s;
+
+    std::atomic<bool> done{false};
+    timeSyncService_P1->SetSimulationStepHandlerAsync(
+        [&done, simDuration, &wc_P1, &lifeCycleService_P1](std::chrono::nanoseconds now,
+                                                    std::chrono::nanoseconds /*duration*/) {
+        static auto timeSimStart_P1 = std::chrono::system_clock::now();
+        if (now <= simDuration)
+        {
+            wc_P1 = std::chrono::system_clock::now() - timeSimStart_P1;
+        }
+
+        if (now == simDuration)
+        {
+            lifeCycleService_P1->Stop("Stopping Test");
+            done = true;
+        }
+
+        std::unique_lock<decltype(mx)> lock(mx);
+        doStep = true;
+        cv.notify_one();
+
+        if (done)
+        {
+            return;
+        }
+
+    }, stepSize);
+
+    timeSyncService_P2->SetSimulationStepHandler(
+        [simDuration, &wc_P2](std::chrono::nanoseconds now, std::chrono::nanoseconds /*duration*/) {
+        static auto timeSimStart_P2 = std::chrono::system_clock::now();
+        if (now <= simDuration)
+            wc_P2 = std::chrono::system_clock::now() - timeSimStart_P2;
+    }, stepSize);
+    timeSyncService_P3->SetSimulationStepHandler(
+        [simDuration, &wc_P3](std::chrono::nanoseconds now, std::chrono::nanoseconds /*duration*/) {
+        static auto timeSimStart_P3 = std::chrono::system_clock::now();
+        if (now <= simDuration)
+            wc_P3 = std::chrono::system_clock::now() - timeSimStart_P3;
+    }, stepSize);
+
+    
+    auto completer = std::thread{[&done, timeSyncService_P1]() {
+        while (!done)
+        {
+            std::unique_lock<decltype(mx)> lock(mx);
+            cv.wait(lock, [] { return doStep; });
+            doStep = false;
+
+            timeSyncService_P1->CompleteSimulationStep();
+
+            if (done)
+            {
+                return;
+            }
+        }
+    }};
+
+    ASSERT_TRUE(testHarness.Run(5s)) << "TestSim Harness should not reach timeout";
+
+    std::chrono::nanoseconds acceptedDeviation = 20ms;
+    auto evalWallClockDeviation = [animationFactor, acceptedDeviation,
+                                   simDuration](std::chrono::nanoseconds wallClock) {
+        auto wallClockDeviationFromVirtualTime = std::abs(wallClock.count() / animationFactor - simDuration.count());
+        std::cout << "Wall clock deviation from virtual time: " << wallClockDeviationFromVirtualTime / 1e6 << "ms"
+                  << std::endl;
+        EXPECT_LT(wallClockDeviationFromVirtualTime, acceptedDeviation.count());
+    };
+
+    evalWallClockDeviation(wc_P1);
+    evalWallClockDeviation(wc_P2);
+    evalWallClockDeviation(wc_P3);
+
+    done = true;
+    cv.notify_one();
+    if (completer.joinable())
+    {
+        completer.join();
+    }
+}
+
+
+} // anonymous namespace

--- a/SilKit/IntegrationTests/ITest_Internals_ParticipantModes.cpp
+++ b/SilKit/IntegrationTests/ITest_Internals_ParticipantModes.cpp
@@ -193,8 +193,7 @@ protected:
         }
 
         auto participantInternal = dynamic_cast<SilKit::Core::IParticipantInternal*>(participant.get());
-        Experimental::Services::Orchestration::ISystemController* systemController =
-            participantInternal->GetSystemController();
+        auto systemController = participantInternal->GetSystemController();
 
         auto systemMonitor = participant->CreateSystemMonitor();
         systemMonitor->AddParticipantStatusHandler([&testParticipant, systemController, logger,
@@ -303,8 +302,7 @@ protected:
         }
 
         auto participantInternal = dynamic_cast<SilKit::Core::IParticipantInternal*>(participant.get());
-        Experimental::Services::Orchestration::ISystemController* systemController =
-            participantInternal->GetSystemController();
+        auto systemController = participantInternal->GetSystemController();
         auto systemMonitor = participant->CreateSystemMonitor();
         systemMonitor->AddParticipantStatusHandler([&testParticipant, systemController, logger,
                                                     this](const Services::Orchestration::ParticipantStatus& status) {
@@ -419,8 +417,7 @@ protected:
             SilKit::CreateParticipantImpl(config, systemControllerParticipantName, registryUri);
 
         auto participantInternal = dynamic_cast<SilKit::Core::IParticipantInternal*>(systemControllerParticipant.get());
-        Experimental::Services::Orchestration::ISystemController* systemController =
-            participantInternal->GetSystemController();
+        auto systemController = participantInternal->GetSystemController();
 
         auto* logger = systemControllerParticipant->GetLogger();
 

--- a/SilKit/source/config/ParticipantConfiguration.hpp
+++ b/SilKit/source/config/ParticipantConfiguration.hpp
@@ -263,6 +263,28 @@ struct Middleware
     double connectTimeoutSeconds{5.0};
 };
 
+
+// ================================================================================
+//  TimeSynchronization
+// ================================================================================
+
+//! \brief Structure that contains experimental TimeSynchronization settings
+struct TimeSynchronization
+{
+    double animationFactor{0.0};
+};
+
+
+// ================================================================================
+//  Experimental
+// ================================================================================
+
+//! \brief Structure that contains experimental settings
+struct Experimental
+{
+    TimeSynchronization timeSynchronization;
+};
+
 // ================================================================================
 //  Root
 // ================================================================================
@@ -301,6 +323,7 @@ struct ParticipantConfiguration : public IParticipantConfiguration
     Tracing tracing;
     Extensions extensions;
     Middleware middleware;
+    Experimental experimental;
 };
 
 bool operator==(const CanController& lhs, const CanController& rhs);
@@ -316,6 +339,8 @@ bool operator==(const Tracing& lhs, const Tracing& rhs);
 bool operator==(const Extensions& lhs, const Extensions& rhs);
 bool operator==(const Middleware& lhs, const Middleware& rhs);
 bool operator==(const ParticipantConfiguration& lhs, const ParticipantConfiguration& rhs);
+bool operator==(const TimeSynchronization& lhs, const TimeSynchronization& rhs);
+bool operator==(const Experimental& lhs, const Experimental& rhs);
 
 } // namespace v1
 } // namespace Config

--- a/SilKit/source/config/ParticipantConfiguration.schema.json
+++ b/SilKit/source/config/ParticipantConfiguration.schema.json
@@ -768,6 +768,26 @@
         }
       },
       "additionalProperties": false
+    },
+    "Experimental": {
+      "type": "object",
+      "description": "Experimental configuration",
+      "properties": {
+        "TimeSynchronization": {
+          "type": "object",
+          "description": "Configuration related to time synchronization",
+          "properties": {
+            "AnimationFactor": {
+              "type": "number",
+              "description": "The animation factor describes how fast the simulation is allowed to run, relative to the local wall clock. For example, if the value is 0.1, SIL Kit will try to run the simulation 10 times faster than the wall clock. The default value 0.0 runs the simulation as fast as possible, i.e., the current behavior.",
+              "minimum": 0.0,
+              "default": 0.0
+            }
+          },
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
     }
   },
   "type": "object"

--- a/SilKit/source/config/ParticipantConfigurationFromXImpl.cpp
+++ b/SilKit/source/config/ParticipantConfigurationFromXImpl.cpp
@@ -71,6 +71,16 @@ struct GlobalLogCache
     std::set<std::string> fileNames;
 };
 
+struct TimeSynchronizationCache
+{
+    SilKit::Util::Optional<double> animationFactor;
+};
+
+struct ExperimentalCache
+{
+    TimeSynchronizationCache timeSynchronizationCache;
+};
+
 struct ConfigIncludeData
 {
     std::set<std::string> searchPaths;
@@ -78,6 +88,7 @@ struct ConfigIncludeData
     std::vector<ConfigInclude> configBuffer;
     MiddlewareCache middlewareCache;
     GlobalLogCache logCache;
+    ExperimentalCache experimentalCache;
     std::map<std::string, SilKit::Config::CanController> canCache;
     std::map<std::string, SilKit::Config::LinController> linCache;
     std::map<std::string, SilKit::Config::EthernetController> ethCache;
@@ -352,6 +363,16 @@ void CacheLoggingSinks(const YAML::Node& config, GlobalLogCache& cache)
     }
 }
 
+void CacheTimeSynchronization(const YAML::Node& root, TimeSynchronizationCache& cache)
+{
+    PopulateCacheField(root["TimeSynchronization"], "TimeSynchronization", "AnimationFactor", cache.animationFactor);
+}
+
+void CacheExperimental(const YAML::Node& root, ExperimentalCache& cache)
+{
+    CacheTimeSynchronization(root, cache.timeSynchronizationCache);
+}
+
 void PopulateCaches(const YAML::Node& config, ConfigIncludeData& configIncludeData)
 {
     // Cache those config options that need to be default constructed, since we lose the information
@@ -365,6 +386,11 @@ void PopulateCaches(const YAML::Node& config, ConfigIncludeData& configIncludeDa
     {
         CacheLoggingOptions(config["Logging"], configIncludeData.logCache);
         CacheLoggingSinks(config["Logging"], configIncludeData.logCache);
+    }
+
+    if (config["Experimental"])
+    {
+        CacheExperimental(config["Experimental"], configIncludeData.experimentalCache);
     }
 }
 
@@ -457,6 +483,16 @@ void MergeLogCache(const GlobalLogCache& cache, Logging& logging)
     }
 }
 
+void MergeTimeSynchronizationCache(const TimeSynchronizationCache& cache, TimeSynchronization& timeSynchronization)
+{
+    MergeCacheField(cache.animationFactor, timeSynchronization.animationFactor);
+}
+
+void MergeExperimentalCache(const ExperimentalCache& cache, Experimental& experimental)
+{
+    MergeTimeSynchronizationCache(cache.timeSynchronizationCache, experimental.timeSynchronization);
+}
+
 
 auto MergeConfigs(ConfigIncludeData& configIncludeData) -> SilKit::Config::ParticipantConfiguration
 {
@@ -497,6 +533,7 @@ auto MergeConfigs(ConfigIncludeData& configIncludeData) -> SilKit::Config::Parti
 
     MergeMiddleware(configIncludeData.middlewareCache, config.middleware);
     MergeLogCache(configIncludeData.logCache, config.logging);
+    MergeExperimentalCache(configIncludeData.experimentalCache, config.experimental);
 
     return config;
 }
@@ -657,6 +694,16 @@ bool operator==(const ParticipantConfiguration& lhs, const ParticipantConfigurat
            && lhs.dataSubscribers == rhs.dataSubscribers && lhs.rpcClients == rhs.rpcClients
            && lhs.rpcServers == rhs.rpcServers && lhs.logging == rhs.logging && lhs.healthCheck == rhs.healthCheck
            && lhs.tracing == rhs.tracing && lhs.extensions == rhs.extensions;
+}
+
+bool operator==(const TimeSynchronization& lhs, const TimeSynchronization& rhs)
+{
+    return lhs.animationFactor == rhs.animationFactor;
+}
+
+bool operator==(const Experimental& lhs, const Experimental& rhs)
+{
+    return lhs.timeSynchronization == rhs.timeSynchronization;
 }
 
 } // namespace v1

--- a/SilKit/source/config/ParticipantConfiguration_Full.json
+++ b/SilKit/source/config/ParticipantConfiguration_Full.json
@@ -229,5 +229,10 @@
     "TcpReceiveBufferSize": 3456,
     "RegistryAsFallbackProxy": false,
     "ConnectTimeoutSeconds": 1.234
+  },
+  "Experimental": {
+    "TimeSynchronization": {
+      "AnimationFactor": 1.5
+    }
   }
 }

--- a/SilKit/source/config/YamlConversion.cpp
+++ b/SilKit/source/config/YamlConversion.cpp
@@ -978,6 +978,35 @@ bool Converter::decode(const Node& node, Middleware& obj)
 }
 
 template <>
+Node Converter::encode(const TimeSynchronization& obj)
+{
+    Node node;
+    node["AnimationFactor"] = obj.animationFactor;
+    return node;
+}
+template <>
+bool Converter::decode(const Node& node, TimeSynchronization& obj)
+{
+    obj.animationFactor = parse_as<decltype(obj.animationFactor)>(node["AnimationFactor"]);
+    return true;
+}
+
+template <>
+Node Converter::encode(const Experimental& obj)
+{
+    Node node;
+    node["TimeSynchronization"] = obj.timeSynchronization;
+    return node;
+}
+template <>
+bool Converter::decode(const Node& node, Experimental& obj)
+{
+    obj.timeSynchronization = parse_as<decltype(obj.timeSynchronization)>(node["TimeSynchronization"]);
+    return true;
+}
+
+
+template<>
 Node Converter::encode(const ParticipantConfiguration& obj)
 {
     static const ParticipantConfiguration defaultObj{};
@@ -1006,6 +1035,7 @@ Node Converter::encode(const ParticipantConfiguration& obj)
     non_default_encode(obj.tracing, node, "Extensions", defaultObj.tracing);
     non_default_encode(obj.extensions, node, "Extensions", defaultObj.extensions);
     non_default_encode(obj.middleware, node, "Middleware", defaultObj.middleware);
+    non_default_encode(obj.experimental, node, "Experimental", defaultObj.experimental);
     return node;
 }
 template <>
@@ -1029,6 +1059,7 @@ bool Converter::decode(const Node& node, ParticipantConfiguration& obj)
     optional_decode(obj.tracing, node, "Tracing");
     optional_decode(obj.extensions, node, "Extensions");
     optional_decode(obj.middleware, node, "Middleware");
+    optional_decode(obj.experimental, node, "Experimental");
     return true;
 }
 

--- a/SilKit/source/config/YamlConversion.hpp
+++ b/SilKit/source/config/YamlConversion.hpp
@@ -80,6 +80,9 @@ DEFINE_SILKIT_CONVERT(Middleware);
 
 DEFINE_SILKIT_CONVERT(Extensions);
 
+DEFINE_SILKIT_CONVERT(Experimental);
+DEFINE_SILKIT_CONVERT(TimeSynchronization);
+
 DEFINE_SILKIT_CONVERT(ParticipantConfiguration);
 
 } // namespace YAML

--- a/SilKit/source/config/YamlSchema.cpp
+++ b/SilKit/source/config/YamlSchema.cpp
@@ -194,7 +194,11 @@ auto MakeYamlSchema() -> YamlSchemaElem
              {"RegistryAsFallbackProxy"},
              {"ExperimentalRemoteParticipantConnection"},
              {"ConnectTimeoutSeconds"},
-         }}};
+         }},
+        {"Experimental", 
+            { {"TimeSynchronization", {{"AnimationFactor"}} }
+         }},
+       };
     return yamlSchema;
 }
 

--- a/SilKit/source/core/internal/IParticipantInternal.hpp
+++ b/SilKit/source/core/internal/IParticipantInternal.hpp
@@ -78,6 +78,9 @@ public:
     */
     virtual void JoinSilKitSimulation() = 0;
 
+    // Register subscriptions for the time sync service only when the user actually calls CreateTimeSyncService.
+    virtual void RegisterTimeSyncService(SilKit::Services::Orchestration::TimeSyncService* controllerPtr) = 0;
+
     // For NetworkSimulator integration:
     virtual void RegisterSimulator(ISimulator* busSim, std::string networkName,
                                    SilKit::Experimental::NetworkSimulation::SimulatedNetworkType networkType) = 0;

--- a/SilKit/source/core/mock/participant/MockParticipant.hpp
+++ b/SilKit/source/core/mock/participant/MockParticipant.hpp
@@ -562,6 +562,7 @@ public:
         return &mockTimeProvider;
     }
     void JoinSilKitSimulation() override {}
+    void RegisterTimeSyncService(SilKit::Services::Orchestration::TimeSyncService*) override {}
 
     auto GetServiceDiscovery() -> Discovery::IServiceDiscovery* override
     {

--- a/SilKit/source/core/participant/Participant.hpp
+++ b/SilKit/source/core/participant/Participant.hpp
@@ -405,15 +405,20 @@ private:
     //!< Internal controller creation, explicit network argument for ConfigT without network
     template <class ControllerT, typename... Arg>
     auto CreateController(const SilKitServiceTraitConfigType_t<ControllerT>& config, const std::string& network,
-                          const Core::SupplementalData& supplementalData, bool publishService,
-                          Arg&&... arg) -> ControllerT*;
+                          const Core::SupplementalData& supplementalData, bool publishServiceDiscovery,
+                          bool registerSilKitService, Arg&&... arg)
+        -> ControllerT*;
 
     //!< Internal controller creation, expects config.network
     template <class ControllerT, typename... Arg>
     auto CreateController(const SilKitServiceTraitConfigType_t<ControllerT>& config,
-                          const Core::SupplementalData& supplementalData, bool publishService,
-                          Arg&&... arg) -> ControllerT*;
+                          const Core::SupplementalData& supplementalData, bool publishServiceDiscovery,
+                          bool registerSilKitService, Arg&&... arg)
+        -> ControllerT*;
 
+    //!< Internal late controller registration. Used for TimeSyncService to create the controller 
+    //! and only register message reception later if really needed.
+    void RegisterTimeSyncService(SilKit::Services::Orchestration::TimeSyncService* controllerPtr) override;
 
     void RegisterSimulator(ISimulator* busSim, std::string networkName,
                            Experimental::NetworkSimulation::SimulatedNetworkType networkType) override;

--- a/SilKit/source/services/orchestration/LifecycleManagement.cpp
+++ b/SilKit/source/services/orchestration/LifecycleManagement.cpp
@@ -245,10 +245,14 @@ bool LifecycleManagement::HandleAbort()
     }
 }
 
-
 void LifecycleManagement::StartTime()
 {
     (dynamic_cast<TimeSyncService*>(_lifecycleService->GetTimeSyncService()))->StartTime();
+}
+
+void LifecycleManagement::StopTime()
+{
+    (dynamic_cast<TimeSyncService*>(_lifecycleService->GetTimeSyncService()))->StopTime();
 }
 
 void LifecycleManagement::AddAsyncSubscriptionsCompletionHandler(std::function<void()> handler)

--- a/SilKit/source/services/orchestration/LifecycleManagement.hpp
+++ b/SilKit/source/services/orchestration/LifecycleManagement.hpp
@@ -66,8 +66,10 @@ public: //CTors
     // Autonomous lifecycle state initialization
     void StartAutonomous(std::string reason);
 
-    // Send NextSimTask
+    // Check capabilites, potentially start the wall clock coupling thread and send the initial NextSimTask
     void StartTime();
+    // Potentially stop the wall clock coupling thread
+    void StopTime();
 
     // Callback handling
     CallbackResult HandleCommunicationReady();

--- a/SilKit/source/services/orchestration/LifecycleService.cpp
+++ b/SilKit/source/services/orchestration/LifecycleService.cpp
@@ -419,6 +419,7 @@ auto LifecycleService::CreateTimeSyncService() -> ITimeSyncService*
 {
     if (!_timeSyncActive)
     {
+        _participant->RegisterTimeSyncService(_timeSyncService);
         _timeSyncActive = true;
         return _timeSyncService;
     }

--- a/SilKit/source/services/orchestration/LifecycleStates.cpp
+++ b/SilKit/source/services/orchestration/LifecycleStates.cpp
@@ -463,12 +463,14 @@ void RunningState::ContinueSimulation(std::string reason)
 
 void RunningState::StopSimulation(std::string reason)
 {
+    _lifecycleManager->StopTime();
     _lifecycleManager->SetStateAndForwardIntent(_lifecycleManager->GetStoppingState(), &ILifecycleState::StopSimulation,
                                                 std::move(reason));
 }
 
 void RunningState::AbortSimulation(std::string reason)
 {
+    _lifecycleManager->StopTime();
     // TODO handle abort during executeSimStep
     // For now, just abort and hope for the best...
     ResolveAbortSimulation(std::move(reason));

--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -12,7 +12,10 @@ The format is based on `Keep a Changelog (http://keepachangelog.com/en/1.0.0/) <
 Added
 ~~~~~
 
-- Network Simulation event flow documentation
+- Couple the virtual time to the wall clock. 
+  An animation factor can be configured that describes how fast the simulation is allowed to run relative to the local wall clock.
+  Accessible via a new experimental section in the Participant Configuration (Experimental | TimeSynchronization | AnimationFactor).
+- Event flow documentation for the Network Simulation API.
 - Registry (Dashboard): Automatically use bulk-endpoint if it is available
 
 

--- a/docs/configuration/configuration.rst
+++ b/docs/configuration/configuration.rst
@@ -106,6 +106,8 @@ The outline of a participant configuration file is as follows:
       - ...
     RpcServers: 
       - ...
+    Experimental: 
+      - ...
 
 .. _subsec:participant-config-overview:
 
@@ -176,6 +178,9 @@ Overview
    * - :ref:`RpcClients<sec:cfg-participant-rpc-clients>`
      - Configure RPC clients.
 
+   * - :ref:`Experimental<sec:cfg-participant-experimental>`
+     - Experimental configuration options for the |ProductName|.
+
 Configuration Options
 ~~~~~~~~~~~~~~~~~~~~~
 .. toctree::
@@ -188,6 +193,7 @@ Configuration Options
    tracing-configuration
    extension-configuration
    middleware-configuration
+   experimental-configuration
 
 .. _sec:registry-config:
 

--- a/docs/configuration/experimental-configuration.rst
+++ b/docs/configuration/experimental-configuration.rst
@@ -1,0 +1,45 @@
+.. _sec:cfg-participant-experimental:
+
+===================================================
+Experimental Configuration
+===================================================
+
+.. |ProductName| replace:: SIL Kit
+
+.. contents:: :local:
+   :depth: 3
+
+Overview
+--------------------
+
+This section includes experimental configuration fields.
+
+.. warning::
+  The featues available through the experimental section might be changed or removed in future versions of the |ProductName|.
+
+TimeSynchronization
+--------------------
+
+.. code-block:: yaml
+
+    Experimental:
+        TimeSynchronization:
+            AnimationFactor: 1.0
+
+.. list-table:: TimeSynchronization Configuration
+   :widths: 15 85
+   :header-rows: 1
+
+   * - Property Name
+     - Description
+
+   * - AnimationFactor
+     - This value affects |ProductName| simulations where a time synchronization service is used. 
+       When this value is set, the virtual time is coulped to the local wall clock of the underlying system, scaled down by the given factor.
+       E.g., a value of 1.0 means direct coupling to the wall clock. 
+       A value of 2.0 means that the virtual time runs **twice as slow** as the local wall clock. 
+       Accordingly, a value of 0.5 will cause the virtual time to run **twice as fast**. 
+       When omitting the value or setting it to zero, no coupling to the wall clock takes place.
+
+       .. note::
+         Depending on the simulation step size, the choosen animation factor and the computational load per simulation step, it might not be possible to couple the virtual time to the wall clock with the desired factor.


### PR DESCRIPTION
## Subject
Introduce wall clock coupling of virtual time. Accessible via participant configuration: 
```
Experimental:
  TimeSynchronization:
    AnimationFactor: 1.0
```

## Description
- Added a _WallClockCoupling_ thread similar to the _WatchDog_ thread that manages the time advances when due
- Prevent sending NextSimTask at other places than the _WallClockCoupling_ thread  if the coupling is active
- Improved performance for mixed system w/ wo/ time synchronization by not sending NextSimTask message to participants that don't use a TimeSyncService:
   - The timeSyncService is created by default with a lifecycle service, although it might be unused
   - Now, controllers can be created internally without performing the message subscriptions (preventing `RegisterSilKitService`)
   - For the TimeSyncService, the subscriptions are then performed when the user calls `CreateTimeSyncService`

## Instructions for review / testing
- Review code changes
- Review changes to docs in `configuration.rst` and `experimental-configuration.rst`
- Try with any demo: Comment out sleeps in SimStepHandler, use adapted participant config with e.g.

```
Experimental:
  TimeSynchronization:
    AnimationFactor: 100.0

```
- Test is not run in the CI, run `FTest_WallClockCoupling.cpp` manually

## Developer checklist (address before review)

- [x] Changelog.md updated
- [x] Documentation updated (public API changes only)
- [ ] Squash and merge &rarr; proper PR title
