### PR TITLE
dashboard: fix crash when dashboard is unavailable

### DIFF
--- a/SilKit/source/dashboard/DashboardInstance.cpp
+++ b/SilKit/source/dashboard/DashboardInstance.cpp
@@ -121,11 +121,16 @@ struct EventQueueWorkerThread
 
     auto DetectBulkUpdate() const -> bool
     {
+        bool bulkUpdateAvailable = false;
+
         auto bulkSimulationDto = SilKit::Dashboard::BulkSimulationDto::createShared();
-        const auto response =
-            apiClient->updateSimulation(oatpp::UInt64{std::uint64_t{0}}, std::move(bulkSimulationDto));
-        const auto statusCode = response->getStatusCode();
-        const bool bulkUpdateAvailable = 200 <= statusCode && statusCode < 300;
+        const auto response = apiClient->updateSimulation(oatpp::UInt64{std::uint64_t{0}}, bulkSimulationDto);
+
+        if (response)
+        {
+            const auto statusCode = response->getStatusCode();
+            bulkUpdateAvailable = 200 <= statusCode && statusCode < 300;
+        }
 
         if (bulkUpdateAvailable)
         {

--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -9,6 +9,10 @@ The format is based on `Keep a Changelog (http://keepachangelog.com/en/1.0.0/) <
 [4.0.52] - UNRELEASED 
 ---------------------
 
+Fixed
+~~~~~
+
+- Fixed crash in ``sil-kit-registry`` utility that happened when the dashboard is enabled, but not actually available.
 
 
 [4.0.51] - 2024-07-18 


### PR DESCRIPTION
Issue: SILKIT-1586

<!--
SPDX-FileCopyrightText: 2023 Vector Informatik GmbH

SPDX-License-Identifier: MIT
-->

## Description
<!--
    - Give a short summary of the intention of the changes.
    - Don't replicate the commit messages here.
    - Which Jira tickets are addressed with this pull request (list all if multiple tickets are affected)?
-->

The `response` object is null if the server isn't available.

## Instructions for review / testing
<!--
    - Hilight some of the important changes, which reviewers should focus on
    - Which parts should be reviewed in detail? For example: content of console output, correct semantics of changes
    - Test steps and test setup description. For example: which programs or configs to use
-->

Run the registry with `--dashboard-uri` / `--enable-dashboard` but without running the dashboard itself (i.e., nothing to connect to).

## Developer checklist (address before review)

- [x] Changelog.md updated
- [ ] Prepared update for depending repositories
- [ ] Documentation updated (public API changes only)
- [ ] API docstrings updated (public API changes only)
- [ ] Rebase &rarr; commit history clean
- [x] Squash and merge &rarr; proper PR title
