### PR TITLE
-- ci: use gcc-release preset for builds

### DIFF
--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -50,7 +50,7 @@ jobs:
         uses: ./.github/actions/build-cmake-preset
         id: build
         with:
-          preset-name: linux-release
+          preset-name: gcc-release
           do-package: ${{ inputs.do_package }}
           retention-days: ${{ env.retention_days }}
 

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -449,12 +449,12 @@
 
         {
             "name": "gcc-debug",
-            "inherits": [ "mixin-posix", "mixin-dirs", "mixin-ninja", "mixin-debug", "mixin-gcc7", "mixin-werror" ]
+            "inherits": [ "mixin-posix", "mixin-dirs", "mixin-ninja", "mixin-debug", "mixin-gcc", "mixin-werror" ]
         },
 
         {
             "name": "gcc-release",
-            "inherits": [ "mixin-release", "gcc7-debug", "mixin-build-docs" ]
+            "inherits": [ "mixin-release", "gcc-debug", "mixin-build-docs" ]
         },
 
         {
@@ -686,12 +686,12 @@
         },
 
         {
-            "name": "gcc7-debug",
-            "configurePreset": "gcc7-debug"
+            "name": "gcc-debug",
+            "configurePreset": "gcc-debug"
         },
         {
-            "name": "gcc7-release",
-            "configurePreset": "gcc7-release"
+            "name": "gcc-release",
+            "configurePreset": "gcc-release"
         },
 
         {
@@ -929,12 +929,12 @@
         },
 
         {
-            "name": "gcc7-debug",
-            "configurePreset": "gcc7-debug"
+            "name": "gcc-debug",
+            "configurePreset": "gcc-debug"
         },
         {
-            "name": "gcc7-release",
-            "configurePreset": "gcc7-release"
+            "name": "gcc-release",
+            "configurePreset": "gcc-release"
         },
 
         {

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -230,12 +230,12 @@
             }
         },
         {
-            "name": "mixin-gcc7",
-            "description": "Target GCC-7",
+            "name": "mixin-gcc",
+            "description": "Target GCC",
             "hidden": true,
             "cacheVariables": {
-                "CMAKE_C_COMPILER": "gcc-7",
-                "CMAKE_CXX_COMPILER": "g++-7"
+                "CMAKE_C_COMPILER": "gcc",
+                "CMAKE_CXX_COMPILER": "g++"
             }
         },
         {
@@ -448,12 +448,12 @@
         },
 
         {
-            "name": "gcc7-debug",
+            "name": "gcc-debug",
             "inherits": [ "mixin-posix", "mixin-dirs", "mixin-ninja", "mixin-debug", "mixin-gcc7", "mixin-werror" ]
         },
 
         {
-            "name": "gcc7-release",
+            "name": "gcc-release",
             "inherits": [ "mixin-release", "gcc7-debug", "mixin-build-docs" ]
         },
 


### PR DESCRIPTION
the linux-release cmake preset uses a legacy build directory which doesnt work with our CI workflows.