### PR TITLE
config: allow overriding rpc and pub/sub labels

### DIFF
--- a/SilKit/IntegrationTests/ITest_Internals_DataPubSub.cpp
+++ b/SilKit/IntegrationTests/ITest_Internals_DataPubSub.cpp
@@ -501,7 +501,7 @@ TEST_F(ITest_Internals_DataPubSub, test_1pub_1sub_sync_mixed_labels)
     RunSyncTest(pubsubs);
 }
 
-// Matching mandatory labels
+// Matching mandatory labels provided by a participant configuration
 TEST_F(ITest_Internals_DataPubSub, test_1pub_1sub_sync_label_override)
 {
     const uint32_t numMsgToPublish = defaultNumMsgToPublish;

--- a/SilKit/IntegrationTests/ITest_Internals_DataPubSub.cpp
+++ b/SilKit/IntegrationTests/ITest_Internals_DataPubSub.cpp
@@ -501,6 +501,60 @@ TEST_F(ITest_Internals_DataPubSub, test_1pub_1sub_sync_mixed_labels)
     RunSyncTest(pubsubs);
 }
 
+// Matching mandatory labels
+TEST_F(ITest_Internals_DataPubSub, test_1pub_1sub_sync_label_override)
+{
+    const uint32_t numMsgToPublish = defaultNumMsgToPublish;
+    const uint32_t numMsgToReceive = numMsgToPublish;
+
+    auto pub1Config = SilKit::Config::ParticipantConfigurationFromStringImpl(R"(
+DataPublishers:
+  - Name: PubCtrl1
+    Labels:
+      - Key: OverrideKeyA
+        Value: OverrideValueA
+        Kind: Optional
+      - Key: OverrideKeyB
+        Value: OverrideValueB
+        Kind: Mandatory
+)");
+
+    auto sub1Config = SilKit::Config::ParticipantConfigurationFromStringImpl(R"(
+DataSubscribers:
+  - Name: SubCtrl1
+    Labels:
+      - Key: OverrideKeyA
+        Value: OverrideValueA
+        Kind: Mandatory
+      - Key: OverrideKeyB
+        Value: OverrideValueB
+        Kind: Optional
+)");
+
+    std::vector<PubSubParticipant> pubsubs;
+    pubsubs.push_back({"Pub1",
+                       {{"PubCtrl1",
+                         "TopicA",
+                         {"A"},
+                         {{"kA", "vA", MatchingLabel::Kind::Mandatory}, {"kB", "vB", MatchingLabel::Kind::Mandatory}},
+                         0,
+                         defaultMsgSize,
+                         numMsgToPublish}},
+                       {},
+                       pub1Config});
+    pubsubs.push_back({"Sub1",
+                       {},
+                       {{"SubCtrl1",
+                         "TopicA",
+                         {"A"},
+                         {{"kA", "NOT vA", MatchingLabel::Kind::Mandatory}},
+                         defaultMsgSize,
+                         numMsgToReceive,
+                         1}},
+                       sub1Config});
+
+    RunSyncTest(pubsubs);
+}
 
 // Wrong mandatory label value -> Expect no reception
 TEST_F(ITest_Internals_DataPubSub, test_1pub_1sub_sync_wrong_mandatory_label_value)

--- a/SilKit/IntegrationTests/ITest_Internals_DataPubSub.hpp
+++ b/SilKit/IntegrationTests/ITest_Internals_DataPubSub.hpp
@@ -184,27 +184,27 @@ protected:
     struct PubSubParticipant
     {
         PubSubParticipant(const std::string& newName)
+            : PubSubParticipant(newName, {}, {})
         {
-            name = newName;
         }
         PubSubParticipant(const std::string& newName, const std::vector<DataPublisherInfo>& newDataPublishers,
                           const std::vector<DataSubscriberInfo>& newDataSubscribers,
                           std::shared_ptr<SilKit::Config::IParticipantConfiguration> newConfig =
                               SilKit::Config::MakeEmptyParticipantConfigurationImpl())
+            : config{std::move(newConfig)}
+            , name{newName}
+            , dataSubscribers{newDataSubscribers}
+            , dataPublishers{newDataPublishers}
         {
-            config = newConfig;
-            name = newName;
-            dataSubscribers = newDataSubscribers;
-            dataPublishers = newDataPublishers;
         }
 
-        std::shared_ptr<SilKit::Config::IParticipantConfiguration> config = MakeEmptyParticipantConfigurationImpl();
+        std::shared_ptr<SilKit::Config::IParticipantConfiguration> config;
         bool delayedDefaultDataHandler = false;
         std::string name;
         std::vector<DataSubscriberInfo> dataSubscribers;
         std::vector<DataPublisherInfo> dataPublishers;
         std::unique_ptr<SilKit::IParticipant> participant;
-        SilKit::Core::IParticipantInternal* participantImpl;
+        SilKit::Core::IParticipantInternal* participantImpl = nullptr;
 
         // Common
         std::promise<void> participantCreatedPromise;

--- a/SilKit/IntegrationTests/ITest_Internals_Rpc.cpp
+++ b/SilKit/IntegrationTests/ITest_Internals_Rpc.cpp
@@ -297,7 +297,7 @@ TEST_F(ITest_Internals_Rpc, test_1client_1server_sync_labels)
     RunSyncTest(rpcs);
 }
 
-// Matching mandatory and optional labels on both sides
+// Matching mandatory and optional labels on both sides provided by a participant configuration
 TEST_F(ITest_Internals_Rpc, test_1client_1server_sync_label_override)
 {
     const uint32_t numCallsToReceive = defaultNumCalls;

--- a/SilKit/IntegrationTests/ITest_Internals_Rpc.cpp
+++ b/SilKit/IntegrationTests/ITest_Internals_Rpc.cpp
@@ -24,6 +24,8 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE. */
 
 #include "ITest_Internals_Rpc.hpp"
 
+#include "ParticipantConfigurationFromXImpl.hpp"
+
 namespace {
 
 //--------------------------------------
@@ -291,6 +293,63 @@ TEST_F(ITest_Internals_Rpc, test_1client_1server_sync_labels)
                       numCallsToReceive}},
                     {},
                     {}});
+
+    RunSyncTest(rpcs);
+}
+
+// Matching mandatory and optional labels on both sides
+TEST_F(ITest_Internals_Rpc, test_1client_1server_sync_label_override)
+{
+    const uint32_t numCallsToReceive = defaultNumCalls;
+    const uint32_t numCallsToReturn = defaultNumCalls;
+
+    auto client1Config = SilKit::Config::ParticipantConfigurationFromStringImpl(R"(
+RpcClients:
+  - Name: ClientCtrl1
+    Labels:
+      - Key: OverrideKeyA
+        Value: OverrideValueA
+        Kind: Mandatory
+      - Key: OverrideKeyB
+        Value: OverrideValueB
+        Kind: Optional
+)");
+
+    auto server1Config = SilKit::Config::ParticipantConfigurationFromStringImpl(R"(
+RpcServers:
+  - Name: ServerCtrl1
+    Labels:
+      - Key: OverrideKeyA
+        Value: OverrideValueA
+        Kind: Optional
+      - Key: OverrideKeyB
+        Value: OverrideValueB
+        Kind: Mandatory
+)");
+
+    std::vector<RpcParticipant> rpcs;
+    rpcs.push_back({"Client1",
+                    {},
+                    {{"ClientCtrl1",
+                      "TestFuncA",
+                      "A",
+                      {{"KeyA", "ValA", SilKit::Services::MatchingLabel::Kind::Mandatory},
+                       {"KeyB", "ValB", SilKit::Services::MatchingLabel::Kind::Mandatory}},
+                      defaultMsgSize,
+                      defaultNumCalls,
+                      numCallsToReturn}},
+                    {"TestFuncA"},
+                    client1Config});
+    rpcs.push_back({"Server1",
+                    {{"ServerCtrl1",
+                      "TestFuncA",
+                      "A",
+                      {{"KeyA", "ValA2", SilKit::Services::MatchingLabel::Kind::Optional}},
+                      defaultMsgSize,
+                      numCallsToReceive}},
+                    {},
+                    {},
+                    server1Config});
 
     RunSyncTest(rpcs);
 }

--- a/SilKit/source/config/ParticipantConfiguration.cpp
+++ b/SilKit/source/config/ParticipantConfiguration.cpp
@@ -20,3 +20,65 @@ OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE. */
 
 #include "ParticipantConfiguration.hpp"
+
+#include <string>
+#include <type_traits>
+
+namespace SilKit {
+namespace Config {
+namespace v1 {
+
+auto Label::ToPublicApi() const -> SilKit::Services::MatchingLabel
+{
+    SilKit::Services::MatchingLabel result;
+
+    result.key = key;
+    result.value = value;
+
+    switch (kind)
+    {
+    case Kind::Mandatory:
+        result.kind = SilKit::Services::MatchingLabel::Kind::Mandatory;
+        break;
+    case Kind::Optional:
+        result.kind = SilKit::Services::MatchingLabel::Kind::Optional;
+        break;
+    default:
+        throw SilKit::ConfigurationError{
+            "Invalid SilKit::Config::v1::MatchingLabel::Kind("
+            + std::to_string(static_cast<std::underlying_type_t<Label::Kind>>(kind)) + ")"};
+    }
+
+    return result;
+}
+
+
+auto Label::FromPublicApi(const SilKit::Services::MatchingLabel& label) -> Label
+{
+    Label result;
+
+    result.key = label.key;
+    result.value = label.value;
+
+    switch (label.kind)
+    {
+    case SilKit::Services::MatchingLabel::Kind::Mandatory:
+        result.kind = Label::Kind::Mandatory;
+        break;
+    case SilKit::Services::MatchingLabel::Kind::Optional:
+        result.kind = Label::Kind::Optional;
+        break;
+    default:
+        throw SilKit::ConfigurationError{
+            "Invalid SilKit::Services::MatchingLabel::Kind("
+            + std::to_string(static_cast<std::underlying_type_t<SilKit::Services::MatchingLabel::Kind>>(label.kind))
+            + ")"};
+    }
+
+    return result;
+}
+
+
+} // namespace v1
+} // namespace Config
+} // namespace SilKit

--- a/SilKit/source/config/ParticipantConfiguration.cpp
+++ b/SilKit/source/config/ParticipantConfiguration.cpp
@@ -79,6 +79,14 @@ auto Label::FromPublicApi(const SilKit::Services::MatchingLabel& label) -> Label
 }
 
 
+auto Label::VectorFromPublicApi(const std::vector<SilKit::Services::MatchingLabel>& labels) -> std::vector<Label>
+{
+    std::vector<SilKit::Config::v1::Label> result;
+    std::transform(labels.begin(), labels.end(), std::back_inserter(result), Label::FromPublicApi);
+    return result;
+}
+
+
 } // namespace v1
 } // namespace Config
 } // namespace SilKit

--- a/SilKit/source/config/ParticipantConfiguration.hpp
+++ b/SilKit/source/config/ParticipantConfiguration.hpp
@@ -24,6 +24,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE. */
 #include <array>
 #include <chrono>
 #include <iostream>
+#include <ostream>
 #include <string>
 #include <vector>
 
@@ -32,6 +33,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE. */
 #include "silkit/services/logging/LoggingDatatypes.hpp"
 #include "silkit/services/pubsub/PubSubDatatypes.hpp"
 #include "silkit/services/rpc/RpcDatatypes.hpp"
+#include "silkit/services/datatypes.hpp"
 
 #include "Configuration.hpp"
 #include "Optional.hpp"
@@ -137,6 +139,26 @@ struct FlexrayController
 };
 
 // ================================================================================
+//  Labels for Data Publisher/Subscriber and Rpc Servcer/Client service
+// ================================================================================
+
+struct Label
+{
+    enum struct Kind
+    {
+        Optional,
+        Mandatory,
+    };
+
+    std::string key;
+    std::string value;
+    Kind kind;
+
+    auto ToPublicApi() const -> SilKit::Services::MatchingLabel;
+    static auto FromPublicApi(const SilKit::Services::MatchingLabel& label) -> Label;
+};
+
+// ================================================================================
 //  Data Publisher/Subscriber service
 // ================================================================================
 
@@ -150,6 +172,7 @@ struct DataPublisher
 
     std::string name;
     SilKit::Util::Optional<std::string> topic;
+    SilKit::Util::Optional<std::vector<Label>> labels;
 
     //! \brief History length of a DataPublisher.
     SilKit::Util::Optional<size_t> history{0};
@@ -168,6 +191,7 @@ struct DataSubscriber
 
     std::string name;
     SilKit::Util::Optional<std::string> topic;
+    SilKit::Util::Optional<std::vector<Label>> labels;
 
     std::vector<std::string> useTraceSinks;
     Replay replay;
@@ -187,6 +211,7 @@ struct RpcServer
 
     std::string name;
     SilKit::Util::Optional<std::string> functionName;
+    SilKit::Util::Optional<std::vector<Label>> labels;
 
     std::vector<std::string> useTraceSinks;
     Replay replay;
@@ -202,6 +227,7 @@ struct RpcClient
 
     std::string name;
     SilKit::Util::Optional<std::string> functionName;
+    SilKit::Util::Optional<std::vector<Label>> labels;
 
     std::vector<std::string> useTraceSinks;
     Replay replay;
@@ -368,6 +394,10 @@ bool operator==(const Middleware& lhs, const Middleware& rhs);
 bool operator==(const ParticipantConfiguration& lhs, const ParticipantConfiguration& rhs);
 bool operator==(const TimeSynchronization& lhs, const TimeSynchronization& rhs);
 bool operator==(const Experimental& lhs, const Experimental& rhs);
+bool operator==(const Label& lhs, const Label& rhs);
+
+auto operator<<(std::ostream& out, const Label::Kind& kind) -> std::ostream&;
+auto operator<<(std::ostream& out, const Label& label) -> std::ostream&;
 
 bool operator<(const MetricsSink& lhs, const MetricsSink& rhs);
 bool operator>(const MetricsSink& lhs, const MetricsSink& rhs);

--- a/SilKit/source/config/ParticipantConfiguration.hpp
+++ b/SilKit/source/config/ParticipantConfiguration.hpp
@@ -156,6 +156,7 @@ struct Label
 
     auto ToPublicApi() const -> SilKit::Services::MatchingLabel;
     static auto FromPublicApi(const SilKit::Services::MatchingLabel& label) -> Label;
+    static auto VectorFromPublicApi(const std::vector<SilKit::Services::MatchingLabel>& labels) -> std::vector<Label>;
 };
 
 // ================================================================================

--- a/SilKit/source/config/ParticipantConfiguration.schema.json
+++ b/SilKit/source/config/ParticipantConfiguration.schema.json
@@ -414,6 +414,31 @@
       "type": "string",
       "description": "Name of the RPC function called by RpcClients on RpcServers"
     },
+    "MatchingLabel": {
+      "type": "object",
+      "properties": {
+        "Key": {
+          "type": "string",
+          "description": "Label key"
+        },
+        "Value": {
+          "type": "string",
+          "description": "Label value"
+        },
+        "Kind": {
+          "type": "string",
+          "description": "Label kind",
+          "enum": ["Mandatory", "Optional"]
+        }
+      }
+    },
+    "Labels": {
+      "type": "array",
+      "description": "Override the matching labels assigned to the controller",
+      "items": {
+        "$ref": "#/definitions/MatchingLabel"
+      }
+    },
     "Logging": {
       "type": "object",
       "description": "Configures the properties of the SIL Kit Logging Service",
@@ -573,6 +598,9 @@
           },
           "Topic": {
             "$ref": "#/definitions/Topic"
+          },
+          "Labels": {
+            "$ref": "#/definitions/Labels"
           }
         },
         "additionalProperties": false,
@@ -590,6 +618,9 @@
           },
           "Topic": {
             "$ref": "#/definitions/Topic"
+          },
+          "Labels": {
+            "$ref": "#/definitions/Labels"
           }
         },
         "additionalProperties": false,
@@ -607,6 +638,9 @@
           },
           "FunctionName": {
             "$ref": "#/definitions/RpcFunctionName"
+          },
+          "Labels": {
+            "$ref": "#/definitions/Labels"
           }
         },
         "additionalProperties": false,
@@ -624,6 +658,9 @@
           },
           "FunctionName": {
             "$ref": "#/definitions/RpcFunctionName"
+          },
+          "Labels": {
+            "$ref": "#/definitions/Labels"
           }
         },
         "additionalProperties": false,

--- a/SilKit/source/config/ParticipantConfigurationFromXImpl.cpp
+++ b/SilKit/source/config/ParticipantConfigurationFromXImpl.cpp
@@ -813,6 +813,29 @@ bool operator>(const MetricsSink& lhs, const MetricsSink& rhs)
     return !(lhs < rhs);
 }
 
+bool operator==(const Label& lhs, const Label& rhs)
+{
+    return lhs.key == rhs.key && lhs.value == rhs.value && lhs.kind == rhs.kind;
+}
+
+auto operator<<(std::ostream& out, const Label::Kind& kind) -> std::ostream&
+{
+    switch (kind)
+    {
+    case Label::Kind::Mandatory:
+        return out << "Mandatory";
+    case Label::Kind::Optional:
+        return out << "Optional";
+    default:
+        return out << "MatchingLabel::Kind(" << static_cast<std::underlying_type_t<Label::Kind>>(kind) << ")";
+    }
+}
+
+auto operator<<(std::ostream& out, const Label& label) -> std::ostream&
+{
+    return out << "MatchingLabel{" << label.key << ", " << label.value << ", " << label.kind << "}";
+}
+
 } // namespace v1
 
 

--- a/SilKit/source/config/ParticipantConfiguration_Full.json
+++ b/SilKit/source/config/ParticipantConfiguration_Full.json
@@ -150,6 +150,13 @@
     {
       "Name": "Publisher1",
       "Topic": "Temperature",
+      "Labels": [
+        {
+          "Key": "A",
+          "Value": "B",
+          "Kind": "Optional"
+        }
+      ],
       "UseTraceSinks": [
         "Sink1"
       ]
@@ -159,6 +166,13 @@
     {
       "Name": "Subscriber1",
       "Topic": "Temperature",
+      "Labels": [
+        {
+          "Key": "C",
+          "Value": "D",
+          "Kind": "Mandatory"
+        }
+      ],
       "UseTraceSinks": [
         "Sink1"
       ]
@@ -168,6 +182,13 @@
     {
       "Name": "Server1",
       "FunctionName": "Function1",
+      "Labels": [
+        {
+          "Key": "E",
+          "Value": "F",
+          "Kind": "Optional"
+        }
+      ],
       "UseTraceSinks": [
         "Sink1"
       ]
@@ -177,6 +198,13 @@
     {
       "Name": "Client1",
       "FunctionName": "Function1",
+      "Labels": [
+        {
+          "Key": "G",
+          "Value": "H",
+          "Kind": "Mandatory"
+        }
+      ],
       "UseTraceSinks": [
         "Sink1"
       ]

--- a/SilKit/source/config/ParticipantConfiguration_Full.yaml
+++ b/SilKit/source/config/ParticipantConfiguration_Full.yaml
@@ -117,21 +117,37 @@ FlexrayControllers:
 DataPublishers:
 - Name: Publisher1
   Topic: Temperature
+  Labels:
+    - Key: A
+      Value: B
+      Kind: Optional
   UseTraceSinks:
   - Sink1
 DataSubscribers:
 - Name: Subscriber1
   Topic: Temperature
+  Labels:
+    - Key: C
+      Value: D
+      Kind: Mandatory
   UseTraceSinks:
   - Sink1
 RpcServers:
 - Name: Server1
   FunctionName: Function1
+  Labels:
+    - Key: E
+      Value: F
+      Kind: Optional
   UseTraceSinks:
   - Sink1
 RpcClients:
 - Name: Client1
   FunctionName: Function1
+  Labels:
+    - Key: G
+      Value: H
+      Kind: Mandatory
   UseTraceSinks:
   - Sink1
 Logging:

--- a/SilKit/source/config/SilKitYamlHelper.hpp
+++ b/SilKit/source/config/SilKitYamlHelper.hpp
@@ -158,6 +158,18 @@ void optional_encode(const SilKit::Util::Optional<ConfigT>& value, YAML::Node& n
     }
 }
 
+template <typename ConfigT,
+          typename std::enable_if<!(std::is_fundamental<ConfigT>::value || std::is_same<ConfigT, std::string>::value),
+                                  bool>::type = true>
+void optional_encode(const SilKit::Util::Optional<std::vector<ConfigT>>& value, YAML::Node& node,
+                     const std::string& fieldName)
+{
+    if (value.has_value())
+    {
+        node[fieldName] = value.value();
+    }
+}
+
 template <typename ConfigT>
 void optional_encode(const std::vector<ConfigT>& value, YAML::Node& node, const std::string& fieldName)
 {

--- a/SilKit/source/config/YamlConversion.hpp
+++ b/SilKit/source/config/YamlConversion.hpp
@@ -62,8 +62,12 @@ DEFINE_SILKIT_CONVERT(SilKit::Services::Flexray::FlexrayClockPeriod);
 DEFINE_SILKIT_CONVERT(SilKit::Services::Flexray::FlexrayTransmissionMode);
 DEFINE_SILKIT_CONVERT(FlexrayController);
 
+// Conversions for ServiceDiscovery Supplemental Data
 DEFINE_SILKIT_CONVERT(SilKit::Services::MatchingLabel::Kind);
 DEFINE_SILKIT_CONVERT(SilKit::Services::MatchingLabel);
+
+DEFINE_SILKIT_CONVERT(Label::Kind);
+DEFINE_SILKIT_CONVERT(Label);
 DEFINE_SILKIT_CONVERT(DataPublisher);
 DEFINE_SILKIT_CONVERT(DataSubscriber);
 DEFINE_SILKIT_CONVERT(RpcServer);

--- a/SilKit/source/config/YamlSchema.cpp
+++ b/SilKit/source/config/YamlSchema.cpp
@@ -157,6 +157,7 @@ auto MakeYamlSchema() -> YamlSchemaElem
          {
              {"Name"},
              {"Topic"},
+             {"Labels"},
              {"UseTraceSinks"},
              replay,
          }},
@@ -164,6 +165,7 @@ auto MakeYamlSchema() -> YamlSchemaElem
          {
              {"Name"},
              {"Topic"},
+             {"Labels"},
              {"UseTraceSinks"},
              replay,
          }},
@@ -171,6 +173,7 @@ auto MakeYamlSchema() -> YamlSchemaElem
          {
              {"Name"},
              {"FunctionName"},
+             {"Labels"},
              {"UseTraceSinks"},
              replay,
          }},
@@ -178,6 +181,7 @@ auto MakeYamlSchema() -> YamlSchemaElem
          {
              {"Name"},
              {"FunctionName"},
+             {"Labels"},
              {"UseTraceSinks"},
              replay,
          }},

--- a/SilKit/source/core/participant/Participant.hpp
+++ b/SilKit/source/core/participant/Participant.hpp
@@ -406,6 +406,10 @@ private:
     void LogMismatchBetweenConfigAndPassedValue(const std::string& controllerName, const ValueT& passedValue,
                                                 const ValueT& configuredValue);
 
+    template <typename ValueT>
+    void LogMismatchBetweenConfigAndPassedValue(const std::string& controllerName, const std::vector<ValueT>& passedValue,
+                                                const std::vector<ValueT>& configuredValue);
+
     void OnSilKitSimulationJoined();
 
     void SetupRemoteLogging();

--- a/SilKit/source/core/participant/Participant_impl.hpp
+++ b/SilKit/source/core/participant/Participant_impl.hpp
@@ -513,14 +513,6 @@ static inline auto FormatLabelsForLogging(const std::vector<MatchingLabel>& labe
     return os.str();
 }
 
-static inline auto PublicApiToConfigLabels(const std::vector<SilKit::Services::MatchingLabel>& labels)
-    -> std::vector<SilKit::Config::v1::Label>
-{
-    std::vector<SilKit::Config::v1::Label> result;
-    std::transform(labels.begin(), labels.end(), std::back_inserter(result), SilKit::Config::v1::Label::FromPublicApi);
-    return result;
-}
-
 template <class SilKitConnectionT>
 auto Participant<SilKitConnectionT>::CreateDataPublisher(const std::string& canonicalName,
                                                          const SilKit::Services::PubSub::PubSubSpec& dataSpec,
@@ -537,7 +529,8 @@ auto Participant<SilKitConnectionT>::CreateDataPublisher(const std::string& cano
     SilKit::Config::DataPublisher controllerConfig =
         GetConfigByControllerName(_participantConfig.dataPublishers, canonicalName);
     UpdateOptionalConfigValue(canonicalName, controllerConfig.topic, dataSpec.Topic());
-    UpdateOptionalConfigValue(canonicalName, controllerConfig.labels, PublicApiToConfigLabels(dataSpec.Labels()));
+    UpdateOptionalConfigValue(canonicalName, controllerConfig.labels,
+                              SilKit::Config::v1::Label::VectorFromPublicApi(dataSpec.Labels()));
 
     auto sortedConfigLabels = controllerConfig.labels.value();
     std::sort(sortedConfigLabels.begin(), sortedConfigLabels.end(),
@@ -602,7 +595,8 @@ auto Participant<SilKitConnectionT>::CreateDataSubscriber(
     SilKit::Config::DataSubscriber controllerConfig =
         GetConfigByControllerName(_participantConfig.dataSubscribers, canonicalName);
     UpdateOptionalConfigValue(canonicalName, controllerConfig.topic, dataSpec.Topic());
-    UpdateOptionalConfigValue(canonicalName, controllerConfig.labels, PublicApiToConfigLabels(dataSpec.Labels()));
+    UpdateOptionalConfigValue(canonicalName, controllerConfig.labels,
+                              SilKit::Config::v1::Label::VectorFromPublicApi(dataSpec.Labels()));
 
     auto sortedConfigLabels = controllerConfig.labels.value();
     std::sort(sortedConfigLabels.begin(), sortedConfigLabels.end(),
@@ -687,7 +681,8 @@ auto Participant<SilKitConnectionT>::CreateRpcClient(
     SilKit::Config::RpcClient controllerConfig =
         GetConfigByControllerName(_participantConfig.rpcClients, canonicalName);
     UpdateOptionalConfigValue(canonicalName, controllerConfig.functionName, dataSpec.FunctionName());
-    UpdateOptionalConfigValue(canonicalName, controllerConfig.labels, PublicApiToConfigLabels(dataSpec.Labels()));
+    UpdateOptionalConfigValue(canonicalName, controllerConfig.labels,
+                              SilKit::Config::v1::Label::VectorFromPublicApi(dataSpec.Labels()));
 
     auto sortedConfigLabels = controllerConfig.labels.value();
     std::sort(sortedConfigLabels.begin(), sortedConfigLabels.end(),
@@ -740,7 +735,8 @@ auto Participant<SilKitConnectionT>::CreateRpcServer(
     SilKit::Config::RpcServer controllerConfig =
         GetConfigByControllerName(_participantConfig.rpcServers, canonicalName);
     UpdateOptionalConfigValue(canonicalName, controllerConfig.functionName, dataSpec.FunctionName());
-    UpdateOptionalConfigValue(canonicalName, controllerConfig.labels, PublicApiToConfigLabels(dataSpec.Labels()));
+    UpdateOptionalConfigValue(canonicalName, controllerConfig.labels,
+                              SilKit::Config::v1::Label::VectorFromPublicApi(dataSpec.Labels()));
 
     auto sortedConfigLabels = controllerConfig.labels.value();
     std::sort(sortedConfigLabels.begin(), sortedConfigLabels.end(),

--- a/SilKit/source/core/participant/Participant_impl.hpp
+++ b/SilKit/source/core/participant/Participant_impl.hpp
@@ -513,6 +513,14 @@ static inline auto FormatLabelsForLogging(const std::vector<MatchingLabel>& labe
     return os.str();
 }
 
+static inline auto PublicApiToConfigLabels(const std::vector<SilKit::Services::MatchingLabel>& labels)
+    -> std::vector<SilKit::Config::v1::Label>
+{
+    std::vector<SilKit::Config::v1::Label> result;
+    std::transform(labels.begin(), labels.end(), std::back_inserter(result), SilKit::Config::v1::Label::FromPublicApi);
+    return result;
+}
+
 template <class SilKitConnectionT>
 auto Participant<SilKitConnectionT>::CreateDataPublisher(const std::string& canonicalName,
                                                          const SilKit::Services::PubSub::PubSubSpec& dataSpec,
@@ -529,13 +537,16 @@ auto Participant<SilKitConnectionT>::CreateDataPublisher(const std::string& cano
     SilKit::Config::DataPublisher controllerConfig =
         GetConfigByControllerName(_participantConfig.dataPublishers, canonicalName);
     UpdateOptionalConfigValue(canonicalName, controllerConfig.topic, dataSpec.Topic());
+    UpdateOptionalConfigValue(canonicalName, controllerConfig.labels, PublicApiToConfigLabels(dataSpec.Labels()));
+
+    auto sortedConfigLabels = controllerConfig.labels.value();
+    std::sort(sortedConfigLabels.begin(), sortedConfigLabels.end(),
+              [](const auto& v1, const auto& v2) { return v1.key < v2.key; });
+
     SilKit::Services::PubSub::PubSubSpec configuredDataNodeSpec{controllerConfig.topic.value(), dataSpec.MediaType()};
-    auto labels = dataSpec.Labels();
-    std::sort(labels.begin(), labels.end(),
-              [](const MatchingLabel& v1, const MatchingLabel& v2) { return v1.key < v2.key; });
-    for (auto label : labels)
+    for (const auto& label : sortedConfigLabels)
     {
-        configuredDataNodeSpec.AddLabel(label);
+        configuredDataNodeSpec.AddLabel(label.ToPublicApi());
     }
 
     SilKit::Core::SupplementalData supplementalData;
@@ -543,8 +554,8 @@ auto Participant<SilKitConnectionT>::CreateDataPublisher(const std::string& cano
     supplementalData[SilKit::Core::Discovery::supplKeyDataPublisherTopic] = configuredDataNodeSpec.Topic();
     supplementalData[SilKit::Core::Discovery::supplKeyDataPublisherPubUUID] = network;
     supplementalData[SilKit::Core::Discovery::supplKeyDataPublisherMediaType] = configuredDataNodeSpec.MediaType();
-    auto labelStr = SilKit::Config::Serialize<std::decay_t<decltype(labels)>>(labels);
-    supplementalData[SilKit::Core::Discovery::supplKeyDataPublisherPubLabels] = labelStr;
+    supplementalData[SilKit::Core::Discovery::supplKeyDataPublisherPubLabels] =
+        SilKit::Config::Serialize(configuredDataNodeSpec.Labels());
 
     auto controller = CreateController<Services::PubSub::DataPublisher>(
         controllerConfig, network, std::move(supplementalData), true, true, &_timeProvider, configuredDataNodeSpec,
@@ -559,7 +570,7 @@ auto Participant<SilKitConnectionT>::CreateDataPublisher(const std::string& cano
             "Created DataPublisher '{}' with topic '{}' and media type '{}' for network '{}' with service name "
             "'{}' and labels: {}",
             controllerConfig.name, controllerConfig.topic.value(), dataSpec.MediaType(), network,
-            controller->GetServiceDescriptor().to_string(), FormatLabelsForLogging(dataSpec.Labels()));
+            controller->GetServiceDescriptor().to_string(), FormatLabelsForLogging(configuredDataNodeSpec.Labels()));
     }
 
     auto* traceSource = dynamic_cast<ITraceMessageSource*>(controller);
@@ -591,22 +602,24 @@ auto Participant<SilKitConnectionT>::CreateDataSubscriber(
     SilKit::Config::DataSubscriber controllerConfig =
         GetConfigByControllerName(_participantConfig.dataSubscribers, canonicalName);
     UpdateOptionalConfigValue(canonicalName, controllerConfig.topic, dataSpec.Topic());
+    UpdateOptionalConfigValue(canonicalName, controllerConfig.labels, PublicApiToConfigLabels(dataSpec.Labels()));
+
+    auto sortedConfigLabels = controllerConfig.labels.value();
+    std::sort(sortedConfigLabels.begin(), sortedConfigLabels.end(),
+              [](const auto& v1, const auto& v2) { return v1.key < v2.key; });
 
     SilKit::Services::PubSub::PubSubSpec configuredDataNodeSpec{controllerConfig.topic.value(), dataSpec.MediaType()};
-    auto labels = dataSpec.Labels();
-    std::sort(labels.begin(), labels.end(),
-              [](const MatchingLabel& v1, const MatchingLabel& v2) { return v1.key < v2.key; });
-    for (auto label : labels)
+    for (const auto& label : sortedConfigLabels)
     {
-        configuredDataNodeSpec.AddLabel(label);
+        configuredDataNodeSpec.AddLabel(label.ToPublicApi());
     }
 
     Core::SupplementalData supplementalData;
     supplementalData[SilKit::Core::Discovery::controllerType] = SilKit::Core::Discovery::controllerTypeDataSubscriber;
     supplementalData[SilKit::Core::Discovery::supplKeyDataSubscriberTopic] = configuredDataNodeSpec.Topic();
     supplementalData[SilKit::Core::Discovery::supplKeyDataSubscriberMediaType] = configuredDataNodeSpec.MediaType();
-    auto labelStr = SilKit::Config::Serialize<std::decay_t<decltype(labels)>>(labels);
-    supplementalData[SilKit::Core::Discovery::supplKeyDataSubscriberSubLabels] = labelStr;
+    supplementalData[SilKit::Core::Discovery::supplKeyDataSubscriberSubLabels] =
+        SilKit::Config::Serialize(configuredDataNodeSpec.Labels());
 
     auto controller = CreateController<Services::PubSub::DataSubscriber>(
         controllerConfig, network, std::move(supplementalData), true, true, controllerConfig, &_timeProvider,
@@ -621,7 +634,7 @@ auto Participant<SilKitConnectionT>::CreateDataSubscriber(
             "Created DataSubscriber '{}' with topic '{}' and media type '{}' for network '{}' with service name "
             "'{}' and labels: {}",
             controllerConfig.name, controllerConfig.topic.value(), dataSpec.MediaType(), network,
-            controller->GetServiceDescriptor().to_string(), FormatLabelsForLogging(dataSpec.Labels()));
+            controller->GetServiceDescriptor().to_string(), FormatLabelsForLogging(configuredDataNodeSpec.Labels()));
     }
 
     auto* traceSource = dynamic_cast<ITraceMessageSource*>(controller);
@@ -674,26 +687,30 @@ auto Participant<SilKitConnectionT>::CreateRpcClient(
     SilKit::Config::RpcClient controllerConfig =
         GetConfigByControllerName(_participantConfig.rpcClients, canonicalName);
     UpdateOptionalConfigValue(canonicalName, controllerConfig.functionName, dataSpec.FunctionName());
+    UpdateOptionalConfigValue(canonicalName, controllerConfig.labels, PublicApiToConfigLabels(dataSpec.Labels()));
+
+    auto sortedConfigLabels = controllerConfig.labels.value();
+    std::sort(sortedConfigLabels.begin(), sortedConfigLabels.end(),
+              [](const auto& v1, const auto& v2) { return v1.key < v2.key; });
+
+    SilKit::Services::Rpc::RpcSpec configuredRpcSpec{controllerConfig.functionName.value(), dataSpec.MediaType()};
+    for (const auto& label : sortedConfigLabels)
+    {
+        configuredRpcSpec.AddLabel(label.ToPublicApi());
+    }
 
     // RpcClient gets discovered by RpcServer which creates RpcServerInternal on a matching connection
     Core::SupplementalData supplementalData;
     supplementalData[SilKit::Core::Discovery::controllerType] = SilKit::Core::Discovery::controllerTypeRpcClient;
     supplementalData[SilKit::Core::Discovery::supplKeyRpcClientFunctionName] = controllerConfig.functionName.value();
     supplementalData[SilKit::Core::Discovery::supplKeyRpcClientMediaType] = dataSpec.MediaType();
-    const auto& labels = dataSpec.Labels();
-    auto labelStr = SilKit::Config::Serialize<std::decay_t<decltype(labels)>>(labels);
-    supplementalData[SilKit::Core::Discovery::supplKeyRpcClientLabels] = labelStr;
+    supplementalData[SilKit::Core::Discovery::supplKeyRpcClientLabels] =
+        SilKit::Config::Serialize(configuredRpcSpec.Labels());
     supplementalData[SilKit::Core::Discovery::supplKeyRpcClientUUID] = network;
-
-    SilKit::Services::Rpc::RpcSpec configuredDataSpec{controllerConfig.functionName.value(), dataSpec.MediaType()};
-    for (auto label : dataSpec.Labels())
-    {
-        configuredDataSpec.AddLabel(label);
-    }
 
     auto controller =
         CreateController<Services::Rpc::RpcClient>(controllerConfig, network, std::move(supplementalData), true, true,
-                                                   &_timeProvider, configuredDataSpec, network, handler);
+                                                   &_timeProvider, configuredRpcSpec, network, handler);
 
     // RpcClient discovers RpcServerInternal and is ready to dispatch calls
     controller->RegisterServiceDiscovery();
@@ -723,24 +740,28 @@ auto Participant<SilKitConnectionT>::CreateRpcServer(
     SilKit::Config::RpcServer controllerConfig =
         GetConfigByControllerName(_participantConfig.rpcServers, canonicalName);
     UpdateOptionalConfigValue(canonicalName, controllerConfig.functionName, dataSpec.FunctionName());
+    UpdateOptionalConfigValue(canonicalName, controllerConfig.labels, PublicApiToConfigLabels(dataSpec.Labels()));
+
+    auto sortedConfigLabels = controllerConfig.labels.value();
+    std::sort(sortedConfigLabels.begin(), sortedConfigLabels.end(),
+              [](const auto& v1, const auto& v2) { return v1.key < v2.key; });
+
+    SilKit::Services::Rpc::RpcSpec configuredRpcSpec{controllerConfig.functionName.value(), dataSpec.MediaType()};
+    for (const auto& label : sortedConfigLabels)
+    {
+        configuredRpcSpec.AddLabel(label.ToPublicApi());
+    }
 
     Core::SupplementalData supplementalData;
     supplementalData[SilKit::Core::Discovery::controllerType] = SilKit::Core::Discovery::controllerTypeRpcServer;
     // Needed for RpcServer discovery in tests
     supplementalData[SilKit::Core::Discovery::supplKeyRpcServerFunctionName] = controllerConfig.functionName.value();
     supplementalData[SilKit::Core::Discovery::supplKeyRpcServerMediaType] = dataSpec.MediaType();
-    const auto& labels = dataSpec.Labels();
-    auto labelStr = SilKit::Config::Serialize<std::decay_t<decltype(labels)>>(labels);
-    supplementalData[SilKit::Core::Discovery::supplKeyRpcServerLabels] = labelStr;
-
-    SilKit::Services::Rpc::RpcSpec configuredDataSpec{controllerConfig.functionName.value(), dataSpec.MediaType()};
-    for (auto label : dataSpec.Labels())
-    {
-        configuredDataSpec.AddLabel(label);
-    }
+    supplementalData[SilKit::Core::Discovery::supplKeyRpcServerLabels] =
+        SilKit::Config::Serialize(configuredRpcSpec.Labels());
 
     auto controller = CreateController<Services::Rpc::RpcServer>(controllerConfig, network, supplementalData, true,
-                                                                 true, &_timeProvider, configuredDataSpec, handler);
+                                                                 true, &_timeProvider, configuredRpcSpec, handler);
 
     // RpcServer discovers RpcClient and creates RpcServerInternal on a matching connection
     controller->RegisterServiceDiscovery();
@@ -1818,6 +1839,22 @@ void Participant<SilKitConnectionT>::LogMismatchBetweenConfigAndPassedValue(cons
        << "Controller name: " << canonicalName << std::endl
        << "Passed value: " << passedValue << std::endl
        << "Configured value: " << configuredValue << std::endl;
+
+    _logger->Info(ss.str());
+}
+
+template <class SilKitConnectionT>
+template <typename ValueT>
+void Participant<SilKitConnectionT>::LogMismatchBetweenConfigAndPassedValue(const std::string& canonicalName,
+                                                                            const std::vector<ValueT>& passedValue,
+                                                                            const std::vector<ValueT>& configuredValue)
+{
+    std::stringstream ss;
+    ss << "Mismatch between a configured and programmatically passed value. The configured value will be used."
+       << std::endl
+       << "Controller name: " << canonicalName << std::endl
+       << "Passed value: " << fmt::format("{}", fmt::join(passedValue, ", ")) << std::endl
+       << "Configured value: " << fmt::format("{}", fmt::join(configuredValue, ", ")) << std::endl;
 
     _logger->Info(ss.str());
 }

--- a/SilKit/source/services/logging/SilKitFmtFormatters.hpp
+++ b/SilKit/source/services/logging/SilKitFmtFormatters.hpp
@@ -49,6 +49,8 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE. */
 #include "WireRpcMessages.hpp"
 #include "WireDataMessages.hpp"
 
+#include "ParticipantConfiguration.hpp"
+
 #include "TestDataTypes.hpp" // for operator<<
 #include "IServiceEndpoint.hpp" // for operator<<(... ServiceDescriptor)
 
@@ -112,6 +114,11 @@ MAKE_FORMATTER(SilKit::Services::PubSub::WireDataMessageEvent);
 MAKE_FORMATTER(SilKit::Services::Rpc::FunctionCall);
 MAKE_FORMATTER(SilKit::Services::Rpc::FunctionCallResponse);
 
+MAKE_FORMATTER(SilKit::Services::MatchingLabel::Kind);
+MAKE_FORMATTER(SilKit::Services::MatchingLabel);
+
+MAKE_FORMATTER(SilKit::Config::v1::Label::Kind);
+MAKE_FORMATTER(SilKit::Config::v1::Label);
 
 MAKE_FORMATTER(SilKit::Core::ServiceDescriptor);
 MAKE_FORMATTER(SilKit::Core::ProtocolVersion);

--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -9,6 +9,11 @@ The format is based on `Keep a Changelog (http://keepachangelog.com/en/1.0.0/) <
 [4.0.54] - Unreleased
 ---------------------
 
+Added
+~~~~~
+
+- Override the labels of ``DataPublisher``, ``DataSubscriber``, ``RpcClient``, and ``RpcServer`` instances through the participant configuration, extending the already possible override of the topic / function name.
+
 Changed
 ~~~~~~~
 

--- a/docs/configuration/services-configuration.rst
+++ b/docs/configuration/services-configuration.rst
@@ -135,6 +135,13 @@ DataPublishers
   DataPublishers: 
   - Name: DataPublisher1
     Topic: SomeTopic1
+    Labels:
+      - Key: SomeKey
+        Value: SomeValue
+        Kind: Mandatory
+      - Key: AnotherKey
+        Value: AnotherValue
+        Kind: Optional
 
 
 .. list-table:: DataPublisher Configuration
@@ -147,6 +154,8 @@ DataPublishers
      - The name of the data publisher.
    * - Topic
      - The topic on which the data publisher publishes its information. (optional)
+   * - Labels
+     - The labels determining matching subscribers with the same topic and media type. (optional)
 
 
 .. _sec:cfg-participant-data-subscribers:
@@ -159,6 +168,13 @@ DataSubscribers
   DataSubscribers: 
   - Name: DataSubscriber1
     Topic: SomeTopic1
+    Labels:
+      - Key: SomeKey
+        Value: SomeValue
+        Kind: Mandatory
+      - Key: AnotherKey
+        Value: AnotherValue
+        Kind: Optional
 
 
 .. list-table:: DataSubscriber Configuration
@@ -171,6 +187,8 @@ DataSubscribers
      - The name of the data subscriber.
    * - Topic
      - The topic on which the data subscriber publishes its information. (optional)
+   * - Labels
+     - The labels determining matching publishers with the same topic and media type. (optional)
 
 
 .. _sec:cfg-participant-rpc-servers:
@@ -184,6 +202,13 @@ RpcServers
   RpcServers:
   - Name: RpcServer1
     FunctionName: SomeFunction1
+    Labels:
+      - Key: SomeKey
+        Value: SomeValue
+        Kind: Mandatory
+      - Key: AnotherKey
+        Value: AnotherValue
+        Kind: Optional
 
 
 .. list-table:: RPC Server Configuration
@@ -196,6 +221,8 @@ RpcServers
      - The name of the RPC server.
    * - FunctionName
      - The function name on which the RPC server offers its service. (optional)
+   * - Labels
+     - The labels determining matching clients with the same function name and media type. (optional)
 
 
 .. _sec:cfg-participant-rpc-clients:
@@ -208,6 +235,13 @@ RpcClients
   RpcClients: 
   - Name: RpcClient1
     FunctionName: SomeFunction1
+    Labels:
+      - Key: SomeKey
+        Value: SomeValue
+        Kind: Mandatory
+      - Key: AnotherKey
+        Value: AnotherValue
+        Kind: Optional
 
 
 .. list-table:: RPC Clients Configuration
@@ -220,3 +254,5 @@ RpcClients
      - The name of the RPC client.
    * - FunctionName
      - The function name to which the RPC client wants to connect to. (optional)
+   * - Labels
+     - The labels determining matching servers with the same function name and media type. (optional)

--- a/docs/configuration/services-configuration.rst
+++ b/docs/configuration/services-configuration.rst
@@ -156,6 +156,7 @@ DataPublishers
      - The topic on which the data publisher publishes its information. (optional)
    * - Labels
      - The labels determining matching subscribers with the same topic and media type. (optional)
+        Note that these labels will replace all programmatically provided labels.
 
 
 .. _sec:cfg-participant-data-subscribers:


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2023 Vector Informatik GmbH

SPDX-License-Identifier: MIT
-->

## Subject
<!--
    - What kind of changes does this pull request comprise?
    - Add a label like "Bugfix", "docs", etc. to this PR to give context.
 -->

This PR implements an extension to the participant configuration that allows to override the labels of `DataPublisher`, `DataSubscriber`, `RpcClient`, and `RpcServer` controllers in the participant configuration.

The format (all other controllers analogous) is like this:

```yaml
RpcClients:
  - Name: MyRpcController
    Labels:
      - Key: SomeKey
        Value: SomeValue
        Kind: Mandatory
      - Key: AnotherKey
        Value: AnotherValue
        Kind: Optional
```

The labels **completely replace** what is specified in the code.

This is just a proposal to play around with, it is not neccessarily the final form.

JIRA Issue SILKIT-1636

## Instructions for review / testing
<!--
    - Hilight some of the important changes, which reviewers should focus on
    - Which parts should be reviewed in detail? For example: content of console output, correct semantics of changes
    - Test steps and test setup description. For example: which programs or configs to use
-->

## Developer checklist (address before review)

- [x] Changelog.md updated
- [ ] Prepared update for depending repositories
- [x] Documentation updated (public API changes only)
- [ ] API docstrings updated (public API changes only)
- [ ] Rebase &rarr; commit history clean
- [x] Squash and merge &rarr; proper PR title
