### PR TITLE
cmake: add _WIN32_WINNT define to I_SilKit_Util

### DIFF
--- a/SilKit/source/util/CMakeLists.txt
+++ b/SilKit/source/util/CMakeLists.txt
@@ -32,6 +32,13 @@ target_link_libraries(O_SilKit_Util
     PRIVATE fmt-header-only
 )
 
+if (MSVC)
+    target_compile_definitions(I_SilKit_Util INTERFACE _WIN32_WINNT=0x0601)
+endif()
+if(MINGW)
+    target_compile_definitions(I_SilKit_Util INTERFACE _WIN32_WINNT=0x0601)
+endif()
+
 
 add_subdirectory(tests)
 


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2023 Vector Informatik GmbH

SPDX-License-Identifier: MIT
-->

## Subject
<!--
    - What kind of changes does this pull request comprise?
    - Add a label like "Bugfix", "docs", etc. to this PR to give context.
 -->

The `ExecutinEnvironment.cpp` compilation produces a warning regarding missing the `_WIN32_WINNT` definition. This should not happen anymore.

## Description
<!--
    - Give a short summary of the intention of the changes.
    - Don't replicate the commit messages here.
    - Which Jira tickets are addressed with this pull request (list all if multiple tickets are affected)?
-->

## Instructions for review / testing
<!--
    - Hilight some of the important changes, which reviewers should focus on
    - Which parts should be reviewed in detail? For example: content of console output, correct semantics of changes
    - Test steps and test setup description. For example: which programs or configs to use
-->

## Developer checklist (address before review)

- [ ] Changelog.md updated
- [ ] Prepared update for depending repositories
- [ ] Documentation updated (public API changes only)
- [ ] API docstrings updated (public API changes only)
- [ ] Rebase &rarr; commit history clean
- [x] Squash and merge &rarr; proper PR title
