### PR TITLE
config: add separate cache for stdout/remote sinks

### DIFF
--- a/SilKit/source/config/Configuration.hpp
+++ b/SilKit/source/config/Configuration.hpp
@@ -25,6 +25,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE. */
 #include <iostream>
 #include <stdexcept>
 #include <string>
+#include <tuple>
 #include <vector>
 
 #include "silkit/participant/exception.hpp"
@@ -219,7 +220,7 @@ bool operator==(const Sink& lhs, const Sink& rhs)
 
 bool operator<(const Sink& lhs, const Sink& rhs)
 {
-    return lhs.logName.compare(rhs.logName) < 0;
+    return std::make_tuple(lhs.type, lhs.logName) < std::make_tuple(rhs.type, rhs.logName);
 }
 
 bool operator>(const Sink& lhs, const Sink& rhs)

--- a/SilKit/source/config/TestParticipantConfigs/ParticipantConfiguration_FullIncludes.yaml
+++ b/SilKit/source/config/TestParticipantConfigs/ParticipantConfiguration_FullIncludes.yaml
@@ -140,6 +140,8 @@ Logging:
   - Type: File
     Level: Critical
     LogName: MyLog1
+  - Type: Remote
+    Level: Trace
   FlushLevel: Warn
   LogFromRemotes: false
 HealthCheck:

--- a/SilKit/source/config/TestParticipantConfigs/ParticipantConfiguration_FullIncludes_Reference.yaml
+++ b/SilKit/source/config/TestParticipantConfigs/ParticipantConfiguration_FullIncludes_Reference.yaml
@@ -160,6 +160,8 @@ Logging:
     LogName: MyLog1
   - Type: Stdout
     Level: Trace
+  - Type: Remote
+    Level: Trace
   - Type: File
     Level: Critical
     LogName: MyLog2

--- a/SilKit/source/config/Test_ParticipantConfiguration.cpp
+++ b/SilKit/source/config/Test_ParticipantConfiguration.cpp
@@ -207,6 +207,39 @@ CanControllers:
     ASSERT_TRUE(config == configRef);
 }
 
+TEST_F(Test_ParticipantConfiguration, participant_config_logging_sinks)
+{
+    const auto configString = R"raw(
+---
+Description: Example include configuration for CAN Controllers
+Includes:
+  Files:
+      - LoggingIncludes.yaml
+Logging:
+  Sinks:
+    - Type: Stdout
+      Level: Info
+CanControllers:
+- Name: CAN1
+  Replay:
+    UseTraceSource: Source1
+    Direction: Both
+    MdfChannel:
+      ChannelName: MyTestChannel1
+      ChannelPath: path/to/myTestChannel1
+      ChannelSource: MyTestChannel
+      GroupName: MyTestGroup
+      GroupPath: path/to/myTestGroup1
+      GroupSource: MyTestGroup
+  UseTraceSinks:
+  - Sink1
+- Name: MyCAN2
+  Network: CAN2
+    )raw";
+
+    EXPECT_THROW(SilKit::Config::ParticipantConfigurationFromStringImpl(configString), SilKit::ConfigurationError);
+}
+
 /*
     Test whether json and yaml configurations are parsed equivalently
 */


### PR DESCRIPTION
## Subject
The current implementation had a bug, which prohibited a user from adding a remote and a stdout sink at the same time to a participant. The bug was fixed by adding separate caches for each logging sink type.

## Instructions for review / testing
Build the CanDemo. Run the CanDemo with the folloging logging Config:

> Logging:
  Sinks:
    - Type: Remote
      Level: Trace
      LogName: CanWriterLog
    - Type: Stdout
      Level: Trace
      LogName: CanWriterLog

## Developer checklist (address before review)

- [ ] Changelog.md updated
- [ ] Prepared update for depending repositories
- [ ] Documentation updated (public API changes only)
- [ ] API docstrings updated (public API changes only)
- [ ] Rebase &rarr; commit history clean
- [ ] Squash and merge &rarr; proper PR title
