### PR TITLE
ci: add SilKitVersion.cmake to exceptions

### DIFF
--- a/SilKit/ci/check_files_changed.py
+++ b/SilKit/ci/check_files_changed.py
@@ -28,7 +28,8 @@ def die(status, fmt, *args):
     sys.exit(status)
 
 # File Set
-exceptional_files = {'README.rst', 'CHANGELOG.rst', 'LICENSE', 'CONTRIBUTING.md'}
+exceptional_files = {'README.rst', 'CHANGELOG.rst', 'LICENSE', 'CONTRIBUTING.md',
+                     'SilKitVersion.cmake'}
 
 parser = argparse.ArgumentParser(prog="JobStatusChecker",
                                  description="Check Job Status of a specific github workflow run")


### PR DESCRIPTION
## Description
Version bumps should not trigger a CI build.\

## Developer checklist (address before review)

- [ ] Changelog.md updated
- [ ] Prepared update for depending repositories
- [ ] Documentation updated (public API changes only)
- [ ] API docstrings updated (public API changes only)
- [ ] Rebase &rarr; commit history clean
- [ ] Squash and merge &rarr; proper PR title
