### PR TITLE
fixup: Shorten thread name

### DIFF
--- a/SilKit/source/services/orchestration/TimeSyncService.cpp
+++ b/SilKit/source/services/orchestration/TimeSyncService.cpp
@@ -671,7 +671,7 @@ void TimeSyncService::StartWallClockCouplingThread()
     _wallClockCouplingThreadRunning = true;
     _wallClockCouplingThread = std::thread{[this]() {
 
-        SilKit::Util::SetThreadName("SilKit-WallClockCoupling");
+        SilKit::Util::SetThreadName("SK-WallClockSync");
 
         const auto startTime = std::chrono::steady_clock::now();
         auto nextAnimatedWallClockSyncPoint = _timeConfiguration.NextSimStep().duration * _animationFactor;


### PR DESCRIPTION
Thread name should be 16 characters or less.