### PR TITLE
-- ci: build linux releases with GCC on Ubuntu 22.04

### DIFF
--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -39,7 +39,7 @@ jobs:
     environment: public-github-runners
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/mariusbgm/sil-kit-ci-ubuntu-18.04:main
+      image: ghcr.io/mariusbgm/sil-kit-ci-ubuntu-22.04:main
     if: inputs.run_build == true
     steps:
       - name: git checkout

--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -34,8 +34,8 @@ jobs:
           do-package: ${{ inputs.do_package }}
           retention-days: ${{ inputs.retention_days }}
 
-  gcc8-release:
-    name: GCC 8 release Builds for Ubuntu 18.04
+  gcc-release:
+    name: GCC release Builds for Ubuntu 22.04
     environment: public-github-runners
     runs-on: ubuntu-latest
     container:
@@ -46,11 +46,11 @@ jobs:
         uses: actions/checkout@v1
         with:
           submodules: true
-      - name: gcc8-release build
+      - name: GCC release build
         uses: ./.github/actions/build-cmake-preset
         id: build
         with:
-          preset-name: gcc8-release
+          preset-name: linux-release
           do-package: ${{ inputs.do_package }}
           retention-days: ${{ env.retention_days }}
 


### PR DESCRIPTION
The Ubuntu 18.04 doesn't work well with the current upload-artifact action. Upgrade to 22.04 for now, until we refactor our builds to only run the CMake step in the target container.
