### PR TITLE
SILKIT-1572 core: message aggregation

### DIFF
--- a/SilKit/IntegrationTests/CMakeLists.txt
+++ b/SilKit/IntegrationTests/CMakeLists.txt
@@ -342,6 +342,14 @@ add_silkit_test_to_executable(SilKitIntegrationTests
 
 add_silkit_test_to_executable(SilKitIntegrationTests
     SOURCES
+    ITest_MessageAggregation.cpp
+
+    LIBS
+    S_ITests_STH
+)
+
+add_silkit_test_to_executable(SilKitIntegrationTests
+    SOURCES
     ITest_RequestRemoteParticipantConnect.cpp
 
     LIBS

--- a/SilKit/IntegrationTests/FTest_WallClockCoupling.cpp
+++ b/SilKit/IntegrationTests/FTest_WallClockCoupling.cpp
@@ -44,8 +44,7 @@ using namespace SilKit::Tests;
 TEST(FTest_WallClockCoupling, test_wallclock_sync_simtask)
 {
     double animationFactor = 2.0;
-    std::string configWithAnimFactor =
-        R"({"Experimental": {"TimeSynchronization": { "AnimationFactor": 2.0 } }})";
+    std::string configWithAnimFactor = R"({"Experimental": {"TimeSynchronization": { "AnimationFactor": 2.0 } }})";
 
     SimTestHarness testHarness({"P1", "P2", "P3"}, MakeTestRegistryUri(), true);
 
@@ -93,7 +92,8 @@ TEST(FTest_WallClockCoupling, test_wallclock_sync_simtask)
     ASSERT_TRUE(testHarness.Run(5s)) << "TestSim Harness should not reach timeout";
 
     std::chrono::nanoseconds acceptedDeviation = 20ms;
-    auto evalWallClockDeviation = [animationFactor, acceptedDeviation, simDuration](std::chrono::nanoseconds wallClock) {
+    auto evalWallClockDeviation = [animationFactor, acceptedDeviation,
+                                   simDuration](std::chrono::nanoseconds wallClock) {
         auto wallClockDeviationFromVirtualTime = std::abs(wallClock.count() / animationFactor - simDuration.count());
         std::cout << "Wall clock deviation from virtual time: " << wallClockDeviationFromVirtualTime / 1e6 << "ms"
                   << std::endl;
@@ -113,8 +113,7 @@ std::condition_variable cv;
 TEST(FTest_WallClockCoupling, test_wallclock_mixed_simtask)
 {
     double animationFactor = 2.0;
-    std::string configWithAnimFactor =
-        R"({"Experimental": {"TimeSynchronization": { "AnimationFactor": 2.0 } }})";
+    std::string configWithAnimFactor = R"({"Experimental": {"TimeSynchronization": { "AnimationFactor": 2.0 } }})";
 
     SimTestHarness testHarness({"P1", "P2", "P3"}, MakeTestRegistryUri(), true);
 
@@ -135,7 +134,7 @@ TEST(FTest_WallClockCoupling, test_wallclock_mixed_simtask)
     std::atomic<bool> done{false};
     timeSyncService_P1->SetSimulationStepHandlerAsync(
         [&done, simDuration, &wc_P1, &lifeCycleService_P1](std::chrono::nanoseconds now,
-                                                    std::chrono::nanoseconds /*duration*/) {
+                                                           std::chrono::nanoseconds /*duration*/) {
         static auto timeSimStart_P1 = std::chrono::system_clock::now();
         if (now <= simDuration)
         {
@@ -156,8 +155,8 @@ TEST(FTest_WallClockCoupling, test_wallclock_mixed_simtask)
         {
             return;
         }
-
-    }, stepSize);
+    },
+        stepSize);
 
     timeSyncService_P2->SetSimulationStepHandler(
         [simDuration, &wc_P2](std::chrono::nanoseconds now, std::chrono::nanoseconds /*duration*/) {
@@ -172,7 +171,7 @@ TEST(FTest_WallClockCoupling, test_wallclock_mixed_simtask)
             wc_P3 = std::chrono::system_clock::now() - timeSimStart_P3;
     }, stepSize);
 
-    
+
     auto completer = std::thread{[&done, timeSyncService_P1]() {
         while (!done)
         {

--- a/SilKit/IntegrationTests/Hourglass/Test_HourglassFlexray.cpp
+++ b/SilKit/IntegrationTests/Hourglass/Test_HourglassFlexray.cpp
@@ -367,7 +367,8 @@ TEST_F(Test_HourglassFlexray, SilKit_FlexrayController_ExecuteCmd_DeferredHalt)
     SilKit::DETAIL_SILKIT_DETAIL_NAMESPACE_NAME::Impl::Services::Flexray::FlexrayController FlexrayController(
         nullptr, "FlexrayController1", "FlexrayNetwork1");
 
-    EXPECT_CALL(capi, SilKit_FlexrayController_ExecuteCmd(mockFlexrayController, SilKit_FlexrayChiCommand_DEFERRED_HALT))
+    EXPECT_CALL(capi,
+                SilKit_FlexrayController_ExecuteCmd(mockFlexrayController, SilKit_FlexrayChiCommand_DEFERRED_HALT))
         .Times(1);
     FlexrayController.DeferredHalt();
 }
@@ -387,7 +388,8 @@ TEST_F(Test_HourglassFlexray, SilKit_FlexrayController_ExecuteCmd_AllowColdstart
     SilKit::DETAIL_SILKIT_DETAIL_NAMESPACE_NAME::Impl::Services::Flexray::FlexrayController FlexrayController(
         nullptr, "FlexrayController1", "FlexrayNetwork1");
 
-    EXPECT_CALL(capi, SilKit_FlexrayController_ExecuteCmd(mockFlexrayController, SilKit_FlexrayChiCommand_ALLOW_COLDSTART))
+    EXPECT_CALL(capi,
+                SilKit_FlexrayController_ExecuteCmd(mockFlexrayController, SilKit_FlexrayChiCommand_ALLOW_COLDSTART))
         .Times(1);
     FlexrayController.AllowColdstart();
 }

--- a/SilKit/IntegrationTests/Hourglass/Test_HourglassLin.cpp
+++ b/SilKit/IntegrationTests/Hourglass/Test_HourglassLin.cpp
@@ -246,7 +246,8 @@ TEST_F(Test_HourglassLin, SilKit_LinController_SetFrameResponse)
     frameResponse.frame = frame;
     frameResponse.responseMode = LinFrameResponseMode::Rx;
 
-    EXPECT_CALL(capi, SilKit_LinController_SetFrameResponse(mockLinController, LinFrameResponseMatcher(frameResponse))).Times(1);
+    EXPECT_CALL(capi, SilKit_LinController_SetFrameResponse(mockLinController, LinFrameResponseMatcher(frameResponse)))
+        .Times(1);
     LinController.SetFrameResponse(frameResponse);
 }
 

--- a/SilKit/IntegrationTests/Hourglass/Test_HourglassParticipantLogger.cpp
+++ b/SilKit/IntegrationTests/Hourglass/Test_HourglassParticipantLogger.cpp
@@ -251,8 +251,7 @@ TEST_F(Test_HourglassParticipantLogger, SilKit_Logger_GetLogLevel)
     std::string configString = "";
     auto config = SilKit::Config::ParticipantConfigurationFromString(configString);
 
-    EXPECT_CALL(capi, SilKit_Logger_GetLogLevel(testing::_, testing::_))
-        .Times(1);
+    EXPECT_CALL(capi, SilKit_Logger_GetLogLevel(testing::_, testing::_)).Times(1);
 
     auto participant = SilKit::CreateParticipant(config, name);
     auto logger = participant->GetLogger();

--- a/SilKit/IntegrationTests/ITest_DeterministicSimVAsio.cpp
+++ b/SilKit/IntegrationTests/ITest_DeterministicSimVAsio.cpp
@@ -157,9 +157,8 @@ public:
             });
         }
 
-        timeSyncService->SetSimulationStepHandler([this](const nanoseconds now, nanoseconds /*duration*/) {
-            _currentTick = now;
-        }, period);
+        timeSyncService->SetSimulationStepHandler(
+            [this](const nanoseconds now, nanoseconds /*duration*/) { _currentTick = now; }, period);
     }
 
     std::future<ParticipantState> RunAsync() const

--- a/SilKit/IntegrationTests/ITest_MessageAggregation.cpp
+++ b/SilKit/IntegrationTests/ITest_MessageAggregation.cpp
@@ -1,0 +1,147 @@
+// SPDX-FileCopyrightText: 2023 Vector Informatik GmbH
+//
+// SPDX-License-Identifier: MIT
+
+#include <string>
+#include <chrono>
+#include <iostream>
+
+#include "ITestFixture.hpp"
+
+#include "gtest/gtest.h"
+
+namespace {
+
+using namespace SilKit::Tests;
+using namespace SilKit::Config;
+using namespace SilKit::Services;
+using namespace SilKit::Services::PubSub;
+
+using namespace std::chrono_literals;
+
+struct ITest_MessageAggregation : ITest_SimTestHarness
+{
+    using ITest_SimTestHarness::ITest_SimTestHarness;
+};
+
+TEST_F(ITest_MessageAggregation, receive_msg_after_lifecycle_has_been_stopped)
+{
+    std::promise<void> recvMsgPromise;
+    auto recvMsgFuture = recvMsgPromise.get_future();
+
+    SetupFromParticipantList({"Publisher", "Subscriber"});
+    SilKit::Services::PubSub::PubSubSpec dataSpec{"someTopic", {}};
+
+    {
+        std::string participantName = "Publisher";
+        auto&& simParticipant = _simTestHarness->GetParticipant(participantName);
+        auto&& participant = simParticipant->Participant();
+        auto&& lifecycleService = simParticipant->GetOrCreateLifecycleService();
+        auto&& timeSyncService = simParticipant->GetOrCreateTimeSyncService();
+        auto&& dataPublisher = participant->CreateDataPublisher("PubCtrl", dataSpec);
+
+        timeSyncService->SetSimulationStepHandler(
+            [dataPublisher, lifecycleService](std::chrono::nanoseconds /*now*/,
+                                                std::chrono::nanoseconds /*duration*/) {
+            uint32_t messageSizeInBytes = 1;
+            std::vector<uint8_t> data(messageSizeInBytes, '*');
+            dataPublisher->Publish(std::move(data));
+
+            // stop lifecycle immediately (one message is sent and should be received by subscriber)
+            lifecycleService->Stop("Stop and check if message of current time step is transmitted.");
+        },
+            1ms);
+    }
+
+    {
+        std::string participantName = "Subscriber";
+        auto&& simParticipant = _simTestHarness->GetParticipant(participantName);
+        auto&& participant = simParticipant->Participant();
+        /*auto&& lifecycleService =*/simParticipant->GetOrCreateLifecycleService();
+        auto&& timeSyncService = simParticipant->GetOrCreateTimeSyncService();
+        /*auto&& dataSubscriber =*/participant->CreateDataSubscriber(
+            "PubCtrl", dataSpec,
+            [&recvMsgPromise](IDataSubscriber* /*subscriber*/, const DataMessageEvent& /*dataMessageEvent*/) {
+            recvMsgPromise.set_value();
+        });
+
+        timeSyncService->SetSimulationStepHandler(
+            [](std::chrono::nanoseconds /*now*/, std::chrono::nanoseconds /*duration*/) {}, 1ms);
+    }
+
+    auto ok = _simTestHarness->Run(5s);
+    ASSERT_TRUE(ok) << "SimTestHarness should terminate without timeout";
+
+    bool msgReceived = recvMsgFuture.wait_for(5s) == std::future_status::ready;
+    EXPECT_TRUE(msgReceived)
+        << "Message of current time step has not been received (flush of aggregated messages has not been performed).";
+}
+
+TEST_F(ITest_MessageAggregation, timeout_in_case_of_deadlock_when_using_async_sim_step_handler)
+{
+    SetupFromParticipantList({"Publisher", "Subscriber"});
+    SilKit::Services::PubSub::PubSubSpec dataSpecPing{"ping", {}};
+    SilKit::Services::PubSub::PubSubSpec dataSpecPong{"pong", {}};
+
+    bool msgReceived{false};
+
+    // participant with async simulation step handler & enabled message aggregation
+    {
+        std::string participantName = "Publisher";
+        std::string participantConfig(
+            R"({"Experimental": {"TimeSynchronization": {"EnableMessageAggregation": "On"}}})");
+        auto&& simParticipant = _simTestHarness->GetParticipant(participantName, participantConfig);
+        auto&& participant = simParticipant->Participant();
+        auto&& lifecycleService = simParticipant->GetOrCreateLifecycleService();
+        auto&& timeSyncService = simParticipant->GetOrCreateTimeSyncService();
+        auto&& dataPublisher = participant->CreateDataPublisher("Ctrl", dataSpecPing);
+        /*auto&& dataSubscriber =*/participant->CreateDataSubscriber(
+            "Ctrl", dataSpecPong,
+            [timeSyncService, &msgReceived](IDataSubscriber* /*subscriber*/,
+                                            const DataMessageEvent& /*dataMessageEvent*/) {
+            // unblock, if message from other participant is received
+            msgReceived = true;
+            timeSyncService->CompleteSimulationStep();
+        });
+
+        timeSyncService->SetSimulationStepHandlerAsync(
+            [dataPublisher, lifecycleService, timeSyncService, &msgReceived](std::chrono::nanoseconds /*now*/,
+                                                                             std::chrono::nanoseconds /*duration*/) {
+            // send ping
+            std::vector<uint8_t> ping(1, '?');
+            dataPublisher->Publish(std::move(ping));
+
+            if (msgReceived)
+            {
+                lifecycleService->Stop("One time step has been performed successfully.");
+            }
+        },
+            1s);
+    }
+
+    {
+        std::string participantName = "Subscriber";
+        auto&& simParticipant = _simTestHarness->GetParticipant(participantName);
+        auto&& participant = simParticipant->Participant();
+        /*auto&& lifecycleService =*/simParticipant->GetOrCreateLifecycleService();
+        auto&& timeSyncService = simParticipant->GetOrCreateTimeSyncService();
+        auto&& dataPublisher = participant->CreateDataPublisher("Ctrl", dataSpecPong);
+        /*auto&& dataSubscriber =*/participant->CreateDataSubscriber(
+            "Ctrl", dataSpecPing,
+            [dataPublisher](IDataSubscriber* /*subscriber*/, const DataMessageEvent& /*dataMessageEvent*/) {
+            // send back pong
+            std::vector<uint8_t> pong(1, '!');
+            dataPublisher->Publish(std::move(pong));
+        });
+
+        timeSyncService->SetSimulationStepHandlerAsync(
+            [timeSyncService](std::chrono::nanoseconds /*now*/, std::chrono::nanoseconds /*duration*/) {
+            timeSyncService->CompleteSimulationStep();
+        }, 1s);
+    }
+
+    auto ok = _simTestHarness->Run(5s);
+    ASSERT_TRUE(ok) << "SimTestHarness should terminate without timeout";
+}
+
+} // namespace

--- a/SilKit/IntegrationTests/ITest_MessageAggregation.cpp
+++ b/SilKit/IntegrationTests/ITest_MessageAggregation.cpp
@@ -43,16 +43,14 @@ TEST_F(ITest_MessageAggregation, receive_msg_after_lifecycle_has_been_stopped)
         auto&& dataPublisher = participant->CreateDataPublisher("PubCtrl", dataSpec);
 
         timeSyncService->SetSimulationStepHandler(
-            [dataPublisher, lifecycleService](std::chrono::nanoseconds /*now*/,
-                                                std::chrono::nanoseconds /*duration*/) {
+            [dataPublisher, lifecycleService](std::chrono::nanoseconds /*now*/, std::chrono::nanoseconds /*duration*/) {
             uint32_t messageSizeInBytes = 1;
             std::vector<uint8_t> data(messageSizeInBytes, '*');
             dataPublisher->Publish(std::move(data));
 
             // stop lifecycle immediately (one message is sent and should be received by subscriber)
             lifecycleService->Stop("Stop and check if message of current time step is transmitted.");
-        },
-            1ms);
+        }, 1ms);
     }
 
     {

--- a/SilKit/IntegrationTests/ITest_MessageAggregation.cpp
+++ b/SilKit/IntegrationTests/ITest_MessageAggregation.cpp
@@ -34,7 +34,9 @@ TEST_F(ITest_MessageAggregation, receive_msg_after_lifecycle_has_been_stopped)
 
     {
         std::string participantName = "Publisher";
-        auto&& simParticipant = _simTestHarness->GetParticipant(participantName);
+        std::string participantConfig(
+            R"({"Experimental": {"TimeSynchronization": {"EnableMessageAggregation": "Auto"}}})");
+        auto&& simParticipant = _simTestHarness->GetParticipant(participantName, participantConfig);
         auto&& participant = simParticipant->Participant();
         auto&& lifecycleService = simParticipant->GetOrCreateLifecycleService();
         auto&& timeSyncService = simParticipant->GetOrCreateTimeSyncService();

--- a/SilKit/include/silkit/capi/Flexray.h
+++ b/SilKit/include/silkit/capi/Flexray.h
@@ -515,21 +515,21 @@ struct SilKit_FlexrayPocStatusEvent
     SilKit_StructHeader structHeader; //!< The interface id specifying which version of this struct was obtained
     SilKit_NanosecondsTime timestamp; //!< SIL Kit timestamp
     SilKit_FlexrayPocState state;
-        /* = SilKit_FlexrayPocState_DefaultConfig; */ //!< Status of the Protocol Operation Control (POC).
+    /* = SilKit_FlexrayPocState_DefaultConfig; */ //!< Status of the Protocol Operation Control (POC).
     SilKit_Bool chiHaltRequest; /* = false; */ //!< indicates whether a halt request was received from the CHI
     SilKit_Bool coldstartNoise; /* = false; */ //!< indicates noisy channel conditions during coldstart
     SilKit_Bool freeze;
-        /* = false; */ //!< indicates that the POC entered a halt state due to an error condition requiring immediate halt.
+    /* = false; */ //!< indicates that the POC entered a halt state due to an error condition requiring immediate halt.
     SilKit_Bool chiReadyRequest;
-        /* = false; */ //!< indicates that the CHI requested to enter ready state at the end of the communication cycle.
+    /* = false; */ //!< indicates that the CHI requested to enter ready state at the end of the communication cycle.
     SilKit_FlexrayErrorModeType errorMode;
-        /* = SilKit_FlexrayErrorModeType_Active; */ //!< indicates the error mode of the POC
+    /* = SilKit_FlexrayErrorModeType_Active; */ //!< indicates the error mode of the POC
     SilKit_FlexraySlotModeType slotMode;
-        /* = SilKit_FlexraySlotModeType_KeySlot; */ //!< indicates the slot mode of the POC
+    /* = SilKit_FlexraySlotModeType_KeySlot; */ //!< indicates the slot mode of the POC
     SilKit_FlexrayStartupStateType startupState;
-        /* = SilKit_FlexrayStartupStateType_Undefined; */ //!< indicates states within the STARTUP mechanism
+    /* = SilKit_FlexrayStartupStateType_Undefined; */ //!< indicates states within the STARTUP mechanism
     SilKit_FlexrayWakeupStatusType wakeupStatus;
-        /* = SilKit_FlexrayWakeupStatusType_Undefined; */ //!< outcome of the execution of the WAKEUP mechanism
+    /* = SilKit_FlexrayWakeupStatusType_Undefined; */ //!< outcome of the execution of the WAKEUP mechanism
 };
 typedef struct SilKit_FlexrayPocStatusEvent SilKit_FlexrayPocStatusEvent;
 

--- a/SilKit/include/silkit/services/logging/string_utils.hpp
+++ b/SilKit/include/silkit/services/logging/string_utils.hpp
@@ -28,6 +28,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE. */
 #include <cctype>
 
 #include "LoggingDatatypes.hpp"
+#include "StringHelpers.hpp"
 
 namespace SilKit {
 namespace Services {
@@ -81,12 +82,7 @@ std::ostream& operator<<(std::ostream& outStream, const Level& level)
 
 inline Level from_string(const std::string& levelStr)
 {
-    auto lowerCase = [](auto s) {
-        std::transform(s.begin(), s.end(), s.begin(), [](unsigned char c) { return (unsigned char)std::tolower(c); });
-        return s;
-    };
-    auto logLevel = lowerCase(levelStr);
-
+    auto logLevel = SilKit::Util::LowerCase(levelStr);
     if (logLevel == "trace")
         return Level::Trace;
     if (logLevel == "debug")

--- a/SilKit/source/config/ParticipantConfiguration.hpp
+++ b/SilKit/source/config/ParticipantConfiguration.hpp
@@ -296,7 +296,7 @@ struct Middleware
 struct TimeSynchronization
 {
     double animationFactor{0.0};
-    Aggregation enableMessageAggregation{Aggregation::Auto};
+    Aggregation enableMessageAggregation{Aggregation::Off};
 };
 
 // ================================================================================

--- a/SilKit/source/config/ParticipantConfiguration.hpp
+++ b/SilKit/source/config/ParticipantConfiguration.hpp
@@ -296,8 +296,8 @@ struct Middleware
 struct TimeSynchronization
 {
     double animationFactor{0.0};
+    Aggregation enableMessageAggregation{Aggregation::Auto};
 };
-
 
 // ================================================================================
 //  Experimental

--- a/SilKit/source/config/ParticipantConfiguration.schema.json
+++ b/SilKit/source/config/ParticipantConfiguration.schema.json
@@ -791,7 +791,7 @@
               "type": "string",
               "enum": [ "Off", "On", "Auto" ],
               "description": "Decide for simulations with time synchronization, if a message aggregation is performed. In case of the Auto mode, the message aggregation is enabled for simulations using the synchronous simulation step handler.",
-              "default": "Auto"
+              "default": "Off"
             }
           },
           "additionalProperties": false

--- a/SilKit/source/config/ParticipantConfiguration.schema.json
+++ b/SilKit/source/config/ParticipantConfiguration.schema.json
@@ -786,6 +786,12 @@
               "description": "The animation factor describes how fast the simulation is allowed to run, relative to the local wall clock. For example, if the value is 0.1, SIL Kit will try to run the simulation 10 times faster than the wall clock. The default value 0.0 runs the simulation as fast as possible, i.e., the current behavior.",
               "minimum": 0.0,
               "default": 0.0
+            },
+            "EnableMessageAggregation": {
+              "type": "string",
+              "enum": [ "Off", "On", "Auto" ],
+              "description": "Decide for simulations with time synchronization, if a message aggregation is performed. In case of the Auto mode, the message aggregation is enabled for simulations using the synchronous simulation step handler.",
+              "default": "Auto"
             }
           },
           "additionalProperties": false

--- a/SilKit/source/config/ParticipantConfigurationFromXImpl.cpp
+++ b/SilKit/source/config/ParticipantConfigurationFromXImpl.cpp
@@ -74,6 +74,7 @@ struct GlobalLogCache
 struct TimeSynchronizationCache
 {
     SilKit::Util::Optional<double> animationFactor;
+    SilKit::Util::Optional<Aggregation> enableMessageAggregation;
 };
 
 struct MetricsCache
@@ -375,6 +376,7 @@ void CacheLoggingSinks(const YAML::Node& config, GlobalLogCache& cache)
 void CacheTimeSynchronization(const YAML::Node& root, TimeSynchronizationCache& cache)
 {
     PopulateCacheField(root, "TimeSynchronization", "AnimationFactor", cache.animationFactor);
+    PopulateCacheField(root, "TimeSynchronization", "EnableMessageAggregation", cache.enableMessageAggregation);
 }
 
 void CacheMetrics(const YAML::Node& root, MetricsCache& cache)
@@ -552,6 +554,7 @@ void MergeLogCache(const GlobalLogCache& cache, Logging& logging)
 void MergeTimeSynchronizationCache(const TimeSynchronizationCache& cache, TimeSynchronization& timeSynchronization)
 {
     MergeCacheField(cache.animationFactor, timeSynchronization.animationFactor);
+    MergeCacheField(cache.enableMessageAggregation, timeSynchronization.enableMessageAggregation);
 }
 
 void MergeMetricsCache(const MetricsCache& cache, Metrics& metrics)
@@ -792,7 +795,7 @@ bool operator==(const ParticipantConfiguration& lhs, const ParticipantConfigurat
 
 bool operator==(const TimeSynchronization& lhs, const TimeSynchronization& rhs)
 {
-    return lhs.animationFactor == rhs.animationFactor;
+    return lhs.animationFactor == rhs.animationFactor && lhs.enableMessageAggregation == rhs.enableMessageAggregation;
 }
 
 bool operator==(const Experimental& lhs, const Experimental& rhs)

--- a/SilKit/source/config/ParticipantConfiguration_Full.json
+++ b/SilKit/source/config/ParticipantConfiguration_Full.json
@@ -233,7 +233,7 @@
   "Experimental": {
     "TimeSynchronization": {
       "AnimationFactor": 1.5,
-      "EnableMessageAggregation": "Auto" 
+      "EnableMessageAggregation": "Off" 
     },
     "Metrics": {
       "CollectFromRemote": false,

--- a/SilKit/source/config/ParticipantConfiguration_Full.json
+++ b/SilKit/source/config/ParticipantConfiguration_Full.json
@@ -232,7 +232,8 @@
   },
   "Experimental": {
     "TimeSynchronization": {
-      "AnimationFactor": 1.5
+      "AnimationFactor": 1.5,
+      "EnableMessageAggregation": "Auto" 
     },
     "Metrics": {
       "CollectFromRemote": false,

--- a/SilKit/source/config/ParticipantConfiguration_Full.yaml
+++ b/SilKit/source/config/ParticipantConfiguration_Full.yaml
@@ -170,6 +170,7 @@ Middleware:
 Experimental:
   TimeSynchronization:
     AnimationFactor: 1.5
+    EnableMessageAggregation: Auto
   Metrics:
     CollectFromRemote: false
     Sinks:

--- a/SilKit/source/config/ParticipantConfiguration_Full.yaml
+++ b/SilKit/source/config/ParticipantConfiguration_Full.yaml
@@ -170,7 +170,7 @@ Middleware:
 Experimental:
   TimeSynchronization:
     AnimationFactor: 1.5
-    EnableMessageAggregation: Auto
+    EnableMessageAggregation: Off
   Metrics:
     CollectFromRemote: false
     Sinks:

--- a/SilKit/source/config/YamlConversion.cpp
+++ b/SilKit/source/config/YamlConversion.cpp
@@ -1106,16 +1106,56 @@ bool Converter::decode(const Node& node, Middleware& obj)
 }
 
 template <>
+Node Converter::encode(const Aggregation& obj)
+{
+    Node node;
+    switch (obj)
+    {
+    case Aggregation::Off:
+        node = "Off";
+        break;
+    case Aggregation::On:
+        node = "On";
+        break;
+    case Aggregation::Auto:
+        node = "Auto";
+        break;
+    default:
+        throw ConfigurationError{"Unknown Aggregation Type"};
+    }
+    return node;
+}
+template <>
+bool Converter::decode(const Node& node, Aggregation& obj)
+{
+    auto&& str = parse_as<std::string>(node);
+    if (str == "Off" || str == "")
+        obj = Aggregation::Off;
+    else if (str == "On")
+        obj = Aggregation::On;
+    else if (str == "Auto")
+        obj = Aggregation::Auto;
+    else
+    {
+        throw ConversionError(node, "Unknown Aggregation: " + str + ".");
+    }
+    return true;
+}
+
+template <>
 Node Converter::encode(const TimeSynchronization& obj)
 {
     Node node;
-    node["AnimationFactor"] = obj.animationFactor;
+    static const TimeSynchronization defaultObj;
+    non_default_encode(obj.animationFactor, node, "AnimationFactor", defaultObj.animationFactor);
+    non_default_encode(obj.enableMessageAggregation, node, "EnableMessageAggregation", defaultObj.enableMessageAggregation);
     return node;
 }
 template <>
 bool Converter::decode(const Node& node, TimeSynchronization& obj)
 {
-    obj.animationFactor = parse_as<decltype(obj.animationFactor)>(node["AnimationFactor"]);
+    optional_decode(obj.animationFactor, node, "AnimationFactor");
+    optional_decode(obj.enableMessageAggregation, node, "EnableMessageAggregation");
     return true;
 }
 

--- a/SilKit/source/config/YamlConversion.cpp
+++ b/SilKit/source/config/YamlConversion.cpp
@@ -166,7 +166,7 @@ bool Converter::decode(const Node& node, Sink::Format& obj)
 }
 
 
-template<>
+template <>
 Node Converter::encode(const Sink::Type& obj)
 {
     Node node;
@@ -1148,7 +1148,8 @@ Node Converter::encode(const TimeSynchronization& obj)
     Node node;
     static const TimeSynchronization defaultObj;
     non_default_encode(obj.animationFactor, node, "AnimationFactor", defaultObj.animationFactor);
-    non_default_encode(obj.enableMessageAggregation, node, "EnableMessageAggregation", defaultObj.enableMessageAggregation);
+    non_default_encode(obj.enableMessageAggregation, node, "EnableMessageAggregation",
+                       defaultObj.enableMessageAggregation);
     return node;
 }
 template <>
@@ -1178,7 +1179,7 @@ bool Converter::decode(const Node& node, Experimental& obj)
 }
 
 
-template<>
+template <>
 Node Converter::encode(const ParticipantConfiguration& obj)
 {
     static const ParticipantConfiguration defaultObj{};

--- a/SilKit/source/config/YamlConversion.hpp
+++ b/SilKit/source/config/YamlConversion.hpp
@@ -87,6 +87,7 @@ DEFINE_SILKIT_CONVERT(Extensions);
 
 DEFINE_SILKIT_CONVERT(Experimental);
 DEFINE_SILKIT_CONVERT(TimeSynchronization);
+DEFINE_SILKIT_CONVERT(Aggregation);
 
 DEFINE_SILKIT_CONVERT(ParticipantConfiguration);
 

--- a/SilKit/source/config/YamlSchema.cpp
+++ b/SilKit/source/config/YamlSchema.cpp
@@ -205,7 +205,7 @@ auto MakeYamlSchema() -> YamlSchemaElem
          }},
         {"Experimental",
          {
-             {"TimeSynchronization", {{"AnimationFactor"}}},
+             {"TimeSynchronization", {{"AnimationFactor"}, {"EnableMessageAggregation"}}},
              {"Metrics",
               {
                   metricsSinks,

--- a/SilKit/source/core/internal/IParticipantInternal.hpp
+++ b/SilKit/source/core/internal/IParticipantInternal.hpp
@@ -333,6 +333,7 @@ public:
                                                                           const std::string& msgTypeName) = 0;
 
     virtual void NotifyShutdown() = 0;
+    virtual void EvaluateAggregationInfo(bool isSyncSimStepHandler) = 0;
 
     virtual void RegisterReplayController(SilKit::Tracing::IReplayDataController* replayController,
                                           const std::string& controllerName,

--- a/SilKit/source/core/internal/LoggingDatatypesInternal.hpp
+++ b/SilKit/source/core/internal/LoggingDatatypesInternal.hpp
@@ -68,8 +68,7 @@ inline std::ostream& operator<<(std::ostream& out, const LogMsg& msg);
 
 
 inline std::string to_string(const std::unordered_map<std::string, std::string>& kv);
-inline std::ostream& operator<<(std::ostream& out,
-    const std::unordered_map<std::string, std::string>& kv);
+inline std::ostream& operator<<(std::ostream& out, const std::unordered_map<std::string, std::string>& kv);
 
 // ================================================================================
 //  Inline Implementations
@@ -83,7 +82,7 @@ bool operator==(const SourceLoc& lhs, const SourceLoc& rhs)
 inline bool operator==(const LogMsg& lhs, const LogMsg& rhs)
 {
     return lhs.loggerName == rhs.loggerName && lhs.level == rhs.level && lhs.time == rhs.time
-           && lhs.source == rhs.source && lhs.payload == rhs.payload && lhs.keyValues == rhs.keyValues ;
+           && lhs.source == rhs.source && lhs.payload == rhs.payload && lhs.keyValues == rhs.keyValues;
 }
 
 std::string to_string(const SourceLoc& sourceLoc)
@@ -124,8 +123,7 @@ inline std::ostream& operator<<(std::ostream& out, const std::unordered_map<std:
             {
                 result.append(",");
             }
-            result.append("\"" + it->first + "\"" + ":" + "\""
-                          + it->second + "\"");
+            result.append("\"" + it->first + "\"" + ":" + "\"" + it->second + "\"");
             ++it;
         }
         result.append("}");
@@ -145,9 +143,8 @@ std::string to_string(const LogMsg& msg)
 std::ostream& operator<<(std::ostream& out, const LogMsg& msg)
 {
     out << "LogMsg{logger=" << msg.loggerName << ", level=" << msg.level
-        << ", time=" << std::chrono::duration_cast<std::chrono::microseconds>(msg.time.time_since_epoch()).count() << ", source=" << msg.source << ", payload=\""
-        << msg.payload << "\"" << msg.keyValues 
-        << "}";
+        << ", time=" << std::chrono::duration_cast<std::chrono::microseconds>(msg.time.time_since_epoch()).count()
+        << ", source=" << msg.source << ", payload=\"" << msg.payload << "\"" << msg.keyValues << "}";
     return out;
 }
 

--- a/SilKit/source/core/mock/nullconnection/NullConnectionParticipant.cpp
+++ b/SilKit/source/core/mock/nullconnection/NullConnectionParticipant.cpp
@@ -67,6 +67,7 @@ struct NullConnection
     void FlushSendBuffers() {}
     void ExecuteDeferred(std::function<void()> /*callback*/) {}
     void NotifyShutdown() {}
+    void EnableAggregation() {}
 
     void RegisterMessageReceiver(std::function<void(IVAsioPeer* /*peer*/, ParticipantAnnouncement)> /*callback*/) {}
     void RegisterPeerShutdownCallback(std::function<void(IVAsioPeer* peer)> /*callback*/) {}

--- a/SilKit/source/core/mock/nullconnection/NullConnectionParticipant.cpp
+++ b/SilKit/source/core/mock/nullconnection/NullConnectionParticipant.cpp
@@ -33,8 +33,8 @@ namespace {
 struct NullConnection
 {
     NullConnection(SilKit::Core::IParticipantInternal*, VSilKit::IMetricsManager*,
-                   SilKit::Config::ParticipantConfiguration /*config*/,
-                   std::string /*participantName*/, SilKit::Core::ParticipantId /*participantId*/,
+                   SilKit::Config::ParticipantConfiguration /*config*/, std::string /*participantName*/,
+                   SilKit::Core::ParticipantId /*participantId*/,
                    SilKit::Core::Orchestration::ITimeProvider* /*timeProvider*/, ProtocolVersion)
     {
     }

--- a/SilKit/source/core/mock/participant/MockParticipant.hpp
+++ b/SilKit/source/core/mock/participant/MockParticipant.hpp
@@ -684,6 +684,7 @@ public:
     }
 
     void NotifyShutdown() override {};
+    void EvaluateAggregationInfo(bool /*isSyncSimStepHandler*/) override {};
     void RegisterReplayController(SilKit::Tracing::IReplayDataController*, const std::string&,
                                   const SilKit::Config::SimulatedNetwork&) override
     {

--- a/SilKit/source/core/participant/Participant.hpp
+++ b/SilKit/source/core/participant/Participant.hpp
@@ -349,6 +349,7 @@ public:
                                                                   const std::string& msgTypeName) override;
 
     void NotifyShutdown() override;
+    void EvaluateAggregationInfo(bool isSyncSimStepHandler) override;
 
     void RegisterReplayController(SilKit::Tracing::IReplayDataController* replayController,
                                   const std::string& controllerName,
@@ -424,17 +425,15 @@ private:
     template <class ControllerT, typename... Arg>
     auto CreateController(const SilKitServiceTraitConfigType_t<ControllerT>& config, const std::string& network,
                           const Core::SupplementalData& supplementalData, bool publishServiceDiscovery,
-                          bool registerSilKitService, Arg&&... arg)
-        -> ControllerT*;
+                          bool registerSilKitService, Arg&&... arg) -> ControllerT*;
 
     //!< Internal controller creation, expects config.network
     template <class ControllerT, typename... Arg>
     auto CreateController(const SilKitServiceTraitConfigType_t<ControllerT>& config,
                           const Core::SupplementalData& supplementalData, bool publishServiceDiscovery,
-                          bool registerSilKitService, Arg&&... arg)
-        -> ControllerT*;
+                          bool registerSilKitService, Arg&&... arg) -> ControllerT*;
 
-    //!< Internal late controller registration. Used for TimeSyncService to create the controller 
+    //!< Internal late controller registration. Used for TimeSyncService to create the controller
     //! and only register message reception later if really needed.
     void RegisterTimeSyncService(SilKit::Services::Orchestration::TimeSyncService* controllerPtr) override;
 

--- a/SilKit/source/core/vasio/AggregationMessageTraits.hpp
+++ b/SilKit/source/core/vasio/AggregationMessageTraits.hpp
@@ -1,0 +1,70 @@
+// SPDX-FileCopyrightText: 2023 Vector Informatik GmbH
+//
+// SPDX-License-Identifier: MIT
+
+#pragma once
+
+#include "VAsioDatatypes.hpp"
+
+#include "OrchestrationDatatypes.hpp"
+
+#include "WireCanMessages.hpp"
+#include "WireDataMessages.hpp"
+#include "WireEthernetMessages.hpp"
+#include "WireRpcMessages.hpp"
+
+namespace SilKit {
+namespace Core {
+
+/// default comprising VAsio data types and service data types
+template <typename MessageT>
+inline constexpr auto aggregationKind() -> MessageAggregationKind
+{
+    return MessageAggregationKind::Other;
+}
+
+/// messages signalizing the end of a time step
+template <>
+inline constexpr auto aggregationKind<SilKit::Services::Orchestration::NextSimTask>() -> MessageAggregationKind
+{
+    return MessageAggregationKind::FlushAggregationMessage;
+}
+template <>
+inline constexpr auto aggregationKind<SilKit::Services::Orchestration::ParticipantStatus>() -> MessageAggregationKind
+{
+    return MessageAggregationKind::FlushAggregationMessage;
+}
+
+/// messages containing user data/payload (to be aggregated)
+// PubSub
+template <>
+inline constexpr auto aggregationKind<SilKit::Services::PubSub::WireDataMessageEvent>() -> MessageAggregationKind
+{
+    return MessageAggregationKind::UserDataMessage;
+}
+// RPC
+template <>
+inline constexpr auto aggregationKind<SilKit::Services::Rpc::FunctionCall>() -> MessageAggregationKind
+{
+    return MessageAggregationKind::UserDataMessage;
+}
+template <>
+inline constexpr auto aggregationKind<SilKit::Services::Rpc::FunctionCallResponse>() -> MessageAggregationKind
+{
+    return MessageAggregationKind::UserDataMessage;
+}
+// CAN
+template <>
+inline constexpr auto aggregationKind<SilKit::Services::Can::WireCanFrameEvent>() -> MessageAggregationKind
+{
+    return MessageAggregationKind::UserDataMessage;
+}
+// Ethernet
+template <>
+inline constexpr auto aggregationKind<SilKit::Services::Ethernet::WireEthernetFrameEvent>() -> MessageAggregationKind
+{
+    return MessageAggregationKind::UserDataMessage;
+}
+
+} // namespace Core
+} // namespace SilKit

--- a/SilKit/source/core/vasio/IVAsioPeer.hpp
+++ b/SilKit/source/core/vasio/IVAsioPeer.hpp
@@ -61,6 +61,8 @@ public:
     //! Version management for backward compatibility on network ser/des level
     virtual void SetProtocolVersion(ProtocolVersion v) = 0;
     virtual auto GetProtocolVersion() const -> ProtocolVersion = 0;
+
+    virtual void EnableAggregation() = 0;
 };
 
 

--- a/SilKit/source/core/vasio/RingBuffer.cpp
+++ b/SilKit/source/core/vasio/RingBuffer.cpp
@@ -74,7 +74,7 @@ void RingBuffer::GetWritingBuffers(std::vector<MutableBuffer>& buffers)
     {
         buffers.push_back(std::move(arrayOne));
     }
-    
+
     auto arrayTwo = GetFreeMemoryArrayTwo();
     if (arrayTwo.GetSize() > 0)
     {

--- a/SilKit/source/core/vasio/SerializedMessage.cpp
+++ b/SilKit/source/core/vasio/SerializedMessage.cpp
@@ -53,6 +53,11 @@ auto SerializedMessage::GetRegistryKind() const -> RegistryMessageKind
     return _registryKind;
 }
 
+auto SerializedMessage::GetAggregationKind() const -> MessageAggregationKind
+{
+    return _aggregationKind;
+}
+
 auto SerializedMessage::GetRemoteIndex() const -> EndpointId
 {
     if (!IsMwOrSim(_messageKind))
@@ -156,6 +161,11 @@ void SerializedMessage::ReadNetworkHeaders()
         _remoteIndex = ExtractEndpointId(_buffer);
         _endpointAddress = ExtractEndpointAddress(_buffer);
     }
+}
+
+void SerializedMessage::SetAggregationKind(MessageAggregationKind msgAggregationKind)
+{
+    _aggregationKind = msgAggregationKind;
 }
 
 } // namespace Core

--- a/SilKit/source/core/vasio/SerializedMessage.hpp
+++ b/SilKit/source/core/vasio/SerializedMessage.hpp
@@ -22,6 +22,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE. */
 #include "VAsioMsgKind.hpp"
 #include "VAsioDatatypes.hpp"
 #include "SerializedMessageTraits.hpp"
+#include "AggregationMessageTraits.hpp"
 #include "MessageBuffer.hpp"
 
 // Component specific Serialize/Deserialize functions
@@ -95,11 +96,14 @@ public: // Receiving a SerializedMessage: from binary blob to SilKitMessage<T>
 
     auto GetMessageKind() const -> VAsioMsgKind;
     auto GetRegistryKind() const -> RegistryMessageKind;
+    auto GetAggregationKind() const -> MessageAggregationKind;
     auto GetRemoteIndex() const -> EndpointId;
     auto GetEndpointAddress() const -> EndpointAddress;
     void SetProtocolVersion(ProtocolVersion version);
     auto GetProxyMessageHeader() const -> ProxyMessageHeader;
     auto GetRegistryMessageHeader() const -> RegistryMsgHeader;
+
+    void SetAggregationKind(MessageAggregationKind msgAggregationKind);
 
 private:
     void WriteNetworkHeaders();
@@ -108,6 +112,7 @@ private:
     uint32_t _messageSize{0};
     VAsioMsgKind _messageKind{VAsioMsgKind::Invalid};
     RegistryMessageKind _registryKind{RegistryMessageKind::Invalid};
+    MessageAggregationKind _aggregationKind{MessageAggregationKind::Other};
     // For simMsg
     EndpointAddress _endpointAddress{};
     EndpointId _remoteIndex{0};
@@ -130,6 +135,7 @@ SerializedMessage::SerializedMessage(const MessageT& message)
 
     _messageKind = messageKind<MessageT>();
     _registryKind = registryMessageKind<MessageT>();
+    _aggregationKind = aggregationKind<MessageT>();
     WriteNetworkHeaders();
     Serialize(_buffer, message);
     //Ensure we can directly Deserialize in unit tests by reading the header in again
@@ -144,6 +150,7 @@ SerializedMessage::SerializedMessage(ProtocolVersion version, const MessageT& me
 
     _messageKind = messageKind<MessageT>();
     _registryKind = registryMessageKind<MessageT>();
+    _aggregationKind = aggregationKind<MessageT>();
     _buffer.SetProtocolVersion(version);
     WriteNetworkHeaders();
     Serialize(_buffer, message);
@@ -161,6 +168,7 @@ SerializedMessage::SerializedMessage(const MessageT& message, EndpointAddress en
     _endpointAddress = endpointAddress;
     _messageKind = messageKind<MessageT>();
     _registryKind = registryMessageKind<MessageT>();
+    _aggregationKind = aggregationKind<MessageT>();
     WriteNetworkHeaders();
     Serialize(_buffer, message);
     //Ensure we can directly Deserialize in unit tests by reading the header in again

--- a/SilKit/source/core/vasio/Test_RingBuffer.cpp
+++ b/SilKit/source/core/vasio/Test_RingBuffer.cpp
@@ -11,10 +11,10 @@
 
 using namespace SilKit::Core;
 
-static std::mt19937 generator{0}; // constant seed for deterministic behaviour 
+static std::mt19937 generator{0}; // constant seed for deterministic behaviour
 
 std::vector<std::vector<uint8_t> > GenerateDataBlocks(const size_t maxSize, const size_t numDataBlocks)
-{    
+{
     std::vector<std::vector<uint8_t> > dataBlocks;
 
     // configure random number generators
@@ -108,7 +108,7 @@ TEST(Test_RingBuffer, resizeRingBuffer)
             ringBuffer.Read(readData);
 
             ASSERT_EQ(elem, readData);
-        }    
+        }
     }
 }
 
@@ -130,7 +130,7 @@ TEST(Test_RingBuffer, writeMultiple_resizeAllowed)
         // write all data blocks at once (resize capacity if necessary)
         for (const auto& elem : dataBlocks)
         {
-            auto remainingSpace = ringBuffer.Capacity() - ringBuffer.Size(); 
+            auto remainingSpace = ringBuffer.Capacity() - ringBuffer.Size();
             if (elem.size() > remainingSpace)
             {
                 ringBuffer.Reserve(ringBuffer.Size() + elem.size());
@@ -139,10 +139,10 @@ TEST(Test_RingBuffer, writeMultiple_resizeAllowed)
             Write(ringBuffer, elem);
 
             // append current data block for comparison
-            currentDataBlock.insert(currentDataBlock.end(), elem.begin(), elem.end());            
+            currentDataBlock.insert(currentDataBlock.end(), elem.begin(), elem.end());
         }
 
-        // read all data available 
+        // read all data available
         std::vector<uint8_t> readData(ringBuffer.Size());
         ringBuffer.Read(readData);
 
@@ -153,7 +153,7 @@ TEST(Test_RingBuffer, writeMultiple_resizeAllowed)
 }
 
 // write and read of multiple data blocks at once (fixed capacity)
-TEST(Test_RingBuffer, writeMultiple_fixedCapacity) 
+TEST(Test_RingBuffer, writeMultiple_fixedCapacity)
 {
     const size_t capacity{1000};
     RingBuffer ringBuffer(capacity);
@@ -177,7 +177,7 @@ TEST(Test_RingBuffer, writeMultiple_fixedCapacity)
             for (const auto& elem : dataBlocks)
             {
                 auto remainingSpace = ringBuffer.Capacity() - ringBuffer.Size();
-                
+
                 if (elem.size() <= remainingSpace) // write current block, if there is enough space
                 {
                     Write(ringBuffer, elem);
@@ -190,7 +190,7 @@ TEST(Test_RingBuffer, writeMultiple_fixedCapacity)
                 else // stop writing
                 {
                     break;
-                }                
+                }
             }
 
             dataBlocks.erase(dataBlocks.begin(), dataBlocks.begin() + numWrittenBlocks);

--- a/SilKit/source/core/vasio/Test_TransformAcceptorUris.cpp
+++ b/SilKit/source/core/vasio/Test_TransformAcceptorUris.cpp
@@ -158,6 +158,11 @@ struct DummyVAsioPeerBase : IVAsioPeer
         throw MethodNotImplementedError{};
     }
 
+    void EnableAggregation() final
+    {
+        throw MethodNotImplementedError{};
+    }
+
     void SetProtocolVersion(ProtocolVersion) final
     {
         throw MethodNotImplementedError{};

--- a/SilKit/source/core/vasio/Test_VAsioConnection.cpp
+++ b/SilKit/source/core/vasio/Test_VAsioConnection.cpp
@@ -137,6 +137,7 @@ struct MockVAsioPeer : public IVAsioPeer
     MOCK_METHOD(void, SetProtocolVersion, (ProtocolVersion), (override));
     MOCK_METHOD(ProtocolVersion, GetProtocolVersion, (), (const, override));
     MOCK_METHOD(void, Shutdown, (), (override));
+    MOCK_METHOD(void, EnableAggregation, (), (override));
 
     // IServiceEndpoint (via IVAsioPeer)
     MOCK_METHOD(void, SetServiceDescriptor, (const ServiceDescriptor& serviceDescriptor), (override));

--- a/SilKit/source/core/vasio/VAsioConnection.cpp
+++ b/SilKit/source/core/vasio/VAsioConnection.cpp
@@ -1236,6 +1236,11 @@ void VAsioConnection::AddPeer(std::unique_ptr<IVAsioPeer> newPeer)
 {
     newPeer->StartAsyncRead();
 
+    if (_useAggregation)
+    {
+        newPeer->EnableAggregation();
+    }
+
     std::unique_lock<std::mutex> lock{_peersLock};
 
     auto* const proxyPeer = dynamic_cast<VAsioProxyPeer*>(newPeer.get());
@@ -1360,6 +1365,18 @@ void VAsioConnection::RemovePeerFromConnection(IVAsioPeer* peer)
 void VAsioConnection::NotifyShutdown()
 {
     _isShuttingDown = true;
+}
+
+void VAsioConnection::EnableAggregation()
+{
+    // pass information to all existing peers
+    for (auto& peer : _peers)
+    {
+        peer->EnableAggregation();
+    }
+
+    // keep information for peers joining in the future
+    _useAggregation = true;
 }
 
 void VAsioConnection::OnSocketData(IVAsioPeer* from, SerializedMessage&& buffer)

--- a/SilKit/source/core/vasio/VAsioConnection.hpp
+++ b/SilKit/source/core/vasio/VAsioConnection.hpp
@@ -91,9 +91,8 @@ public:
     VAsioConnection(const VAsioConnection&) = delete;
     VAsioConnection(VAsioConnection&&) = delete;
     VAsioConnection(IParticipantInternal* participant, IMetricsManager* metricsManager,
-                    SilKit::Config::ParticipantConfiguration config,
-                    std::string participantName, ParticipantId participantId,
-                    Services::Orchestration::ITimeProvider* timeProvider,
+                    SilKit::Config::ParticipantConfiguration config, std::string participantName,
+                    ParticipantId participantId, Services::Orchestration::ITimeProvider* timeProvider,
                     ProtocolVersion version = CurrentProtocolVersion());
     ~VAsioConnection() override;
 

--- a/SilKit/source/core/vasio/VAsioConnection.hpp
+++ b/SilKit/source/core/vasio/VAsioConnection.hpp
@@ -207,6 +207,8 @@ public:
 
     void NotifyShutdown();
 
+    void EnableAggregation();
+
     // Register handlers for completion of async service creation
     void AddAsyncSubscriptionsCompletionHandler(std::function<void()> handler);
 
@@ -572,6 +574,8 @@ private:
     IParticipantInternal* _participant{nullptr};
 
     friend class ::SilKit::Core::RemoteConnectionManager;
+
+    bool _useAggregation{false};
 };
 
 

--- a/SilKit/source/core/vasio/VAsioDatatypes.hpp
+++ b/SilKit/source/core/vasio/VAsioDatatypes.hpp
@@ -147,6 +147,13 @@ struct ProxyMessage
     std::vector<uint8_t> payload;
 };
 
+enum class MessageAggregationKind : uint8_t
+{
+    UserDataMessage = 0,
+    FlushAggregationMessage = 1,
+    Other = 2,
+};
+
 // ================================================================================
 //  Inline Implementations
 // ================================================================================

--- a/SilKit/source/core/vasio/VAsioPeer.cpp
+++ b/SilKit/source/core/vasio/VAsioPeer.cpp
@@ -157,7 +157,7 @@ void VAsioPeer::Aggregate(const std::vector<uint8_t>& blob)
         _flushTimer->AsyncWaitFor(_flushTimeout);
         _initialTimerStarted = true;
     }
-    
+
     _aggregatedMessages.insert(_aggregatedMessages.end(), blob.begin(), blob.end());
 
     // ensure that the aggregation buffer does not exceed a certain size
@@ -178,7 +178,7 @@ void VAsioPeer::Flush()
     SendSilKitMsgInternal(std::move(blob));
 
     // reset timer when flush is triggered
-	_flushTimer->AsyncWaitFor(_flushTimeout);
+    _flushTimer->AsyncWaitFor(_flushTimeout);
 }
 
 void VAsioPeer::StartAsyncWrite()

--- a/SilKit/source/core/vasio/VAsioPeer.cpp
+++ b/SilKit/source/core/vasio/VAsioPeer.cpp
@@ -56,6 +56,10 @@ VAsioPeer::VAsioPeer(IVAsioPeerListener* listener, IIoContext* ioContext, std::u
     , _msgBuffer{4096}
 {
     _socket->SetListener(*this);
+
+    // set up timer (guarantees working communication in case of message aggregation)
+    _flushTimer = _ioContext->MakeTimer();
+    _flushTimer->SetListener(*this);
 }
 
 VAsioPeer::~VAsioPeer()
@@ -74,6 +78,7 @@ void VAsioPeer::Shutdown()
     }
 
     _socket->Shutdown();
+    _flushTimer->Shutdown();
 }
 
 
@@ -111,17 +116,69 @@ auto VAsioPeer::GetSimulationName() const -> const std::string&
 
 void VAsioPeer::SendSilKitMsg(SerializedMessage buffer)
 {
+    auto blob = buffer.ReleaseStorage();
+
+    if (_useAggregation && buffer.GetAggregationKind() == MessageAggregationKind::UserDataMessage)
+    {
+        Aggregate(blob);
+    }
+    else if (_useAggregation && buffer.GetAggregationKind() == MessageAggregationKind::FlushAggregationMessage)
+    {
+        Aggregate(blob); // don't forget to send (current) time sync message
+        Flush();
+    }
+    else
+    {
+        SendSilKitMsgInternal(std::move(blob));
+    }
+}
+
+void VAsioPeer::SendSilKitMsgInternal(std::vector<uint8_t> blob)
+{
     // Prevent sending when shutting down
     if (!_isShuttingDown && _socket != nullptr)
     {
         std::unique_lock<std::mutex> lock{_sendingQueueMutex};
 
-        _sendingQueue.push_back(buffer.ReleaseStorage());
+        _sendingQueue.emplace_back(std::move(blob));
 
         lock.unlock();
 
         _ioContext->Dispatch([this] { StartAsyncWrite(); });
     }
+}
+
+void VAsioPeer::Aggregate(const std::vector<uint8_t>& blob)
+{
+    // start initial timer
+    // NB: resetting timer in every Aggregate() is costly
+    if (!_initialTimerStarted)
+    {
+        _flushTimer->AsyncWaitFor(_flushTimeout);
+        _initialTimerStarted = true;
+    }
+    
+    _aggregatedMessages.insert(_aggregatedMessages.end(), blob.begin(), blob.end());
+
+    // ensure that the aggregation buffer does not exceed a certain size
+    if (_aggregatedMessages.size() > _aggregationBufferThreshold)
+    {
+        Services::Logging::Debug(_logger,
+                                 "VAsioPeer: Automated flush of aggregation buffer has been triggered, since the "
+                                 "maximum buffer size of {}Byte has been exceeded.",
+                                 _aggregationBufferThreshold);
+        Flush();
+    }
+}
+
+void VAsioPeer::Flush()
+{
+    decltype(_aggregatedMessages) blob;
+    blob.swap(_aggregatedMessages);
+    SendSilKitMsgInternal(std::move(blob));
+
+    // reset timer when flush is triggered
+	_flushTimer->AsyncWaitFor(_flushTimeout);
 }
 
 void VAsioPeer::StartAsyncWrite()
@@ -277,6 +334,29 @@ void VAsioPeer::OnShutdown(IRawByteStream& stream)
     _listener->OnPeerShutdown(this);
 }
 
+void VAsioPeer::OnTimerExpired(ITimer& timer)
+{
+    SILKIT_UNUSED_ARG(timer);
+    SILKIT_TRACE_METHOD_(_logger, "({})", static_cast<const void*>(&timer));
+
+    if (!_aggregatedMessages.empty())
+    {
+        Services::Logging::Warn(
+            _logger,
+            "VAsioPeer: Automated flush of aggregation buffer has been triggered, since the "
+            "maximum allowed time step duration of {}milliseconds has been exceeded. Consider switching off the "
+            "message aggregation via the config option 'EnableMessageAggregation'.",
+            _flushTimeout.count());
+
+        Flush();
+    }
+}
+
+void VAsioPeer::EnableAggregation()
+{
+    _useAggregation = true;
+    SilKit::Services::Logging::Debug(_logger, "VAsioPeer: Enable aggregation for peer {}", _info.participantName);
+}
 
 } // namespace Core
 } // namespace SilKit

--- a/SilKit/source/core/vasio/VAsioPeer.hpp
+++ b/SilKit/source/core/vasio/VAsioPeer.hpp
@@ -148,8 +148,9 @@ private:
     bool _useAggregation{false};
     const size_t _aggregationBufferThreshold{100 * 1000};
 
+    // we trigger a flush of aggregated messages, if too much time has passed since the last flush
     std::unique_ptr<ITimer> _flushTimer;
-    std::chrono::milliseconds _flushTimeout{50};
+    const std::chrono::milliseconds _flushTimeout{50};
     bool _initialTimerStarted{false};
 };
 

--- a/SilKit/source/core/vasio/VAsioPeer.hpp
+++ b/SilKit/source/core/vasio/VAsioPeer.hpp
@@ -38,6 +38,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE. */
 
 #include "IIoContext.hpp"
 #include "IRawByteStream.hpp"
+#include "ITimer.hpp"
 
 
 namespace SilKit {
@@ -47,6 +48,7 @@ namespace Core {
 class VAsioPeer
     : public IVAsioPeer
     , private IRawByteStreamListener
+    , private ITimerListener
 {
 public:
     // ----------------------------------------
@@ -93,6 +95,8 @@ public:
 
     void Shutdown() override;
 
+    void EnableAggregation() override;
+
 private:
     // ----------------------------------------
     // Private Methods
@@ -100,11 +104,17 @@ private:
     void WriteSomeAsync();
     void ReadSomeAsync();
     void DispatchBuffer();
+    void SendSilKitMsgInternal(std::vector<uint8_t> blob);
+    void Aggregate(const std::vector<uint8_t>& blob);
+    void Flush();
 
 private: // IRawByteStreamListener
     void OnAsyncReadSomeDone(IRawByteStream& stream, size_t bytesTransferred) override;
     void OnAsyncWriteSomeDone(IRawByteStream& stream, size_t bytesTransferred) override;
     void OnShutdown(IRawByteStream& stream) override;
+
+    // ITimerListener
+    void OnTimerExpired(ITimer& timer) override;
 
 private:
     // ----------------------------------------
@@ -130,9 +140,17 @@ private:
     std::deque<std::vector<uint8_t>> _sendingQueue;
     ConstBuffer _currentSendingBuffer;
     std::vector<uint8_t> _currentSendingBufferData;
+    std::vector<uint8_t> _aggregatedMessages;
 
     std::atomic_bool _sending{false};
     Core::ServiceDescriptor _serviceDescriptor;
+
+    bool _useAggregation{false};
+    const size_t _aggregationBufferThreshold{100 * 1000};
+
+    std::unique_ptr<ITimer> _flushTimer;
+    std::chrono::milliseconds _flushTimeout{50};
+    bool _initialTimerStarted{false};
 };
 
 // ================================================================================

--- a/SilKit/source/core/vasio/VAsioProxyPeer.cpp
+++ b/SilKit/source/core/vasio/VAsioProxyPeer.cpp
@@ -58,7 +58,11 @@ void VAsioProxyPeer::SendSilKitMsg(SerializedMessage buffer)
 
     Log::Trace(_logger, "VAsioProxyPeer ({}): SendSilKitMsg({})", _peerInfo.participantName, msg.payload.size());
 
-    _peer->SendSilKitMsg(SerializedMessage{msg});
+    // keep track of aggregation kind
+    auto bufferProxy = SerializedMessage{msg};
+    bufferProxy.SetAggregationKind(buffer.GetAggregationKind());
+
+    _peer->SendSilKitMsg(std::move(bufferProxy));
 }
 
 void VAsioProxyPeer::Subscribe(VAsioMsgSubscriber subscriber)
@@ -97,6 +101,11 @@ void VAsioProxyPeer::StartAsyncRead()
 void VAsioProxyPeer::Shutdown()
 {
     Log::Debug(_logger, "VAsioProxyPeer ({}): Shutdown: Ignored", _peerInfo.participantName);
+}
+
+void VAsioProxyPeer::EnableAggregation()
+{
+    Log::Debug(_logger, "VAsioProxyPeer ({}): EnableAggregation: Ignored", _peerInfo.participantName);
 }
 
 void VAsioProxyPeer::SetProtocolVersion(ProtocolVersion v)

--- a/SilKit/source/core/vasio/VAsioProxyPeer.hpp
+++ b/SilKit/source/core/vasio/VAsioProxyPeer.hpp
@@ -55,6 +55,7 @@ public: // IVAsioPeer
     auto GetLocalAddress() const -> std::string override;
     void StartAsyncRead() override;
     void Shutdown() override;
+    void EnableAggregation() override;
     void SetProtocolVersion(ProtocolVersion v) override;
     auto GetProtocolVersion() const -> ProtocolVersion override;
     void SetSimulationName(const std::string& simulationName) override;

--- a/SilKit/source/core/vasio/mock/MockVAsioPeer.hpp
+++ b/SilKit/source/core/vasio/mock/MockVAsioPeer.hpp
@@ -36,6 +36,7 @@ struct MockVAsioPeer : IVAsioPeer
     MOCK_METHOD(const std::string &, GetSimulationName, (), (const, override));
     MOCK_METHOD(void, StartAsyncRead, (), (override));
     MOCK_METHOD(void, Shutdown, (), (override));
+    MOCK_METHOD(void, EnableAggregation, (), (override));
     MOCK_METHOD(void, SetProtocolVersion, (ProtocolVersion), (override));
     MOCK_METHOD(ProtocolVersion, GetProtocolVersion, (), (const, override));
 

--- a/SilKit/source/dashboard/Client/DashboardSystemApiClient.hpp
+++ b/SilKit/source/dashboard/Client/DashboardSystemApiClient.hpp
@@ -158,8 +158,8 @@ class DashboardSystemApiClient : public oatpp::web::client::ApiClient
              BODY_DTO(Object<SimulationEndDto>, simulation))
 
     // bulk update of a simulation
-    API_CALL("POST", "system-service/v1.1/simulations/{simulationId}", updateSimulation,
-             PATH(UInt64, simulationId), BODY_DTO(Object<BulkSimulationDto>, simulation))
+    API_CALL("POST", "system-service/v1.1/simulations/{simulationId}", updateSimulation, PATH(UInt64, simulationId),
+             BODY_DTO(Object<BulkSimulationDto>, simulation))
 };
 
 } // namespace Dashboard

--- a/SilKit/source/services/logging/ILoggerInternal.hpp
+++ b/SilKit/source/services/logging/ILoggerInternal.hpp
@@ -31,8 +31,6 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE. */
 #include <string>
 
 
-
-
 namespace SilKit {
 namespace Services {
 namespace Logging {
@@ -47,7 +45,6 @@ struct ILoggerInternal : ILogger
 };
 
 
-
 template <typename... Args>
 void Log(ILogger* logger, Level level, const char* fmt, const Args&... args);
 
@@ -58,19 +55,22 @@ public:
     LoggerMessage(ILoggerInternal* logger, Level level)
         : _logger(logger)
         , _level(level)
-    {}
+    {
+    }
 
     LoggerMessage(ILoggerInternal* logger)
         : _logger(logger)
         , _level(Level::Trace)
-    {}
+    {
+    }
 
     LoggerMessage(ILoggerInternal* logger, const LogMsg& msg)
         : _logger(logger)
         , _level(msg.level)
         , _msg(msg.payload)
         , _keyValues(msg.keyValues)
-    {}
+    {
+    }
 
     template <typename... Args>
     void SetMessage(fmt::format_string<Args...> fmt, Args&&... args)
@@ -83,7 +83,7 @@ public:
         _msg = std::move(newMsg);
     }
 
-    template<typename Key, typename Value>
+    template <typename Key, typename Value>
     void SetKeyValue(Key&& key, Value&& value)
     {
         _keyValues[std::forward<Key>(key)] = std::forward<Value>(value);

--- a/SilKit/source/services/logging/Logger.hpp
+++ b/SilKit/source/services/logging/Logger.hpp
@@ -51,7 +51,8 @@ public:
     RemoteLogger(Level level, std::string participantName)
         : _level(level)
         , _participantName(participantName)
-    {}
+    {
+    }
 
     void Log(log_clock::time_point logTime, Level msgLevel, std::string msg)
     {
@@ -77,12 +78,7 @@ public:
         {
             if (_level <= msg.GetLevel())
             {
-                LogMsg logmsg{ _participantName
-                            , msg.GetLevel()
-                            , logTime
-                            , {}
-                            , msg.GetMsgString()
-                            , msg.GetKeyValues() };
+                LogMsg logmsg{_participantName, msg.GetLevel(), logTime, {}, msg.GetMsgString(), msg.GetKeyValues()};
                 // dispatch msg
                 _remoteSink(logmsg);
             }
@@ -117,7 +113,8 @@ public:
     {
         return _level;
     }
-    private:
+
+private:
     Level _level;
     std::function<void(const LogMsg&)> _remoteSink;
     std::string _participantName;
@@ -156,7 +153,7 @@ public:
     void DisableRemoteLogging();
     //void LogReceivedMsg(const LogMsg& msg);
 
-     auto GetLogLevel() const -> Level override;
+    auto GetLogLevel() const -> Level override;
 
     // ILoggerInternal
     void ProcessLoggerMessage(const LoggerMessage& msg) override;

--- a/SilKit/source/services/logging/LoggingSerdes.cpp
+++ b/SilKit/source/services/logging/LoggingSerdes.cpp
@@ -41,21 +41,12 @@ inline MessageBuffer& operator>>(MessageBuffer& buffer, SourceLoc& sourceLoc)
 
 inline MessageBuffer& operator<<(MessageBuffer& buffer, const LogMsg& msg)
 {
-    buffer << msg.loggerName
-           << msg.level
-           << msg.time
-           << msg.source
-           << msg.payload
-           << msg.keyValues;
+    buffer << msg.loggerName << msg.level << msg.time << msg.source << msg.payload << msg.keyValues;
     return buffer;
 }
 inline MessageBuffer& operator>>(MessageBuffer& buffer, LogMsg& msg)
 {
-    buffer >> msg.loggerName
-           >> msg.level
-           >> msg.time
-           >> msg.source
-           >> msg.payload;
+    buffer >> msg.loggerName >> msg.level >> msg.time >> msg.source >> msg.payload;
     if (buffer.RemainingBytesLeft() > 0)
     {
         buffer >> msg.keyValues;

--- a/SilKit/source/services/logging/MockLogger.hpp
+++ b/SilKit/source/services/logging/MockLogger.hpp
@@ -38,6 +38,7 @@ class MockLogger : public ::SilKit::Services::Logging::ILoggerInternal
     using Level = ::SilKit::Services::Logging::Level;
     using LoggerMessage = ::SilKit::Services::Logging::LoggerMessage;
     using LogMsg = ::SilKit::Services::Logging::LogMsg;
+
 public:
     MockLogger()
     {

--- a/SilKit/source/services/logging/SpdlogTypeConversion.hpp
+++ b/SilKit/source/services/logging/SpdlogTypeConversion.hpp
@@ -113,12 +113,7 @@ inline auto to_spdlog(const SourceLoc& loc) -> spdlog::source_loc
 
 inline auto to_spdlog(const LogMsg& msg) -> spdlog::details::log_msg
 {
-    return spdlog::details::log_msg{
-        to_spdlog(msg.source),
-        msg.loggerName,
-        to_spdlog(msg.level),
-        msg.payload
-    };
+    return spdlog::details::log_msg{to_spdlog(msg.source), msg.loggerName, to_spdlog(msg.level), msg.payload};
 }
 
 inline auto to_spdlog(const LogMsg& msg, const std::string& payload) -> spdlog::details::log_msg

--- a/SilKit/source/services/logging/Test_Logger.cpp
+++ b/SilKit/source/services/logging/Test_Logger.cpp
@@ -22,7 +22,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE. */
 #include <chrono>
 #include <functional>
 #include <string>
-#include<unordered_map>
+#include <unordered_map>
 
 #include "gtest/gtest.h"
 #include "gmock/gmock.h"
@@ -54,37 +54,29 @@ class MockParticipant : public DummyParticipant
 {
 public:
     MOCK_METHOD((void), SendMsg_LogMsg, (const IServiceEndpoint*, LogMsg));
-    void SendMsg(const IServiceEndpoint* from, Services::Logging::LogMsg&& msg) override 
+    void SendMsg(const IServiceEndpoint* from, Services::Logging::LogMsg&& msg) override
     {
         SendMsg_LogMsg(from, msg);
     }
-    void SendMsg(const IServiceEndpoint* from, const Services::Logging::LogMsg& msg) override 
+    void SendMsg(const IServiceEndpoint* from, const Services::Logging::LogMsg& msg) override
     {
         SendMsg_LogMsg(from, msg);
     }
 };
 
 
-
 auto ALogMsgWith(std::string loggerName, Level level, std::string payload) -> Matcher<LogMsg>
 {
-    return AllOf(
-        Field(&LogMsg::loggerName, loggerName),
-        Field(&LogMsg::level, level),
-        Field(&LogMsg::payload, payload)
+    return AllOf(Field(&LogMsg::loggerName, loggerName), Field(&LogMsg::level, level), Field(&LogMsg::payload, payload)
 
     );
 }
 
 auto ALogMsgWith(std::string loggerName, Level level, std::string payload,
-                 std::unordered_map<std::string, std::string> keyValues ) -> Matcher<LogMsg>
+                 std::unordered_map<std::string, std::string> keyValues) -> Matcher<LogMsg>
 {
-    return AllOf(
-        Field(&LogMsg::loggerName, loggerName), 
-        Field(&LogMsg::level, level), 
-        Field(&LogMsg::payload, payload),
-        Field(&LogMsg::keyValues, keyValues)
-    );
+    return AllOf(Field(&LogMsg::loggerName, loggerName), Field(&LogMsg::level, level), Field(&LogMsg::payload, payload),
+                 Field(&LogMsg::keyValues, keyValues));
 }
 
 TEST(Test_Logger, log_level_conversion)
@@ -137,18 +129,13 @@ TEST(Test_Logger, send_log_message_from_logger)
     logMsgSender.SetServiceDescriptor(controllerAddress);
 
 
-    logger.RegisterRemoteLogging([&logMsgSender](LogMsg logMsg) {
-        logMsgSender.SendLogMsg(std::move(logMsg));
-    });
+    logger.RegisterRemoteLogging([&logMsgSender](LogMsg logMsg) { logMsgSender.SendLogMsg(std::move(logMsg)); });
 
     std::string payload{"Test log message"};
 
-    EXPECT_CALL(mockParticipant, SendMsg_LogMsg(testing::_,
-        ALogMsgWith(loggerName, Level::Info, payload)))
-        .Times(1);
+    EXPECT_CALL(mockParticipant, SendMsg_LogMsg(testing::_, ALogMsgWith(loggerName, Level::Info, payload))).Times(1);
 
-    EXPECT_CALL(mockParticipant, SendMsg_LogMsg(testing::_,
-        ALogMsgWith(loggerName, Level::Critical, payload)))
+    EXPECT_CALL(mockParticipant, SendMsg_LogMsg(testing::_, ALogMsgWith(loggerName, Level::Critical, payload)))
         .Times(1);
 
     logger.Info(payload);
@@ -204,17 +191,19 @@ TEST(Test_Logger, send_loggermessage_from_logger)
     LogMsgSender logMsgSender(&mockParticipant);
     logMsgSender.SetServiceDescriptor(controllerAddress);
 
-    logger.RegisterRemoteLogging([&logMsgSender](LogMsg logMsg) {
-        logMsgSender.SendLogMsg(std::move(logMsg));
-    });
+    logger.RegisterRemoteLogging([&logMsgSender](LogMsg logMsg) { logMsgSender.SendLogMsg(std::move(logMsg)); });
 
     std::string payload{"Test log message"};
     std::string key{"TestKey"};
     std::string value{"TestValue"};
     std::unordered_map<std::string, std::string> keyValue{{key, value}};
 
-    EXPECT_CALL(mockParticipant, SendMsg_LogMsg(&logMsgSender, ALogMsgWith(loggerName, Level::Debug, payload, keyValue))).Times(1);
-    EXPECT_CALL(mockParticipant, SendMsg_LogMsg(&logMsgSender, ALogMsgWith(loggerName, Level::Critical, payload, keyValue))).Times(1);
+    EXPECT_CALL(mockParticipant,
+                SendMsg_LogMsg(&logMsgSender, ALogMsgWith(loggerName, Level::Debug, payload, keyValue)))
+        .Times(1);
+    EXPECT_CALL(mockParticipant,
+                SendMsg_LogMsg(&logMsgSender, ALogMsgWith(loggerName, Level::Critical, payload, keyValue)))
+        .Times(1);
 
     LoggerMessage lm{&logger, Level::Debug};
     lm.SetMessage(payload);
@@ -227,4 +216,4 @@ TEST(Test_Logger, send_loggermessage_from_logger)
     lm2.Dispatch();
 }
 
-}  // anonymous namespace
+} // anonymous namespace

--- a/SilKit/source/services/metrics/MetricsManager.cpp
+++ b/SilKit/source/services/metrics/MetricsManager.cpp
@@ -41,7 +41,7 @@ auto MetricClockNow() -> VSilKit::MetricTimePoint
     return VSilKit::MetricClock::now();
 }
 #endif
-}
+} // namespace
 namespace VSilKit {
 
 
@@ -120,7 +120,7 @@ private:
 MetricsManager::MetricsManager(std::string participantName, IMetricsProcessor &processor)
     : _participantName{std::move(participantName)}
     , _processor{&processor}
-    ,_lastSubmitUpdate{MetricClockNow()}
+    , _lastSubmitUpdate{MetricClockNow()}
 {
 }
 

--- a/SilKit/source/services/orchestration/LifecycleService.hpp
+++ b/SilKit/source/services/orchestration/LifecycleService.hpp
@@ -110,6 +110,7 @@ public:
     void SetTimeSyncService(TimeSyncService* timeSyncService);
 
     void NewSystemState(SystemState systemState);
+    void NewParticipantStatus(const ParticipantStatus& participantStatus);
 
     bool IsTimeSyncActive() const;
 

--- a/SilKit/source/services/orchestration/TimeSyncService.cpp
+++ b/SilKit/source/services/orchestration/TimeSyncService.cpp
@@ -37,17 +37,17 @@ using namespace std::chrono_literals;
 
 namespace {
 #ifdef _WIN32
-    auto GetDefaultTimerResolution() -> std::chrono::nanoseconds
-    {
-        return 16ms;
-    }
-#else
-    auto GetDefaultTimerResolution() -> std::chrono::nanoseconds
-    {
-        return 1ms;
-    }
-#endif
+auto GetDefaultTimerResolution() -> std::chrono::nanoseconds
+{
+    return 16ms;
 }
+#else
+auto GetDefaultTimerResolution() -> std::chrono::nanoseconds
+{
+    return 1ms;
+}
+#endif
+} // namespace
 
 namespace SilKit {
 namespace Services {
@@ -104,7 +104,7 @@ public:
         _isExecutingSimStep = false;
     }
 
-    auto IsExecutingSimStep() -> bool override 
+    auto IsExecutingSimStep() -> bool override
     {
         return _isExecutingSimStep;
     }
@@ -112,11 +112,11 @@ public:
     void RequestNextStep() override
     {
         // ensure that calls to Stop()/Pause() in a SimTask won't send out a new step and eventually call the SimTask again
-        if (_controller.State() == ParticipantState::Running 
-            && !_controller.StopRequested()
+        if (_controller.State() == ParticipantState::Running && !_controller.StopRequested()
             && !_controller.PauseRequested())
         {
-            if (_lastSentNextSimTask != _configuration->NextSimStep().timePoint) // Prevent sending same step more than once
+            if (_lastSentNextSimTask
+                != _configuration->NextSimStep().timePoint) // Prevent sending same step more than once
             {
                 _lastSentNextSimTask = _configuration->NextSimStep().timePoint;
                 _controller.SendMsg(_configuration->NextSimStep());
@@ -281,7 +281,8 @@ private:
 };
 
 TimeSyncService::TimeSyncService(Core::IParticipantInternal* participant, ITimeProvider* timeProvider,
-                                 const Config::HealthCheck& healthCheckConfig, LifecycleService* lifecycleService, double animationFactor)
+                                 const Config::HealthCheck& healthCheckConfig, LifecycleService* lifecycleService,
+                                 double animationFactor)
     : _participant{participant}
     , _lifecycleService{lifecycleService}
     , _logger{participant->GetLogger()}
@@ -298,7 +299,7 @@ TimeSyncService::TimeSyncService(Core::IParticipantInternal* participant, ITimeP
     {
         Debug(_logger, "TimeSyncService: Coupled to the local wall clock with animation factor {}", _animationFactor);
     }
-    
+
     _watchDog.SetWarnHandler([logger = _logger](std::chrono::milliseconds timeout) {
         Warn(logger, "SimStep did not finish within soft time limit. Timeout detected after {} ms",
              std::chrono::duration_cast<std::chrono::duration<double, std::milli>>(timeout).count());
@@ -409,7 +410,7 @@ auto TimeSyncService::PauseRequested() const -> bool
 }
 
 auto TimeSyncService::IsCoupledToWallClock() const -> bool
-{   
+{
     return _isCoupledToWallClock;
 }
 
@@ -516,9 +517,9 @@ void TimeSyncService::CompleteSimulationStep()
     _logger->Debug("CompleteSimulationStep: calling _timeSyncPolicy->RequestNextStep");
     _participant->ExecuteDeferred([this] {
         GetTimeSyncPolicy()->SetSimStepCompleted();
-        
+
         // With real-time sync, the next step is requested in the real-time thread. If lagging behind, request also here to catch up.
-        if (!_isCoupledToWallClock || _wallClockReachedBeforeCompletion) 
+        if (!_isCoupledToWallClock || _wallClockReachedBeforeCompletion)
         {
             _wallClockReachedBeforeCompletion = false;
             GetTimeSyncPolicy()->RequestNextStep();
@@ -595,7 +596,7 @@ void TimeSyncService::StartTime()
     }
 }
 
-void TimeSyncService::StopTime() 
+void TimeSyncService::StopTime()
 {
     if (_isCoupledToWallClock)
     {
@@ -665,7 +666,7 @@ void TimeSyncService::HybridWait(std::chrono::nanoseconds targetWaitDuration)
 
     // By default, Windows timer have a resolution of 15.6ms
     // The effective time that wait_for or sleep_for actually waits will be a step function with steps every 15.6ms
-    const auto defaultTimerResolution = GetDefaultTimerResolution(); 
+    const auto defaultTimerResolution = GetDefaultTimerResolution();
 
     if (targetWaitDuration < defaultTimerResolution)
     {
@@ -675,7 +676,7 @@ void TimeSyncService::HybridWait(std::chrono::nanoseconds targetWaitDuration)
     {
         auto timeBeforeSleep = std::chrono::steady_clock::now();
         // Wait the share of the targetWaitDuration that we can precisely achieve with the low timer resolution
-        auto sleepDuration = targetWaitDuration - defaultTimerResolution; 
+        auto sleepDuration = targetWaitDuration - defaultTimerResolution;
         std::this_thread::sleep_for(sleepDuration);
         // Busy-wait the remainder
         auto remainder = targetWaitDuration - (std::chrono::steady_clock::now() - timeBeforeSleep);
@@ -688,7 +689,6 @@ void TimeSyncService::StartWallClockCouplingThread()
 {
     _wallClockCouplingThreadRunning = true;
     _wallClockCouplingThread = std::thread{[this]() {
-
         SilKit::Util::SetThreadName("SK-WallClkSync");
 
         const auto startTime = std::chrono::steady_clock::now();
@@ -700,7 +700,7 @@ void TimeSyncService::StartWallClockCouplingThread()
             auto currentRunDuration = std::chrono::steady_clock::now() - startTime;
             auto durationUntilNextWallClockSyncPoint = nextAnimatedWallClockSyncPoint - currentRunDuration;
             HybridWait(std::chrono::duration_cast<std::chrono::nanoseconds>(durationUntilNextWallClockSyncPoint));
-            
+
             if (State() == ParticipantState::Running)
             {
                 auto duration =

--- a/SilKit/source/services/orchestration/TimeSyncService.cpp
+++ b/SilKit/source/services/orchestration/TimeSyncService.cpp
@@ -735,6 +735,11 @@ void TimeSyncService::StopWallClockCouplingThread()
     }
 }
 
+bool TimeSyncService::IsBlocking() const
+{
+    return _timeConfiguration.IsBlocking();
+}
+
 } // namespace Orchestration
 } // namespace Services
 } // namespace SilKit

--- a/SilKit/source/services/orchestration/TimeSyncService.hpp
+++ b/SilKit/source/services/orchestration/TimeSyncService.hpp
@@ -109,6 +109,8 @@ public:
     auto IsCoupledToWallClock() const -> bool;
     auto GetCurrentWallClockSyncPoint() const -> std::chrono::nanoseconds;
 
+    bool IsBlocking() const;
+
 private:
     // ----------------------------------------
     // private methods

--- a/SilKit/source/services/orchestration/TimeSyncService.hpp
+++ b/SilKit/source/services/orchestration/TimeSyncService.hpp
@@ -53,7 +53,6 @@ class TimeSyncService
     , public IMsgForTimeSyncService
     , public Core::IServiceEndpoint
 {
-
 public:
     // ----------------------------------------
     // Public Data Types
@@ -61,7 +60,8 @@ public:
     // ----------------------------------------
     // Constructors, Destructor, and Assignment
     TimeSyncService(Core::IParticipantInternal* participant, ITimeProvider* timeProvider,
-                    const Config::HealthCheck& healthCheckConfig, LifecycleService* lifecycleService, double animationFactor = 0);
+                    const Config::HealthCheck& healthCheckConfig, LifecycleService* lifecycleService,
+                    double animationFactor = 0);
 
     ~TimeSyncService();
 
@@ -88,7 +88,7 @@ public:
     void ConfigureTimeProvider(Orchestration::TimeProviderKind timeProviderKind);
     void StartTime();
     void StopTime();
-    
+
     // IServiceEndpoint
     inline void SetServiceDescriptor(const Core::ServiceDescriptor& serviceDescriptor) override;
     inline auto GetServiceDescriptor() const -> const Core::ServiceDescriptor& override;
@@ -120,7 +120,7 @@ private:
     bool SetupTimeSyncPolicy(bool isSynchronizingVirtualTime);
 
     inline auto GetTimeSyncPolicy() const -> ITimeSyncPolicy*;
-    
+
     void StopWallClockCouplingThread();
     void StartWallClockCouplingThread();
     void HybridWait(std::chrono::nanoseconds targetWaitDuration);
@@ -154,14 +154,13 @@ private:
     Util::PerformanceMonitor _execTimeMonitor;
     Util::PerformanceMonitor _waitTimeMonitor;
     WatchDog _watchDog;
-    bool _isCoupledToWallClock{false}; 
+    bool _isCoupledToWallClock{false};
     std::thread _wallClockCouplingThread;
     mutable std::mutex _mx;
     std::atomic<std::chrono::nanoseconds::rep> _currentWallClockSyncPointNs{0};
     double _animationFactor{0};
     std::atomic<bool> _wallClockCouplingThreadRunning{false};
     std::atomic<bool> _wallClockReachedBeforeCompletion{false};
-    
 };
 
 // ================================================================================

--- a/SilKit/source/services/rpc/RpcTestUtilities.hpp
+++ b/SilKit/source/services/rpc/RpcTestUtilities.hpp
@@ -114,6 +114,7 @@ struct MockConnection
     void FlushSendBuffers() {}
     void ExecuteDeferred(std::function<void()> /*callback*/) {}
     void NotifyShutdown() {}
+    void EnableAggregation() {}
 
     void RegisterMessageReceiver(
         std::function<void(SilKit::Core::IVAsioPeer* /*peer*/, SilKit::Core::ParticipantAnnouncement)> /*callback*/)

--- a/SilKit/source/services/rpc/RpcTestUtilities.hpp
+++ b/SilKit/source/services/rpc/RpcTestUtilities.hpp
@@ -44,8 +44,8 @@ namespace Tests {
 struct MockConnection
 {
     MockConnection(SilKit::Core::IParticipantInternal*, VSilKit::IMetricsManager*,
-                   SilKit::Config::ParticipantConfiguration /*config*/,
-                   std::string /*participantName*/, SilKit::Core::ParticipantId /*participantId*/,
+                   SilKit::Config::ParticipantConfiguration /*config*/, std::string /*participantName*/,
+                   SilKit::Core::ParticipantId /*participantId*/,
                    SilKit::Services::Orchestration::ITimeProvider* /*timeProvider*/, SilKit::Core::ProtocolVersion)
     {
     }

--- a/SilKit/source/util/StringHelpers.cpp
+++ b/SilKit/source/util/StringHelpers.cpp
@@ -112,6 +112,13 @@ auto CurrentTimestampString() -> std::string
     return fmt::format("{:%FT%H-%M-%S}", tm);
 }
 
+auto LowerCase(std::string input) -> std::string
+{
+    std::transform(input.begin(), input.end(), input.begin(),
+                   [](unsigned char c) { return (unsigned char)std::tolower(c); });
+    return input;
+}
+
 
 } // namespace Util
 } // namespace SilKit

--- a/SilKit/source/util/StringHelpers.hpp
+++ b/SilKit/source/util/StringHelpers.hpp
@@ -39,6 +39,8 @@ auto EscapeString(const std::string& input) -> std::string;
 
 auto CurrentTimestampString() -> std::string;
 
+auto LowerCase(std::string input) -> std::string;
+
 
 } // namespace Util
 } // namespace SilKit

--- a/Utilities/SilKitRegistry/Registry.cpp
+++ b/Utilities/SilKitRegistry/Registry.cpp
@@ -35,6 +35,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE. */
 #include "SignalHandler.hpp"
 #include "WindowsServiceMain.hpp"
 #include "RegistryConfiguration.hpp"
+#include "StringHelpers.hpp"
 
 #include "CommandlineParser.hpp"
 #include "ParticipantConfiguration.hpp"
@@ -56,14 +57,9 @@ using namespace SilKit::Util;
 using CliParser = SilKit::Util::CommandlineParser;
 
 namespace {
-auto lowerCase(std::string s)
-{
-    std::transform(s.begin(), s.end(), s.begin(), [](unsigned char c) { return (unsigned char)std::tolower(c); });
-    return s;
-}
 auto isValidLogLevel(const std::string& levelStr)
 {
-    auto logLevel = lowerCase(levelStr);
+    auto logLevel = SilKit::Util::LowerCase(levelStr);
     return logLevel == "trace" || logLevel == "debug" || logLevel == "warn" || logLevel == "info" || logLevel == "error"
            || logLevel == "critical" || logLevel == "off";
 }

--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -14,6 +14,12 @@ Fixed
 
 - Fixed crash in ``sil-kit-registry`` utility that happened when the dashboard is enabled, but not actually available.
 
+Added
+~~~~~
+
+- Message aggregation for simulations with time synchronization.
+  Accessible via the experimental section in the Participant Configuration (Experimental | TimeSynchronization | EnableMessageAggregation).
+
 
 [4.0.51] - 2024-07-18 
 ---------------------

--- a/docs/configuration/experimental-configuration.rst
+++ b/docs/configuration/experimental-configuration.rst
@@ -15,7 +15,7 @@ Overview
 This section includes experimental configuration fields.
 
 .. warning::
-  The featues available through the experimental section might be changed or removed in future versions of the |ProductName|.
+  The features available through the experimental section might be changed or removed in future versions of the |ProductName|.
 
 TimeSynchronization
 --------------------
@@ -25,6 +25,7 @@ TimeSynchronization
     Experimental:
         TimeSynchronization:
             AnimationFactor: 1.0
+            EnableMessageAggregation: Auto
 
 .. list-table:: TimeSynchronization Configuration
    :widths: 15 85
@@ -35,11 +36,22 @@ TimeSynchronization
 
    * - AnimationFactor
      - This value affects |ProductName| simulations where a time synchronization service is used. 
-       When this value is set, the virtual time is coulped to the local wall clock of the underlying system, scaled down by the given factor.
+       When this value is set, the virtual time is coupled to the local wall clock of the underlying system, scaled down by the given factor.
        E.g., a value of 1.0 means direct coupling to the wall clock. 
        A value of 2.0 means that the virtual time runs **twice as slow** as the local wall clock. 
        Accordingly, a value of 0.5 will cause the virtual time to run **twice as fast**. 
        When omitting the value or setting it to zero, no coupling to the wall clock takes place.
 
        .. note::
-         Depending on the simulation step size, the choosen animation factor and the computational load per simulation step, it might not be possible to couple the virtual time to the wall clock with the desired factor.
+         Depending on the simulation step size, the chosen animation factor and the computational load per simulation step, it might not be possible to couple the virtual time to the wall clock with the desired factor.
+
+   * - EnableMessageAggregation
+     - Enable the aggregation of messages in |ProductName| simulations with time synchronization. 
+       Valid options are *On*, *Auto* and *Off*. 
+       If option *Auto* is chosen, the aggregation is enabled only for the case of synchronous simulation step handlers. 
+       If option *On* is chosen, the aggregation is enabled for both synchronous and asynchronous simulation step handlers.
+       
+       .. note::
+         Option *Auto* can be chosen without any concerns. 
+         In the case of option *On*, however, it is necessary to verify that the transmission of messages within a time step does not depend on incoming messages from other participants.
+         In this case, the time step will not be terminated and the communication will block.

--- a/docs/configuration/experimental-configuration.rst
+++ b/docs/configuration/experimental-configuration.rst
@@ -25,7 +25,7 @@ TimeSynchronization
     Experimental:
         TimeSynchronization:
             AnimationFactor: 1.0
-            EnableMessageAggregation: Auto
+            EnableMessageAggregation: Off
 
 .. list-table:: TimeSynchronization Configuration
    :widths: 15 85


### PR DESCRIPTION
## Subject

Implementation of a message aggregation mechanism for the VAsioPeer (time sync case only).


## Description

For simulations with time synchronization, user data messages (PubSub, RPC, CAN, Ethernet) are aggregated in the VAsioPeer and send en bloc at the end of the corresponding time step. Messages are only aggregated, once the state of the lifecycle is ReadyToRun.
The aggregation feature can be enabled/disabled via the flag "EnableMessageAggregation" in the participant config file.

NB: The Test_MetricsManager has been deactivated (failure in previous commit). We need to fix this and reactivate the test.


## Instructions for review / testing


## Developer checklist (address before review)

- [ ] Changelog.md updated
- [ ] Prepared update for depending repositories
- [ ] Documentation updated (public API changes only)
- [ ] API docstrings updated (public API changes only)
- [ ] Rebase &rarr; commit history clean
- [ ] Squash and merge &rarr; proper PR title
