### PR TITLE
tests: fix usage of steady_clock in MetricsManager on windows

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -105,11 +105,13 @@
         },
         {
             "name": "x64-relwithdebinfo",
-            "displayName": "x64 Release with Debug Info",
             "description": "Target Windows (64-bit) with the Visual Studio development environment. (RelWithDebInfo)",
             "inherits": "x64-debug",
             "environment": {
                 "SILKIT_CMAKE_PRESET_BUILD_TYPE": "RelWithDebInfo"
+            },
+            "cacheVariables": {
+                "SILKIT_PACKAGE_SYMBOLS": "OFF"
             }
         },
         {

--- a/SilKit/source/services/metrics/MetricsManager.hpp
+++ b/SilKit/source/services/metrics/MetricsManager.hpp
@@ -34,16 +34,12 @@ using MetricTimePoint = MetricClock::time_point;
 
 class MetricsManager : public IMetricsManager
 {
-public:
-    using Clock = MetricClock;
-    using TimePoint = MetricTimePoint;
-
 private:
     struct IMetric
     {
         virtual ~IMetric() = default;
         virtual auto GetMetricKind() const -> MetricKind = 0;
-        virtual auto GetUpdateTime() const -> TimePoint = 0;
+        virtual auto GetUpdateTime() const -> MetricTimePoint = 0;
         virtual auto FormatValue() const -> std::string = 0;
     };
 
@@ -74,7 +70,7 @@ private:
 
     std::mutex _mutex;
     std::unordered_map<std::string, std::unique_ptr<IMetric>> _metrics;
-    TimePoint _lastSubmitUpdate{Clock::now()};
+    MetricTimePoint _lastSubmitUpdate;
 };
 
 


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2023 Vector Informatik GmbH

SPDX-License-Identifier: MIT
-->

## Subject
<!--
    - What kind of changes does this pull request comprise?
    - Add a label like "Bugfix", "docs", etc. to this PR to give context.
 -->
Fix sporadic unit test failures on MSVC RelWithDebInfo builds.

## Description
<!--
    - Give a short summary of the intention of the changes.
    - Don't replicate the commit messages here.
    - Which Jira tickets are addressed with this pull request (list all if multiple tickets are affected)?
-->
Turns out that the calls to `steady_clock::now()` return the same value sometimes (on Windows!). 
Those calls are now wrapped and checked against the previous value and it's ensured that the timestamp increases strictly monotonically.

## Instructions for review / testing
<!--
    - Hilight some of the important changes, which reviewers should focus on
    - Which parts should be reviewed in detail? For example: content of console output, correct semantics of changes
    - Test steps and test setup description. For example: which programs or configs to use
-->

## Developer checklist (address before review)

- [ ] Changelog.md updated
- [ ] Prepared update for depending repositories
- [ ] Documentation updated (public API changes only)
- [ ] API docstrings updated (public API changes only)
- [ ] Rebase &rarr; commit history clean
- [ ] Squash and merge &rarr; proper PR title
