### PR TITLE
tests: remove MakeTestRegistryUri

### DIFF
--- a/SilKit/IntegrationTests/FTest_CanControllerThreadSafety.cpp
+++ b/SilKit/IntegrationTests/FTest_CanControllerThreadSafety.cpp
@@ -25,8 +25,6 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE. */
 #include <string>
 #include <thread>
 
-#include "GetTestPid.hpp"
-
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 

--- a/SilKit/IntegrationTests/FTest_CanWithoutSync.cpp
+++ b/SilKit/IntegrationTests/FTest_CanWithoutSync.cpp
@@ -31,8 +31,6 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE. */
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
-#include "GetTestPid.hpp"
-
 namespace {
 
 using namespace std::chrono_literals;

--- a/SilKit/IntegrationTests/FTest_CanWithoutSync.cpp
+++ b/SilKit/IntegrationTests/FTest_CanWithoutSync.cpp
@@ -50,7 +50,6 @@ class FTest_CanWithoutSync : public testing::Test
 protected:
     FTest_CanWithoutSync()
     {
-        _registryUri = MakeTestRegistryUri();
         SetupTestData();
     }
 
@@ -214,7 +213,7 @@ TEST_F(FTest_CanWithoutSync, can_communication_no_simulation_flow_vasio)
 {
     auto registry =
         SilKit::Vendor::Vector::CreateSilKitRegistry(SilKit::Config::ParticipantConfigurationFromString(""));
-    registry->StartListening(_registryUri);
+    _registryUri = registry->StartListening("silkit://localhost:0");
     ExecuteTest();
 }
 

--- a/SilKit/IntegrationTests/FTest_EthWithoutSync.cpp
+++ b/SilKit/IntegrationTests/FTest_EthWithoutSync.cpp
@@ -31,7 +31,6 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE. */
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
-#include "GetTestPid.hpp"
 #include "EthernetHelpers.hpp"
 
 namespace {

--- a/SilKit/IntegrationTests/FTest_EthWithoutSync.cpp
+++ b/SilKit/IntegrationTests/FTest_EthWithoutSync.cpp
@@ -52,7 +52,6 @@ class FTest_EthWithoutSync : public testing::Test
 protected:
     FTest_EthWithoutSync()
     {
-        _registryUri = MakeTestRegistryUri();
         SetupTestData();
     }
 
@@ -203,7 +202,7 @@ TEST_F(FTest_EthWithoutSync, eth_communication_no_simulation_flow_vasio)
 {
     auto registry =
         SilKit::Vendor::Vector::CreateSilKitRegistry(SilKit::Config::ParticipantConfigurationFromString(""));
-    registry->StartListening(_registryUri);
+    _registryUri = registry->StartListening("silkit://localhost:0");
     ExecuteTest();
 }
 

--- a/SilKit/IntegrationTests/FTest_PubSubPerf.cpp
+++ b/SilKit/IntegrationTests/FTest_PubSubPerf.cpp
@@ -74,8 +74,7 @@ protected:
             auto start = Now();
 
             std::vector<std::string> syncParticipantNames = {"Publisher", "Subscriber"};
-            auto registryUri = MakeTestRegistryUri();
-            SilKit::Tests::SimTestHarness testHarness(syncParticipantNames, registryUri, true);
+            SilKit::Tests::SimTestHarness testHarness(syncParticipantNames, "silkit://localhost:0", true);
 
             auto definePubSpec = [topicModePub, labelModePub](int i) {
                 std::string topic = "Topic";

--- a/SilKit/IntegrationTests/FTest_PubSubPerf.cpp
+++ b/SilKit/IntegrationTests/FTest_PubSubPerf.cpp
@@ -27,8 +27,6 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE. */
 
 #include "SimTestHarness.hpp"
 
-#include "GetTestPid.hpp"
-
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 

--- a/SilKit/IntegrationTests/FTest_ServiceDiscoveryPerf.cpp
+++ b/SilKit/IntegrationTests/FTest_ServiceDiscoveryPerf.cpp
@@ -52,9 +52,8 @@ protected:
         auto start = Now();
 
         std::vector<std::string> syncParticipantNames = {"Publisher", "Subscriber", "Subscriber2"};
-        auto registryUri = MakeTestRegistryUri();
 
-        SilKit::Tests::SimTestHarness testHarness(syncParticipantNames, registryUri, true);
+        SilKit::Tests::SimTestHarness testHarness(syncParticipantNames, "silkit://localhost:0", true);
         auto&& publisher = testHarness.GetParticipant("Publisher");
 
         for (auto i = 0; i < numberOfServices; i++)

--- a/SilKit/IntegrationTests/FTest_ServiceDiscoveryPerf.cpp
+++ b/SilKit/IntegrationTests/FTest_ServiceDiscoveryPerf.cpp
@@ -27,8 +27,6 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE. */
 
 #include "SimTestHarness.hpp"
 
-#include "GetTestPid.hpp"
-
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 

--- a/SilKit/IntegrationTests/FTest_WallClockCoupling.cpp
+++ b/SilKit/IntegrationTests/FTest_WallClockCoupling.cpp
@@ -31,8 +31,6 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE. */
 
 #include "SimTestHarness.hpp"
 
-#include "GetTestPid.hpp"
-
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 

--- a/SilKit/IntegrationTests/FTest_WallClockCoupling.cpp
+++ b/SilKit/IntegrationTests/FTest_WallClockCoupling.cpp
@@ -46,7 +46,7 @@ TEST(FTest_WallClockCoupling, test_wallclock_sync_simtask)
     double animationFactor = 2.0;
     std::string configWithAnimFactor = R"({"Experimental": {"TimeSynchronization": { "AnimationFactor": 2.0 } }})";
 
-    SimTestHarness testHarness({"P1", "P2", "P3"}, MakeTestRegistryUri(), true);
+    SimTestHarness testHarness({"P1", "P2", "P3"}, "silkit://localhost:0", true);
 
     auto wc_P1{0ns};
     auto wc_P2{0ns};
@@ -115,7 +115,7 @@ TEST(FTest_WallClockCoupling, test_wallclock_mixed_simtask)
     double animationFactor = 2.0;
     std::string configWithAnimFactor = R"({"Experimental": {"TimeSynchronization": { "AnimationFactor": 2.0 } }})";
 
-    SimTestHarness testHarness({"P1", "P2", "P3"}, MakeTestRegistryUri(), true);
+    SimTestHarness testHarness({"P1", "P2", "P3"}, "silkit://localhost:0", true);
 
     auto wc_P1{0ns};
     auto wc_P2{0ns};

--- a/SilKit/IntegrationTests/GetTestPid.hpp
+++ b/SilKit/IntegrationTests/GetTestPid.hpp
@@ -29,16 +29,6 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE. */
 #include <unistd.h>
 #endif
 
-inline auto MakeTestRegistryUri()
-{
-    std::stringstream ss;
-    int port = 8500;
-    int pid = getpid();
-    port += pid % 1000; // clamp to [8500, 9500)
-    // add a random offset to prevent two tests listening on the same port
-    ss << "silkit://localhost:" << port;
-    return ss.str();
-}
 
 inline auto MakeTestDashboardUri()
 {

--- a/SilKit/IntegrationTests/ITestFixture.hpp
+++ b/SilKit/IntegrationTests/ITestFixture.hpp
@@ -78,8 +78,10 @@ protected:
     {
         // create test harness with deferred participant and controller creation.
         // Will only create the SIL Kit Registry and tell the SystemController the participantNames
-        _simTestHarness = std::make_unique<SimTestHarness>(coordinatedParticipantNames, _registryUri, true, true,
+        _simTestHarness =
+            std::make_unique<SimTestHarness>(coordinatedParticipantNames, "silkit://localhost:0", true, true,
                                                            autonomousParticipantNames);
+        _registryUri = _simTestHarness->GetRegistryUri();
     }
 
 protected: // members

--- a/SilKit/IntegrationTests/ITestFixture.hpp
+++ b/SilKit/IntegrationTests/ITestFixture.hpp
@@ -39,7 +39,6 @@ class ITest_SimTestHarness : public testing::Test
 {
 protected: //CTor and operators
     ITest_SimTestHarness()
-        : _registryUri{MakeTestRegistryUri()}
     {
     }
 
@@ -52,11 +51,12 @@ protected: //CTor and operators
     {
         // create test harness with deferred participant creation.
         // Will only create the SIL Kit Registry and tell the SystemController the participantNames
-        _simTestHarness = std::make_unique<SimTestHarness>(participantNames, _registryUri, true);
+        _simTestHarness = std::make_unique<SimTestHarness>(participantNames, "silkit://localhost:0", true);
+        _registryUri = _simTestHarness->GetRegistryUri();
     }
 
 protected: // members
-    std::string _registryUri;
+    std::string _registryUri{};
     std::unique_ptr<SimTestHarness> _simTestHarness;
 };
 

--- a/SilKit/IntegrationTests/ITestFixture.hpp
+++ b/SilKit/IntegrationTests/ITestFixture.hpp
@@ -38,9 +38,6 @@ namespace Tests {
 class ITest_SimTestHarness : public testing::Test
 {
 protected: //CTor and operators
-    ITest_SimTestHarness()
-    {
-    }
 
     auto TestHarness() -> SimTestHarness&
     {

--- a/SilKit/IntegrationTests/ITest_Abort.cpp
+++ b/SilKit/IntegrationTests/ITest_Abort.cpp
@@ -102,7 +102,7 @@ TEST_F(ITest_Abort, test_Abort_Paused_Simulation_Sync)
     AbortSystemController();
 
     // Wait for coordinated to end
-    JoinParticipantThreads(participantThreads_Sync_Coordinated);
+    JoinParticipantThreads(_participantThreads_Sync_Coordinated);
 
     // Expect shutdown state, which should happen after the abort handlers are called.
     for (const auto& participant : monitorParticipants.front().CopyMonitoredParticipantStates())
@@ -114,7 +114,7 @@ TEST_F(ITest_Abort, test_Abort_Paused_Simulation_Sync)
     }
 
     monitorParticipants.front().i.stopRequested = true;
-    JoinParticipantThreads(participantThreads_Async_Autonomous);
+    JoinParticipantThreads(_participantThreads_Async_Autonomous);
 
     StopRegistry();
 }
@@ -174,7 +174,7 @@ TEST_F(ITest_Abort, test_Abort_Running_Simulation_Sync)
     AbortSystemController();
 
     // Wait for coordinated to end
-    JoinParticipantThreads(participantThreads_Sync_Coordinated);
+    JoinParticipantThreads(_participantThreads_Sync_Coordinated);
 
     // Expect shutdown state, which should happen after the abort handlers are called.
     for (const auto& participant : monitorParticipants.front().CopyMonitoredParticipantStates())
@@ -186,7 +186,7 @@ TEST_F(ITest_Abort, test_Abort_Running_Simulation_Sync)
     }
 
     monitorParticipants.front().i.stopRequested = true;
-    JoinParticipantThreads(participantThreads_Async_Autonomous);
+    JoinParticipantThreads(_participantThreads_Async_Autonomous);
 
     StopRegistry();
 }
@@ -260,7 +260,7 @@ TEST_F(ITest_Abort, test_Abort_Stopped_Simulation_Sync)
     StopSystemController();
 
     // Wait for coordinated to end
-    JoinParticipantThreads(participantThreads_Sync_Coordinated);
+    JoinParticipantThreads(_participantThreads_Sync_Coordinated);
 
     // Expect shutdown state, which should happen after the abort handlers are called.
     for (const auto& participant : monitorParticipants.front().CopyMonitoredParticipantStates())
@@ -272,7 +272,7 @@ TEST_F(ITest_Abort, test_Abort_Stopped_Simulation_Sync)
     }
 
     monitorParticipants.front().i.stopRequested = true;
-    JoinParticipantThreads(participantThreads_Async_Autonomous);
+    JoinParticipantThreads(_participantThreads_Async_Autonomous);
 
     StopRegistry();
 }
@@ -338,10 +338,10 @@ TEST_F(ITest_Abort, test_Abort_Communication_Ready_Simulation_Sync)
     systemControllerParticipant.AwaitCommunicationInitialized();
 
     // Wait for coordinated to end
-    JoinParticipantThreads(participantThreads_Sync_Coordinated);
+    JoinParticipantThreads(_participantThreads_Sync_Coordinated);
 
     monitorParticipants.front().i.stopRequested = true;
-    JoinParticipantThreads(participantThreads_Async_Autonomous);
+    JoinParticipantThreads(_participantThreads_Async_Autonomous);
 
     // Expect shutdown state, which should happen after the abort handlers are called.
     for (const auto& participant : monitorParticipants.front().CopyMonitoredParticipantStates())

--- a/SilKit/IntegrationTests/ITest_AsyncSimTask.cpp
+++ b/SilKit/IntegrationTests/ITest_AsyncSimTask.cpp
@@ -31,8 +31,6 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE. */
 
 #include "SimTestHarness.hpp"
 
-#include "GetTestPid.hpp"
-
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 

--- a/SilKit/IntegrationTests/ITest_AsyncSimTask.cpp
+++ b/SilKit/IntegrationTests/ITest_AsyncSimTask.cpp
@@ -54,7 +54,7 @@ TEST(ITest_AsyncSimTask, test_async_simtask_lockstep)
     // Async may not start a new SimTask before calling CompleteSimulationtask to complete the current one.
 
 
-    SimTestHarness testHarness({"Sync", "Async"}, MakeTestRegistryUri());
+    SimTestHarness testHarness({"Sync", "Async"}, "silkit://localhost:0");
 
     std::atomic<std::chrono::nanoseconds> syncTimeNs{0ns};
     std::atomic<bool> done{false};
@@ -142,7 +142,7 @@ TEST(ITest_AsyncSimTask, test_async_simtask_nodeadlock)
     // The async participant uses the CompleteSimTask calls to request next simulation step.
     // The sync participant will be used to check the time progress
 
-    SimTestHarness testHarness({"Sync", "Async"}, MakeTestRegistryUri());
+    SimTestHarness testHarness({"Sync", "Async"}, "silkit://localhost:0");
 
     auto syncTimeNs{0ns};
 
@@ -179,7 +179,7 @@ TEST(ITest_AsyncSimTask, test_async_simtask_different_periods)
     // The async and sync participant use different time periods to validate the that a slower participant does
     // not execute its simtask too often.
 
-    SimTestHarness testHarness({"Sync", "Async"}, MakeTestRegistryUri());
+    SimTestHarness testHarness({"Sync", "Async"}, "silkit://localhost:0");
 
     auto syncTime{0ns};
     auto asyncTime{0ns};
@@ -214,7 +214,7 @@ TEST(ITest_AsyncSimTask, test_async_simtask_multiple_completion_calls)
 {
     // Verify that multiple CompleteSimTask calls do not trigger malicious behaviour
 
-    SimTestHarness testHarness({"Sync", "Async"}, MakeTestRegistryUri());
+    SimTestHarness testHarness({"Sync", "Async"}, "silkit://localhost:0");
 
     auto syncTime{0ns};
     auto asyncTime{0ns};

--- a/SilKit/IntegrationTests/ITest_CatchExceptionsInCallbacks.cpp
+++ b/SilKit/IntegrationTests/ITest_CatchExceptionsInCallbacks.cpp
@@ -32,8 +32,6 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE. */
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
-#include "GetTestPid.hpp"
-
 namespace {
 
 using namespace std::chrono_literals;

--- a/SilKit/IntegrationTests/ITest_CatchExceptionsInCallbacks.cpp
+++ b/SilKit/IntegrationTests/ITest_CatchExceptionsInCallbacks.cpp
@@ -65,11 +65,10 @@ protected:
 
 TEST_F(ITest_CatchExceptionsInCallbacks, please_dont_crash_vasio)
 {
-    auto registryUri = MakeTestRegistryUri();
 
     auto registry =
         SilKit::Vendor::Vector::CreateSilKitRegistry(SilKit::Config::ParticipantConfigurationFromString(""));
-    registry->StartListening(registryUri);
+    auto registryUri = registry->StartListening("silkit://localhost:0");
 
     auto pubParticipant =
         SilKit::CreateParticipant(SilKit::Config::ParticipantConfigurationFromString(""), "Sender", registryUri);

--- a/SilKit/IntegrationTests/ITest_CommunicationGuarantees.cpp
+++ b/SilKit/IntegrationTests/ITest_CommunicationGuarantees.cpp
@@ -453,10 +453,10 @@ protected:
         FAIL() << reason;
     }
 
-    void RunRegistry(const std::string& registryUri)
+    auto RunRegistry(const std::string& registryUri) -> std::string
     {
         registry = SilKit::Vendor::Vector::CreateSilKitRegistry(SilKit::Config::ParticipantConfigurationFromString(""));
-        registry->StartListening(registryUri);
+        return registry->StartListening(registryUri);
     }
 
     void RunSystemMaster(const std::string& registryUri)
@@ -502,9 +502,9 @@ protected:
         participantThreads.clear();
     }
 
-    void SetupSystem(const std::string& registryUri, std::vector<TestParticipant>& participants)
+    auto SetupSystem(const std::string& registryUri, std::vector<TestParticipant>& participants) -> std::string
     {
-        RunRegistry(registryUri);
+        auto newRegistryUri = RunRegistry(registryUri);
 
         for (auto&& p : participants)
         {
@@ -524,6 +524,7 @@ protected:
         {
             systemController.active = false;
         }
+        return newRegistryUri;
     }
 
     void SystemCleanup()
@@ -538,8 +539,7 @@ protected:
     {
         try
         {
-            auto registryUri = MakeTestRegistryUri();
-            SetupSystem(registryUri, participants);
+            auto registryUri = SetupSystem("silkit://localhost:0", participants);
             RunParticipantThreads(participants, registryUri);
             Log() << ">> Await all done";
             for (auto& p : participants)
@@ -598,8 +598,7 @@ protected:
             participants.push_back({"Sub", {}, {topic1}, OperationMode::Autonomous, TimeMode::Async});
             auto& subParticipant = participants.at(1);
 
-            auto registryUri = MakeTestRegistryUri();
-            SetupSystem(registryUri, participants);
+            auto registryUri = SetupSystem("silkit://localhost:0", participants);
             RunParticipantThreads(participants, registryUri);
 
             for (auto& p : participants)
@@ -684,8 +683,7 @@ TEST_F(ITest_CommunicationGuarantees, test_receive_in_comm_ready_handler_autonom
 
     try
     {
-        auto registryUri = MakeTestRegistryUri();
-        RunRegistry(registryUri);
+        auto registryUri = RunRegistry("silkit://localhost:0");
         RunParticipantThreads(autonomousAsyncParticipantsSub, registryUri);
         // If we would start all participants at once, we cannot guarantee communication because
         // the publish might happen even before the subscriber created it's controllers.
@@ -794,9 +792,8 @@ TEST_F(ITest_CommunicationGuarantees, test_receive_in_comm_ready_handler_mixed)
 
     try
     {
-        auto registryUri = MakeTestRegistryUri();
 
-        SetupSystem(registryUri, coordinatedSyncParticipantsSub);
+        auto registryUri = SetupSystem("silkit://localhost:0", coordinatedSyncParticipantsSub);
 
         // Start the coordinated participants
         RunParticipantThreads(coordinatedSyncParticipantsSub, registryUri);

--- a/SilKit/IntegrationTests/ITest_CommunicationGuarantees.cpp
+++ b/SilKit/IntegrationTests/ITest_CommunicationGuarantees.cpp
@@ -26,8 +26,6 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE. */
 #include <string>
 #include <thread>
 
-#include "GetTestPid.hpp"
-
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 

--- a/SilKit/IntegrationTests/ITest_CommunicationGuarantees.cpp
+++ b/SilKit/IntegrationTests/ITest_CommunicationGuarantees.cpp
@@ -502,9 +502,9 @@ protected:
         participantThreads.clear();
     }
 
-    auto SetupSystem(const std::string& registryUri, std::vector<TestParticipant>& participants) -> std::string
+    auto SetupSystem(const std::string& requestedRegistryUri, std::vector<TestParticipant>& participants) -> std::string
     {
-        auto newRegistryUri = RunRegistry(registryUri);
+        auto registryUri = RunRegistry(requestedRegistryUri);
 
         for (auto&& p : participants)
         {
@@ -524,7 +524,7 @@ protected:
         {
             systemController.active = false;
         }
-        return newRegistryUri;
+        return registryUri;
     }
 
     void SystemCleanup()

--- a/SilKit/IntegrationTests/ITest_DeterministicSimVAsio.cpp
+++ b/SilKit/IntegrationTests/ITest_DeterministicSimVAsio.cpp
@@ -235,13 +235,7 @@ private:
 class ITest_DeterministicSimVAsio : public testing::Test
 {
 protected:
-    ITest_DeterministicSimVAsio()
-    {
-        registryUri = MakeTestRegistryUri();
-    }
-
-protected:
-    std::string registryUri;
+    ITest_DeterministicSimVAsio() = default;
 };
 
 TEST_F(ITest_DeterministicSimVAsio, deterministic_simulation_vasio)
@@ -258,7 +252,7 @@ TEST_F(ITest_DeterministicSimVAsio, deterministic_simulation_vasio)
 
     auto registry =
         SilKit::Vendor::Vector::CreateSilKitRegistry(SilKit::Config::ParticipantConfigurationFromString(""));
-    registry->StartListening(registryUri);
+    auto registryUri = registry->StartListening("silkit://localhost:0");
 
     // The subscriber assumes the role of the system controller and initiates simulation state changes
     Subscriber subscriber(subscriberName, registryUri, publisherCount, testSize);

--- a/SilKit/IntegrationTests/ITest_DeterministicSimVAsio.cpp
+++ b/SilKit/IntegrationTests/ITest_DeterministicSimVAsio.cpp
@@ -36,8 +36,6 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE. */
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
-#include "GetTestPid.hpp"
-
 namespace {
 
 using namespace std::chrono;

--- a/SilKit/IntegrationTests/ITest_DifferentPeriods.cpp
+++ b/SilKit/IntegrationTests/ITest_DifferentPeriods.cpp
@@ -37,8 +37,6 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE. */
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
-#include "GetTestPid.hpp"
-
 namespace {
 
 using namespace std::chrono;

--- a/SilKit/IntegrationTests/ITest_DifferentPeriods.cpp
+++ b/SilKit/IntegrationTests/ITest_DifferentPeriods.cpp
@@ -239,13 +239,7 @@ private:
 class ITest_DifferentPeriods : public testing::Test
 {
 protected:
-    ITest_DifferentPeriods()
-    {
-        registryUri = MakeTestRegistryUri();
-    }
-
-protected:
-    std::string registryUri;
+    ITest_DifferentPeriods() = default;
 };
 
 
@@ -269,7 +263,7 @@ TEST_F(ITest_DifferentPeriods, different_simtask_periods)
 
     auto registry =
         SilKit::Vendor::Vector::CreateSilKitRegistry(SilKit::Config::ParticipantConfigurationFromString(""));
-    registry->StartListening(registryUri);
+    auto registryUri = registry->StartListening("silkit://localhost:0");
 
     // The subscriber assumes the role of the system controller and initiates simulation state changes
     Subscriber subscriber(syncParticipantNames, subscriberName, registryUri, publisherCount, numMessages);

--- a/SilKit/IntegrationTests/ITest_DifferentPeriods.cpp
+++ b/SilKit/IntegrationTests/ITest_DifferentPeriods.cpp
@@ -238,8 +238,6 @@ private:
 
 class ITest_DifferentPeriods : public testing::Test
 {
-protected:
-    ITest_DifferentPeriods() = default;
 };
 
 

--- a/SilKit/IntegrationTests/ITest_HopOnHopOff.cpp
+++ b/SilKit/IntegrationTests/ITest_HopOnHopOff.cpp
@@ -71,14 +71,14 @@ TEST_F(ITest_HopOnHopOff, test_GracefulShutdown)
     StopSystemController();
 
     // Wait for coordinated to end
-    JoinParticipantThreads(participantThreads_Sync_Coordinated);
+    JoinParticipantThreads(_participantThreads_Sync_Coordinated);
 
     // Expect shutdown state
     EXPECT_EQ(monitorParticipants.front().participantStates["SyncParticipant1"], ParticipantState::Shutdown);
     EXPECT_EQ(monitorParticipants.front().participantStates["SyncParticipant2"], ParticipantState::Shutdown);
 
     monitorParticipants.front().i.stopRequested = true;
-    JoinParticipantThreads(participantThreads_Async_Autonomous);
+    JoinParticipantThreads(_participantThreads_Async_Autonomous);
 
     StopRegistry();
 }
@@ -145,8 +145,8 @@ TEST_F(ITest_HopOnHopOff, test_Async_HopOnHopOff_ToSynced)
         }
         // Hop off: Stop while-loop of async participants
         for (auto& p : asyncParticipants)
-            p.i.runAsync = false;
-        JoinParticipantThreads(participantThreads_Async_Invalid);
+            p.i._runAsync = false;
+        JoinParticipantThreads(_participantThreads_Async_Invalid);
 
         // Reset communication and wait for reception once more for remaining sync participants
         expectedReceptions = syncParticipants.size();
@@ -175,7 +175,7 @@ TEST_F(ITest_HopOnHopOff, test_Async_HopOnHopOff_ToSynced)
     // Shutdown coordinated participants
     for (auto& p : syncParticipants)
         p.lifecycleService->Stop("Hop Off");
-    JoinParticipantThreads(participantThreads_Sync_Coordinated);
+    JoinParticipantThreads(_participantThreads_Sync_Coordinated);
 
     StopSystemController();
     StopRegistry();
@@ -213,8 +213,8 @@ TEST_F(ITest_HopOnHopOff, test_Async_reconnect_first_joined)
             p.ResetReception();
 
         // Hop off with asyncParticipants1
-        asyncParticipants1.front().i.runAsync = false;
-        participantThreads_Async_Invalid[0].WaitForThreadExit();
+        asyncParticipants1.front().i._runAsync = false;
+        _participantThreads_Async_Invalid[0].WaitForThreadExit();
 
         // Reconnect with asyncParticipant1
         RunParticipants(asyncParticipants1);
@@ -234,11 +234,11 @@ TEST_F(ITest_HopOnHopOff, test_Async_reconnect_first_joined)
 
         // Disconnect with both
         for (auto& p : asyncParticipants1)
-            p.i.runAsync = false;
+            p.i._runAsync = false;
         for (auto& p : asyncParticipants2)
-            p.i.runAsync = false;
+            p.i._runAsync = false;
 
-        JoinParticipantThreads(participantThreads_Async_Invalid);
+        JoinParticipantThreads(_participantThreads_Async_Invalid);
     }
 
     StopRegistry();
@@ -276,8 +276,8 @@ TEST_F(ITest_HopOnHopOff, test_Async_reconnect_second_joined)
             p.ResetReception();
 
         // Hop off with asyncParticipants2
-        asyncParticipants2.front().i.runAsync = false;
-        participantThreads_Async_Invalid[1].WaitForThreadExit();
+        asyncParticipants2.front().i._runAsync = false;
+        _participantThreads_Async_Invalid[1].WaitForThreadExit();
         //participantThreads_Async_Invalid.erase(participantThreads_Async_Invalid.begin()+1);
 
         // Reconnect with asyncParticipant2
@@ -298,11 +298,11 @@ TEST_F(ITest_HopOnHopOff, test_Async_reconnect_second_joined)
 
         // Disconnect with both
         for (auto& p : asyncParticipants1)
-            p.i.runAsync = false;
+            p.i._runAsync = false;
         for (auto& p : asyncParticipants2)
-            p.i.runAsync = false;
+            p.i._runAsync = false;
 
-        JoinParticipantThreads(participantThreads_Async_Invalid);
+        JoinParticipantThreads(_participantThreads_Async_Invalid);
     }
 
     StopRegistry();
@@ -328,9 +328,9 @@ TEST_F(ITest_HopOnHopOff, test_Async_HopOnHopOff_ToEmpty)
 
         // Hop off async participants
         for (auto& p : asyncParticipants)
-            p.i.runAsync = false;
+            p.i._runAsync = false;
 
-        JoinParticipantThreads(participantThreads_Async_Invalid);
+        JoinParticipantThreads(_participantThreads_Async_Invalid);
 
         // Reset communication to repeat the cycle
         for (auto& p : asyncParticipants)
@@ -424,7 +424,7 @@ TEST_F(ITest_HopOnHopOff, test_HopOnHopOff_Autonomous_To_Coordinated)
         for (auto& p : syncParticipantsAutonomous)
             p.lifecycleService->Stop("Hop Off");
 
-        JoinParticipantThreads(participantThreads_Sync_AutonomousA);
+        JoinParticipantThreads(_participantThreads_Sync_AutonomousA);
 
         // Reset communication to repeat the cycle
         expectedReceptions = syncParticipantsCoordinated.size() + asyncParticipants.size();
@@ -438,13 +438,13 @@ TEST_F(ITest_HopOnHopOff, test_HopOnHopOff_Autonomous_To_Coordinated)
 
     // Shutdown async participants
     for (auto& p : asyncParticipants)
-        p.i.runAsync = false;
-    JoinParticipantThreads(participantThreads_Async_Invalid);
+        p.i._runAsync = false;
+    JoinParticipantThreads(_participantThreads_Async_Invalid);
 
     // Shutdown coordinated participants
     for (auto& p : syncParticipantsCoordinated)
         p.lifecycleService->Stop("Hop Off");
-    JoinParticipantThreads(participantThreads_Sync_Coordinated);
+    JoinParticipantThreads(_participantThreads_Sync_Coordinated);
 
     StopSystemController();
     StopRegistry();
@@ -533,7 +533,7 @@ TEST_F(ITest_HopOnHopOff, test_HopOnHopOff_Autonomous_To_Autonomous)
         // Shutdown autonomous B participants
         for (auto& p : syncParticipantsAutonomousB)
             p.lifecycleService->Stop("Hop Off");
-        JoinParticipantThreads(participantThreads_Sync_AutonomousB);
+        JoinParticipantThreads(_participantThreads_Sync_AutonomousB);
 
         // Reset communication to repeat the cycle
         expectedReceptions = syncParticipantsAutonomousA.size() + asyncParticipants.size();
@@ -547,13 +547,13 @@ TEST_F(ITest_HopOnHopOff, test_HopOnHopOff_Autonomous_To_Autonomous)
 
     // Shutdown async participants
     for (auto& p : asyncParticipants)
-        p.i.runAsync = false;
-    JoinParticipantThreads(participantThreads_Async_Invalid);
+        p.i._runAsync = false;
+    JoinParticipantThreads(_participantThreads_Async_Invalid);
 
     // Shutdown autonomous A participants
     for (auto& p : syncParticipantsAutonomousA)
         p.lifecycleService->Stop("End Test Off");
-    JoinParticipantThreads(participantThreads_Sync_AutonomousA);
+    JoinParticipantThreads(_participantThreads_Sync_AutonomousA);
 
     StopRegistry();
 }

--- a/SilKit/IntegrationTests/ITest_Internals_DataPubSub.cpp
+++ b/SilKit/IntegrationTests/ITest_Internals_DataPubSub.cpp
@@ -737,10 +737,9 @@ TEST_F(ITest_Internals_DataPubSub, test_1pub_1sub_async_rejoin)
                                expectedDataUnordered,
                            }}});
 
-    auto registryUri = MakeTestRegistryUri();
 
-    _testSystem.SetupRegistryAndSystemMaster(registryUri, false, {});
-    RunParticipants(subscribers, registryUri, false);
+    _testSystem.SetupRegistryAndSystemMaster("silkit://localhost:0", false, {});
+    RunParticipants(subscribers, _testSystem.GetRegistryUri(), false);
     for (auto& s : subscribers)
     {
         s.WaitForCreateParticipant();
@@ -749,7 +748,7 @@ TEST_F(ITest_Internals_DataPubSub, test_1pub_1sub_async_rejoin)
     for (uint32_t i = 0; i < numRejoins; i++)
     {
         // Start publishers
-        RunParticipants(publishers, registryUri, false);
+        RunParticipants(publishers, _testSystem.GetRegistryUri(), false);
         for (auto& p : publishers)
         {
             p.WaitForAllSent();

--- a/SilKit/IntegrationTests/ITest_Internals_DataPubSub.hpp
+++ b/SilKit/IntegrationTests/ITest_Internals_DataPubSub.hpp
@@ -485,7 +485,6 @@ protected:
 
     void RunSyncTest(std::vector<PubSubParticipant>& pubsubs)
     {
-        auto registryUri = MakeTestRegistryUri();
 
         std::vector<std::string> requiredParticipantNames;
         for (const auto& p : pubsubs)
@@ -493,8 +492,8 @@ protected:
             requiredParticipantNames.push_back(p.name);
         }
 
-        _testSystem.SetupRegistryAndSystemMaster(registryUri, true, std::move(requiredParticipantNames));
-        RunParticipants(pubsubs, registryUri, true);
+        _testSystem.SetupRegistryAndSystemMaster("silkit://localhost:0", true, std::move(requiredParticipantNames));
+        RunParticipants(pubsubs, _testSystem.GetRegistryUri(), true);
         WaitForAllDiscovered(pubsubs);
         StopSimOnAllSentAndReceived(pubsubs, true);
         JoinPubSubThreads();
@@ -503,18 +502,16 @@ protected:
 
     void RunAsyncTest(std::vector<PubSubParticipant>& publishers, std::vector<PubSubParticipant>& subscribers)
     {
-        auto registryUri = MakeTestRegistryUri();
-
-        _testSystem.SetupRegistryAndSystemMaster(registryUri, false, {});
+        _testSystem.SetupRegistryAndSystemMaster("silkit://localhost:0", false, {});
 
         //Start publishers first
-        RunParticipants(publishers, registryUri, false);
+        RunParticipants(publishers, _testSystem.GetRegistryUri(), false);
         for (auto& p : publishers)
         {
             p.WaitForAllSent();
         }
         //Start subscribers afterwards
-        RunParticipants(subscribers, registryUri, false);
+        RunParticipants(subscribers, _testSystem.GetRegistryUri(), false);
         JoinPubSubThreads();
         ShutdownSystem();
     }

--- a/SilKit/IntegrationTests/ITest_Internals_DataPubSub.hpp
+++ b/SilKit/IntegrationTests/ITest_Internals_DataPubSub.hpp
@@ -30,7 +30,6 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE. */
 #include "IServiceDiscovery.hpp"
 #include "ServiceDatatypes.hpp"
 
-#include "GetTestPid.hpp"
 #include "IntegrationTestInfrastructure.hpp"
 
 using namespace std::chrono_literals;

--- a/SilKit/IntegrationTests/ITest_Internals_ParticipantModes.cpp
+++ b/SilKit/IntegrationTests/ITest_Internals_ParticipantModes.cpp
@@ -26,8 +26,6 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE. */
 #include <thread>
 #include <list>
 
-#include "GetTestPid.hpp"
-
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 

--- a/SilKit/IntegrationTests/ITest_Internals_RequestReply.cpp
+++ b/SilKit/IntegrationTests/ITest_Internals_RequestReply.cpp
@@ -53,9 +53,8 @@ protected:
 TEST_F(ITest_Internals_RequestReply, participant_replies)
 {
     // Registry
-    auto registryUri = MakeTestRegistryUri();
     auto registry = SilKit::Vendor::Vector::CreateSilKitRegistry(SilKit::Config::MakeEmptyParticipantConfiguration());
-    registry->StartListening(registryUri);
+    auto registryUri = registry->StartListening("silkit://localhost:0");
 
     // Create participants
     auto&& p1 =

--- a/SilKit/IntegrationTests/ITest_Internals_RequestReply.cpp
+++ b/SilKit/IntegrationTests/ITest_Internals_RequestReply.cpp
@@ -31,7 +31,6 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE. */
 #include "IRequestReplyService.hpp"
 #include "procs/IParticipantReplies.hpp"
 
-#include "GetTestPid.hpp"
 #include "ConfigurationTestUtils.hpp"
 #include "VAsioRegistry.hpp"
 #include "CreateParticipantImpl.hpp"

--- a/SilKit/IntegrationTests/ITest_Internals_Rpc.hpp
+++ b/SilKit/IntegrationTests/ITest_Internals_Rpc.hpp
@@ -607,16 +607,14 @@ protected:
 
     void RunSyncTest(std::vector<RpcParticipant>& rpcs)
     {
-        auto registryUri = MakeTestRegistryUri();
-
         std::vector<std::string> requiredParticipantNames;
         for (const auto& p : rpcs)
         {
             requiredParticipantNames.push_back(p.name);
         }
 
-        _testSystem.SetupRegistryAndSystemMaster(registryUri, true, std::move(requiredParticipantNames));
-        RunParticipants(rpcs, registryUri, true);
+        _testSystem.SetupRegistryAndSystemMaster("silkit://localhost:0", true, std::move(requiredParticipantNames));
+        RunParticipants(rpcs, _testSystem.GetRegistryUri(), true);
         WaitForAllServersDiscovered(rpcs);
         StopSimOnallCalledAndReceived(rpcs, true);
         JoinRpcThreads();
@@ -625,10 +623,8 @@ protected:
 
     void RunAsyncTest(std::vector<RpcParticipant>& rpcs)
     {
-        auto registryUri = MakeTestRegistryUri();
-
-        _testSystem.SetupRegistryAndSystemMaster(registryUri, false, {});
-        RunParticipants(rpcs, registryUri, false);
+        _testSystem.SetupRegistryAndSystemMaster("silkit://localhost:0", false, {});
+        RunParticipants(rpcs, _testSystem.GetRegistryUri(), false);
         WaitForAllServersDiscovered(rpcs);
         JoinRpcThreads();
         ShutdownSystem();

--- a/SilKit/IntegrationTests/ITest_Internals_Rpc.hpp
+++ b/SilKit/IntegrationTests/ITest_Internals_Rpc.hpp
@@ -29,7 +29,6 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE. */
 
 #include "ConfigurationTestUtils.hpp"
 
-#include "GetTestPid.hpp"
 #include "IntegrationTestInfrastructure.hpp"
 #include "IParticipantInternal.hpp"
 #include "IServiceDiscovery.hpp"

--- a/SilKit/IntegrationTests/ITest_Internals_ServiceDiscovery.cpp
+++ b/SilKit/IntegrationTests/ITest_Internals_ServiceDiscovery.cpp
@@ -29,7 +29,6 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE. */
 #include "functional.hpp"
 
 #include "SimTestHarness.hpp"
-#include "GetTestPid.hpp"
 #include "ServiceDiscovery.hpp"
 #include "ConfigurationTestUtils.hpp"
 #include "VAsioRegistry.hpp"

--- a/SilKit/IntegrationTests/ITest_Internals_ServiceDiscovery.cpp
+++ b/SilKit/IntegrationTests/ITest_Internals_ServiceDiscovery.cpp
@@ -54,14 +54,13 @@ protected:
 // All created should be removed as well if a participant leaves
 TEST_F(ITest_Internals_ServiceDiscovery, discover_services)
 {
-    auto registryUri = MakeTestRegistryUri();
     size_t numberOfServices = 5;
     std::string subscriberName = "Subscriber";
     std::string publisherName = "Publisher";
 
     // Registry
     auto registry = SilKit::Vendor::Vector::CreateSilKitRegistry(SilKit::Config::MakeEmptyParticipantConfiguration());
-    registry->StartListening(registryUri);
+    auto registryUri = registry->StartListening("silkit://localhost:0");
 
     // Publisher that will leave the simulation and trigger service removal
     auto&& publisher = SilKit::CreateParticipantImpl(SilKit::Config::MakeEmptyParticipantConfigurationImpl(),
@@ -146,14 +145,13 @@ TEST_F(ITest_Internals_ServiceDiscovery, discover_services)
 // All created should be removed as well if a participant leaves
 TEST_F(ITest_Internals_ServiceDiscovery, discover_specific_services)
 {
-    auto registryUri = MakeTestRegistryUri();
     size_t numberOfServices = 5;
     std::string subscriberName = "Subscriber";
     std::string publisherName = "Publisher";
 
     // Registry
     auto registry = SilKit::Vendor::Vector::CreateSilKitRegistry(SilKit::Config::MakeEmptyParticipantConfiguration());
-    registry->StartListening(registryUri);
+    auto registryUri = registry->StartListening("silkit://localhost:0");
 
     // Publisher that will leave the simulation and trigger service removal
     auto&& publisher = SilKit::CreateParticipantImpl(SilKit::Config::MakeEmptyParticipantConfigurationImpl(),

--- a/SilKit/IntegrationTests/ITest_Internals_TargetedMessaging.cpp
+++ b/SilKit/IntegrationTests/ITest_Internals_TargetedMessaging.cpp
@@ -36,7 +36,6 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE. */
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
-#include "GetTestPid.hpp"
 #include "InternalHelpers.hpp"
 
 namespace {

--- a/SilKit/IntegrationTests/ITest_Internals_TargetedMessaging.cpp
+++ b/SilKit/IntegrationTests/ITest_Internals_TargetedMessaging.cpp
@@ -46,13 +46,11 @@ using namespace SilKit::Services::Orchestration;
 
 TEST(ITest_Internals_TargetedMessaging, targeted_messaging)
 {
-    auto registryUri = MakeTestRegistryUri();
-
     std::vector<std::string> syncParticipantNames{"Sender", "TargetReceiver", "OtherReceiver"};
 
     auto receiveCount = 0;
 
-    SilKit::Tests::SimTestHarness testHarness(syncParticipantNames, registryUri, false);
+    SilKit::Tests::SimTestHarness testHarness(syncParticipantNames, "silkit://localhost:0", false);
 
     auto* senderComSimPart = testHarness.GetParticipant("Sender");
     auto* senderCom = &SilKit::Tests::ToParticipantInternal(*senderComSimPart->Participant());

--- a/SilKit/IntegrationTests/ITest_Lin.cpp
+++ b/SilKit/IntegrationTests/ITest_Lin.cpp
@@ -403,9 +403,8 @@ protected:
 
 TEST_F(ITest_Lin, sync_lin_simulation)
 {
-    auto registryUri = MakeTestRegistryUri();
     std::vector<std::string> participantNames = {"LinMaster", "LinSlave"};
-    _simTestHarness = std::make_unique<SimTestHarness>(participantNames, registryUri, false);
+    _simTestHarness = std::make_unique<SimTestHarness>(participantNames, "silkit://localhost:0", false);
 
     std::vector<std::unique_ptr<LinNode>> linNodes;
     //Create a simulation setup with 2 participants

--- a/SilKit/IntegrationTests/ITest_Lin.cpp
+++ b/SilKit/IntegrationTests/ITest_Lin.cpp
@@ -30,8 +30,6 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE. */
 
 #include "SimTestHarness.hpp"
 
-#include "GetTestPid.hpp"
-
 #include "gtest/gtest.h"
 
 namespace {

--- a/SilKit/IntegrationTests/ITest_LinDynamicResponse.cpp
+++ b/SilKit/IntegrationTests/ITest_LinDynamicResponse.cpp
@@ -35,8 +35,6 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE. */
 #include "SimTestHarness.hpp"
 #include "ITestThreadSafeLogger.hpp"
 
-#include "GetTestPid.hpp"
-
 #include "gtest/gtest.h"
 
 namespace {

--- a/SilKit/IntegrationTests/ITest_LinDynamicResponse.cpp
+++ b/SilKit/IntegrationTests/ITest_LinDynamicResponse.cpp
@@ -663,10 +663,9 @@ protected:
 //! \brief Dynamically respond to a frame header event by sending a previously unconfigured response
 TEST_F(ITest_LinDynamicResponse, deferred_simstep_response)
 {
-    auto registryUri = MakeTestRegistryUri();
     auto participantNames = std::vector<std::string>{"LinMaster", "LinSlave1"};
 
-    _simTestHarness = std::make_unique<SimTestHarness>(participantNames, registryUri, false);
+    _simTestHarness = std::make_unique<SimTestHarness>(participantNames, "silkit://localhost:0", false);
 
     LinFrame slaveResponseFrame;
     slaveResponseFrame.id = 34;
@@ -771,9 +770,8 @@ TEST_F(ITest_LinDynamicResponse, deferred_simstep_response)
 
 TEST_F(ITest_LinDynamicResponse, normal_master_dynamic_slave)
 {
-    auto registryUri = MakeTestRegistryUri();
     std::vector<std::string> participantNames = {"LinMaster", "LinSlave"};
-    _simTestHarness = std::make_unique<SimTestHarness>(participantNames, registryUri, false);
+    _simTestHarness = std::make_unique<SimTestHarness>(participantNames, "silkit://localhost:0", false);
 
     std::vector<std::unique_ptr<LinNode>> linNodes;
     //Create a simulation setup with 2 participants
@@ -961,9 +959,8 @@ TEST_F(ITest_LinDynamicResponse, normal_master_dynamic_slave)
 
 TEST_F(ITest_LinDynamicResponse, normal_master_two_dynamic_slave_collision)
 {
-    auto registryUri = MakeTestRegistryUri();
     std::vector<std::string> participantNames = {"LinMaster", "LinSlave1", "LinSlave2"};
-    _simTestHarness = std::make_unique<SimTestHarness>(participantNames, registryUri, false);
+    _simTestHarness = std::make_unique<SimTestHarness>(participantNames, "silkit://localhost:0", false);
 
     std::vector<std::unique_ptr<LinNode>> linNodes;
     //Create a simulation setup with 2 participants
@@ -1205,9 +1202,8 @@ TEST_F(ITest_LinDynamicResponse, normal_master_two_dynamic_slave_collision)
 
 TEST_F(ITest_LinDynamicResponse, dynamic_master_normal_slave)
 {
-    auto registryUri = MakeTestRegistryUri();
     std::vector<std::string> participantNames = {"LinMaster", "LinSlave"};
-    _simTestHarness = std::make_unique<SimTestHarness>(participantNames, registryUri, false);
+    _simTestHarness = std::make_unique<SimTestHarness>(participantNames, "silkit://localhost:0", false);
 
     std::vector<std::unique_ptr<LinNode>> linNodes;
     //Create a simulation setup with 2 participants
@@ -1398,9 +1394,8 @@ TEST_F(ITest_LinDynamicResponse, dynamic_master_normal_slave)
 
 TEST_F(ITest_LinDynamicResponse, dynamic_master_dynamic_slave)
 {
-    auto registryUri = MakeTestRegistryUri();
     std::vector<std::string> participantNames = {"LinMaster", "LinSlave"};
-    _simTestHarness = std::make_unique<SimTestHarness>(participantNames, registryUri, false);
+    _simTestHarness = std::make_unique<SimTestHarness>(participantNames, "silkit://localhost:0", false);
 
     std::vector<std::unique_ptr<LinNode>> linNodes;
     //Create a simulation setup with 2 participants
@@ -1723,9 +1718,8 @@ private:
 
 TEST_F(ITest_LinDynamicResponse, normal_master_dynamic_slave_response_resets)
 {
-    auto registryUri = MakeTestRegistryUri();
     std::vector<std::string> participantNames = {"LinMaster", "LinSlave"};
-    _simTestHarness = std::make_unique<SimTestHarness>(participantNames, registryUri, false);
+    _simTestHarness = std::make_unique<SimTestHarness>(participantNames, "silkit://localhost:0", false);
 
     std::vector<std::unique_ptr<LinNode>> linNodes;
     //Create a simulation setup with 2 participants
@@ -1849,9 +1843,8 @@ TEST_F(ITest_LinDynamicResponse, normal_master_dynamic_slave_response_resets)
 
 TEST_F(ITest_LinDynamicResponse, normal_master_dynamic_slave_out_of_band_response_does_nothing)
 {
-    auto registryUri = MakeTestRegistryUri();
     std::vector<std::string> participantNames = {"LinMaster", "LinSlave", "LinSlaveDynamic"};
-    _simTestHarness = std::make_unique<SimTestHarness>(participantNames, registryUri, false);
+    _simTestHarness = std::make_unique<SimTestHarness>(participantNames, "silkit://localhost:0", false);
 
     std::vector<std::unique_ptr<LinNode>> linNodes;
     //Create a simulation setup with 2 participants

--- a/SilKit/IntegrationTests/ITest_MultiThreadedParticipants.hpp
+++ b/SilKit/IntegrationTests/ITest_MultiThreadedParticipants.hpp
@@ -79,8 +79,6 @@ enum class TimeMode
 class ITest_MultiThreadedParticipants : public testing::Test
 {
 protected:
-    ITest_MultiThreadedParticipants() {}
-
     struct Callbacks
     {
         MOCK_METHOD(void, AbortHandler, (ParticipantState));
@@ -826,6 +824,7 @@ protected:
 protected:
     std::unique_ptr<SilKit::Vendor::Vector::ISilKitRegistry> _registry;
 
+    SystemControllerParticipant systemControllerParticipant;
     ParticipantThread participantThread_SystemController;
 
     std::vector<ParticipantThread> _participantThreads_Sync_Invalid;
@@ -842,7 +841,5 @@ protected:
 
     std::string _registryUri{"undefined registry uri"};
 
-    // used in derived tests
-    SystemControllerParticipant systemControllerParticipant;
     Callbacks callbacks;
 };

--- a/SilKit/IntegrationTests/ITest_MultiThreadedParticipants.hpp
+++ b/SilKit/IntegrationTests/ITest_MultiThreadedParticipants.hpp
@@ -31,8 +31,6 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE. */
 #include <list>
 #include <vector>
 
-#include "GetTestPid.hpp"
-
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 

--- a/SilKit/IntegrationTests/ITest_MultiThreadedParticipants.hpp
+++ b/SilKit/IntegrationTests/ITest_MultiThreadedParticipants.hpp
@@ -109,7 +109,7 @@ protected:
 
             ImmovableMembers(ImmovableMembers&& other) noexcept
                 : allReceived{other.allReceived.load()}
-                , runAsync{other.runAsync.load()}
+                , _runAsync{other._runAsync.load()}
                 , stopRequested{other.stopRequested.load()}
                 , runningStateReached{other.runningStateReached.load()}
                 , pausedStateReached{other.pausedStateReached.load()}
@@ -122,7 +122,7 @@ protected:
                 if (this != &other)
                 {
                     allReceived = other.allReceived.load();
-                    runAsync = other.runAsync.load();
+                    _runAsync = other._runAsync.load();
                     stopRequested = other.stopRequested.load();
                     runningStateReached = other.runningStateReached.load();
                     pausedStateReached = other.pausedStateReached.load();
@@ -134,7 +134,7 @@ protected:
 
             mutable std::mutex mutex;
             std::atomic<bool> allReceived{false};
-            std::atomic<bool> runAsync{true};
+            std::atomic<bool> _runAsync{true};
             std::atomic<bool> stopRequested{false};
             std::atomic<bool> runningStateReached{false};
             std::atomic<bool> pausedStateReached{false};
@@ -358,7 +358,7 @@ protected:
             config = SilKit::Config::MakeEmptyParticipantConfiguration();
         }
 
-        testParticipant.participant = SilKit::CreateParticipant(config, testParticipant.name, registryUri);
+        testParticipant.participant = SilKit::CreateParticipant(config, testParticipant.name, _registryUri);
         testParticipant.lifecycleService =
             testParticipant.participant->CreateLifecycleService({testParticipant.lifeCycleOperationMode});
         testParticipant.lifecycleService->SetAbortHandler(
@@ -421,7 +421,7 @@ protected:
             [&testParticipant, this](std::chrono::nanoseconds now, std::chrono::nanoseconds /*duration*/) {
             testParticipant.now = now;
             testParticipant.publisher->Publish(std::vector<uint8_t>{testParticipant.id});
-            if (!testParticipant.simtimePassed && now > simtimeToPass)
+            if (!testParticipant.simtimePassed && now > _simtimeToPass)
             {
                 testParticipant.simtimePassed = true;
                 testParticipant.simtimePassedPromise.set_value();
@@ -445,7 +445,7 @@ protected:
             config = SilKit::Config::MakeEmptyParticipantConfiguration();
         }
 
-        testParticipant.participant = SilKit::CreateParticipant(config, testParticipant.name, registryUri);
+        testParticipant.participant = SilKit::CreateParticipant(config, testParticipant.name, _registryUri);
         if (testParticipant.lifeCycleOperationMode != OperationMode::Invalid)
         {
             testParticipant.lifecycleService =
@@ -490,7 +490,7 @@ protected:
         });
 
         auto runTask = [&testParticipant]() {
-            while (testParticipant.i.runAsync)
+            while (testParticipant.i._runAsync)
             {
                 testParticipant.publisher->Publish(std::vector<uint8_t>{testParticipant.id});
                 std::this_thread::sleep_for(asyncDelayBetweenPublication);
@@ -539,7 +539,7 @@ protected:
         }
 
         systemControllerParticipant.participant =
-            SilKit::CreateParticipant(config, systemControllerParticipantName, registryUri);
+            SilKit::CreateParticipant(config, systemControllerParticipantName, _registryUri);
 
         systemControllerParticipant.systemController =
             SilKit::Experimental::Participant::CreateSystemController(systemControllerParticipant.participant.get());
@@ -649,13 +649,13 @@ protected:
     {
         std::shared_ptr<SilKit::Config::IParticipantConfiguration> config{nullptr};
         config = SilKit::Config::MakeEmptyParticipantConfiguration();
-        registry = SilKit::Vendor::Vector::CreateSilKitRegistry(config);
-        registry->StartListening(registryUri);
+        _registry = SilKit::Vendor::Vector::CreateSilKitRegistry(config);
+        _registryUri = _registry->StartListening("silkit://127.0.0.1:0");
     }
 
     void StopRegistry()
     {
-        registry.reset();
+        _registry.reset();
     }
 
     void RunParticipants(std::list<TestParticipant>& participants, std::string set = "A")
@@ -664,41 +664,41 @@ protected:
         {
             if (p.timeMode == TimeMode::Async)
             {
-                p.i.runAsync = true;
+                p.i._runAsync = true;
 
                 if (p.lifeCycleOperationMode == OperationMode::Invalid)
                 {
-                    participantThreads_Async_Invalid.emplace_back([this, &p] { AsyncParticipantThread(p); });
+                    _participantThreads_Async_Invalid.emplace_back([this, &p] { AsyncParticipantThread(p); });
                 }
                 else if (p.lifeCycleOperationMode == OperationMode::Autonomous)
                 {
-                    participantThreads_Async_Autonomous.emplace_back([this, &p] { AsyncParticipantThread(p); });
+                    _participantThreads_Async_Autonomous.emplace_back([this, &p] { AsyncParticipantThread(p); });
                 }
                 else if (p.lifeCycleOperationMode == OperationMode::Coordinated)
                 {
-                    participantThreads_Async_Coordinated.emplace_back([this, &p] { AsyncParticipantThread(p); });
+                    _participantThreads_Async_Coordinated.emplace_back([this, &p] { AsyncParticipantThread(p); });
                 }
             }
             else if (p.timeMode == TimeMode::Sync)
             {
                 if (p.lifeCycleOperationMode == OperationMode::Invalid)
                 {
-                    participantThreads_Sync_Invalid.emplace_back([this, &p] { SyncParticipantThread(p); });
+                    _participantThreads_Sync_Invalid.emplace_back([this, &p] { SyncParticipantThread(p); });
                 }
                 else if (p.lifeCycleOperationMode == OperationMode::Autonomous)
                 {
                     if (set == "A")
                     {
-                        participantThreads_Sync_AutonomousA.emplace_back([this, &p] { SyncParticipantThread(p); });
+                        _participantThreads_Sync_AutonomousA.emplace_back([this, &p] { SyncParticipantThread(p); });
                     }
                     else if (set == "B")
                     {
-                        participantThreads_Sync_AutonomousB.emplace_back([this, &p] { SyncParticipantThread(p); });
+                        _participantThreads_Sync_AutonomousB.emplace_back([this, &p] { SyncParticipantThread(p); });
                     }
                 }
                 else if (p.lifeCycleOperationMode == OperationMode::Coordinated)
                 {
-                    participantThreads_Sync_Coordinated.emplace_back([this, &p] { SyncParticipantThread(p); });
+                    _participantThreads_Sync_Coordinated.emplace_back([this, &p] { SyncParticipantThread(p); });
                 }
             }
         }
@@ -821,27 +821,28 @@ protected:
         globalParticipantIndex = 0;
         participantNames.clear();
         participantIsSync.clear();
-        registryUri = MakeTestRegistryUri();
     }
 
 protected:
-    std::unique_ptr<SilKit::Vendor::Vector::ISilKitRegistry> registry;
+    std::unique_ptr<SilKit::Vendor::Vector::ISilKitRegistry> _registry;
 
-    SystemControllerParticipant systemControllerParticipant;
     ParticipantThread participantThread_SystemController;
 
-    std::vector<ParticipantThread> participantThreads_Sync_Invalid;
-    std::vector<ParticipantThread> participantThreads_Sync_AutonomousA;
-    std::vector<ParticipantThread> participantThreads_Sync_AutonomousB;
-    std::vector<ParticipantThread> participantThreads_Sync_Coordinated;
+    std::vector<ParticipantThread> _participantThreads_Sync_Invalid;
+    std::vector<ParticipantThread> _participantThreads_Sync_AutonomousA;
+    std::vector<ParticipantThread> _participantThreads_Sync_AutonomousB;
+    std::vector<ParticipantThread> _participantThreads_Sync_Coordinated;
 
-    std::vector<ParticipantThread> participantThreads_Async_Invalid;
-    std::vector<ParticipantThread> participantThreads_Async_Autonomous;
-    std::vector<ParticipantThread> participantThreads_Async_Coordinated;
+    std::vector<ParticipantThread> _participantThreads_Async_Invalid;
+    std::vector<ParticipantThread> _participantThreads_Async_Autonomous;
+    std::vector<ParticipantThread> _participantThreads_Async_Coordinated;
 
-    std::chrono::seconds simtimeToPass{3s};
-    bool runAsync{true};
+    std::chrono::seconds _simtimeToPass{3s};
+    bool _runAsync{true};
 
-    std::string registryUri;
+    std::string _registryUri{"undefined registry uri"};
+
+    // used in derived tests
+    SystemControllerParticipant systemControllerParticipant;
     Callbacks callbacks;
 };

--- a/SilKit/IntegrationTests/ITest_RequestRemoteParticipantConnect.cpp
+++ b/SilKit/IntegrationTests/ITest_RequestRemoteParticipantConnect.cpp
@@ -21,9 +21,9 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE. */
 
 #include <stdexcept>
 #include <thread>
+
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
-#include "GetTestPid.hpp"
 #include "silkit/SilKit.hpp"
 #include "SimTestHarness.hpp"
 

--- a/SilKit/IntegrationTests/ITest_SameParticipants.cpp
+++ b/SilKit/IntegrationTests/ITest_SameParticipants.cpp
@@ -24,7 +24,6 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE. */
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
-#include "GetTestPid.hpp"
 #include "silkit/config/IParticipantConfiguration.hpp"
 #include "silkit/experimental/participant/ParticipantExtensions.hpp"
 #include "silkit/participant/IParticipant.hpp"

--- a/SilKit/IntegrationTests/ITest_SameParticipants.cpp
+++ b/SilKit/IntegrationTests/ITest_SameParticipants.cpp
@@ -42,10 +42,9 @@ TEST(ITest_SameParticipants, test_participants_with_unique_name)
     std::unique_ptr<SilKit::IParticipant> participant2;
 
     // start registry
-    auto registryUri = MakeTestRegistryUri();
     auto registry =
         SilKit::Vendor::Vector::CreateSilKitRegistry(SilKit::Config::ParticipantConfigurationFromString(""));
-    registry->StartListening(registryUri);
+    auto registryUri = registry->StartListening("silkit://localhost:0");
 
     auto pCfg = SilKit::Config::ParticipantConfigurationFromString("");
     EXPECT_NO_THROW(participant1 = SilKit::CreateParticipant(pCfg, "Participant1", registryUri));
@@ -60,10 +59,9 @@ TEST(ITest_SameParticipants, test_participants_with_same_name)
     std::unique_ptr<SilKit::IParticipant> participant2;
 
     // start registry
-    auto registryUri = MakeTestRegistryUri();
     auto registry =
         SilKit::Vendor::Vector::CreateSilKitRegistry(SilKit::Config::ParticipantConfigurationFromString(""));
-    registry->StartListening(registryUri);
+    auto registryUri = registry->StartListening("silkit://localhost:0");
 
     auto pCfg = SilKit::Config::ParticipantConfigurationFromString("");
     EXPECT_NO_THROW(participant1 = SilKit::CreateParticipant(pCfg, "Participant", registryUri));

--- a/SilKit/IntegrationTests/ITest_SingleParticipant.cpp
+++ b/SilKit/IntegrationTests/ITest_SingleParticipant.cpp
@@ -114,8 +114,7 @@ protected:
 
     void ExecuteTest()
     {
-        auto registryUri = MakeTestRegistryUri();
-        SilKit::Tests::SimTestHarness testHarness(syncParticipantNames, registryUri);
+        SilKit::Tests::SimTestHarness testHarness(syncParticipantNames, "silkit://localhost:0");
 
         auto* canWriter = testHarness.GetParticipant("CanWriter");
         SetupWriter(canWriter);

--- a/SilKit/IntegrationTests/ITest_SingleParticipant.cpp
+++ b/SilKit/IntegrationTests/ITest_SingleParticipant.cpp
@@ -25,8 +25,6 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE. */
 
 #include "SimTestHarness.hpp"
 
-#include "GetTestPid.hpp"
-
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 

--- a/SilKit/IntegrationTests/ITest_StateMachineVAsio.cpp
+++ b/SilKit/IntegrationTests/ITest_StateMachineVAsio.cpp
@@ -33,8 +33,6 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE. */
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
-#include "GetTestPid.hpp"
-
 namespace {
 
 using namespace std::chrono_literals;

--- a/SilKit/IntegrationTests/ITest_StateMachineVAsio.cpp
+++ b/SilKit/IntegrationTests/ITest_StateMachineVAsio.cpp
@@ -100,12 +100,11 @@ protected:
 
 TEST_F(ITest_StateMachineVAsio, DISABLED_vasio_state_machine)
 {
-    auto registryUri = MakeTestRegistryUri();
     std::vector<std::string> syncParticipantNames{"TestUnit"};
 
     auto registry =
         SilKit::Vendor::Vector::CreateSilKitRegistry(SilKit::Config::ParticipantConfigurationFromString(""));
-    registry->StartListening(registryUri);
+    auto registryUri = registry->StartListening("silkit://localhost:0");
 
     // Setup Participant for TestController
     auto participant = SilKit::CreateParticipant(SilKit::Config::ParticipantConfigurationFromString(""),

--- a/SilKit/IntegrationTests/ITest_SystemMonitor.cpp
+++ b/SilKit/IntegrationTests/ITest_SystemMonitor.cpp
@@ -28,7 +28,6 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE. */
 #include "functional.hpp"
 
 #include "SimTestHarness.hpp"
-#include "GetTestPid.hpp"
 #include "ConfigurationTestUtils.hpp"
 #include "SyncDatatypeUtils.hpp"
 

--- a/SilKit/IntegrationTests/ITest_SystemMonitor.cpp
+++ b/SilKit/IntegrationTests/ITest_SystemMonitor.cpp
@@ -70,14 +70,13 @@ protected:
 // All created should be removed as well if a participant leaves
 TEST_F(ITest_SystemMonitor, discover_services)
 {
-    auto registryUri = MakeTestRegistryUri();
     const SilKit::Services::Orchestration::ParticipantConnectionInformation& firstParticipantConnection{"First"};
     const SilKit::Services::Orchestration::ParticipantConnectionInformation& secondParticipantConnection{"Second"};
     const SilKit::Services::Orchestration::ParticipantConnectionInformation& thirdParticipantConnection{"Third"};
 
     // Registry
     auto registry = SilKit::Vendor::Vector::CreateSilKitRegistry(SilKit::Config::MakeEmptyParticipantConfiguration());
-    registry->StartListening(registryUri);
+    auto registryUri = registry->StartListening("silkit://localhost:0");
 
     // Create the first participant and register the connect and disconnect callbacks
     auto&& firstParticipant = SilKit::CreateParticipant(SilKit::Config::MakeEmptyParticipantConfiguration(),

--- a/SilKit/IntegrationTests/ITest_ThreeCanController.cpp
+++ b/SilKit/IntegrationTests/ITest_ThreeCanController.cpp
@@ -184,8 +184,7 @@ protected:
 
     void ExecuteTest()
     {
-        auto registryUri = MakeTestRegistryUri();
-        SilKit::Tests::SimTestHarness testHarness(syncParticipantNames, registryUri);
+        SilKit::Tests::SimTestHarness testHarness(syncParticipantNames, "silkit://localhost:0");
 
         auto* canWriter = testHarness.GetParticipant("CanWriter");
         SetupWriter(canWriter);

--- a/SilKit/IntegrationTests/ITest_ThreeCanController.cpp
+++ b/SilKit/IntegrationTests/ITest_ThreeCanController.cpp
@@ -27,8 +27,6 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE. */
 
 #include "SimTestHarness.hpp"
 
-#include "GetTestPid.hpp"
-
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 

--- a/SilKit/IntegrationTests/ITest_ThreeEthController.cpp
+++ b/SilKit/IntegrationTests/ITest_ThreeEthController.cpp
@@ -71,7 +71,6 @@ protected:
 protected:
     ITest_ThreeEthController()
     {
-        registryUri = MakeTestRegistryUri();
 
         testMessages.resize(5);
         for (auto index = 0u; index < testMessages.size(); index++)
@@ -160,7 +159,7 @@ protected:
 
     void ExecuteTest()
     {
-        SilKit::Tests::SimTestHarness testHarness(syncParticipantNames, registryUri);
+        SilKit::Tests::SimTestHarness testHarness(syncParticipantNames, "silkit://localhost:0");
 
         //participant setup
         auto* ethWriter = testHarness.GetParticipant("EthWriter");
@@ -196,7 +195,6 @@ protected:
     }
 
 protected:
-    std::string registryUri;
     std::vector<std::string> syncParticipantNames;
 
     struct TestMessage

--- a/SilKit/IntegrationTests/ITest_ThreeEthController.cpp
+++ b/SilKit/IntegrationTests/ITest_ThreeEthController.cpp
@@ -26,7 +26,6 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE. */
 #include "SimTestHarness.hpp"
 
 #include "EthernetHelpers.hpp"
-#include "GetTestPid.hpp"
 
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"

--- a/SilKit/IntegrationTests/IntegrationTestInfrastructure.hpp
+++ b/SilKit/IntegrationTests/IntegrationTestInfrastructure.hpp
@@ -51,16 +51,21 @@ public:
     {
         try
         {
-            RunRegistry(registryUri);
+            _registryUri = RunRegistry(registryUri);
             if (sync)
             {
-                RunSystemMaster(registryUri, std::move(requiredParticipantNames));
+                RunSystemMaster(_registryUri, std::move(requiredParticipantNames));
             }
         }
         catch (const std::exception& error)
         {
             ShutdownOnException(error);
         }
+    }
+
+    auto GetRegistryUri() -> std::string
+    {
+        return _registryUri;
     }
 
     void SystemMasterStop()
@@ -77,10 +82,10 @@ public:
     }
 
 private:
-    void RunRegistry(const std::string& registryUri)
+    auto RunRegistry(const std::string& registryUri) -> std::string
     {
         _registry = SilKit::Vendor::Vector::CreateSilKitRegistry(SilKit::Config::MakeEmptyParticipantConfiguration());
-        _registry->StartListening(registryUri);
+        return _registry->StartListening(registryUri);
     }
 
     void RunSystemMaster(const std::string& registryUri, std::vector<std::string> requiredParticipantNames)
@@ -133,6 +138,7 @@ private:
     }
 
     std::unique_ptr<SilKit::Vendor::Vector::ISilKitRegistry> _registry;
+    std::string _registryUri{"not yet defined"};
     const std::string systemMasterName{"SystemMaster"};
 
     struct SystemMaster

--- a/SilKit/IntegrationTests/SimTestHarness/SimTestHarness.cpp
+++ b/SilKit/IntegrationTests/SimTestHarness/SimTestHarness.cpp
@@ -300,7 +300,7 @@ SimParticipant* SimTestHarness::GetParticipant(const std::string& participantNam
     return _simParticipants[participantName].get();
 }
 
-auto SimTestHarness::GetRegistryUri() -> std::string
+auto SimTestHarness::GetRegistryUri() const -> std::string
 {
     return _registryUri;
 }

--- a/SilKit/IntegrationTests/SimTestHarness/SimTestHarness.cpp
+++ b/SilKit/IntegrationTests/SimTestHarness/SimTestHarness.cpp
@@ -300,6 +300,11 @@ SimParticipant* SimTestHarness::GetParticipant(const std::string& participantNam
     return _simParticipants[participantName].get();
 }
 
+auto SimTestHarness::GetRegistryUri() -> std::string
+{
+    return _registryUri;
+}
+
 SimParticipant* SimTestHarness::GetParticipant(const std::string& participantName)
 {
     return GetParticipant(participantName, "");

--- a/SilKit/IntegrationTests/SimTestHarness/SimTestHarness.hpp
+++ b/SilKit/IntegrationTests/SimTestHarness/SimTestHarness.hpp
@@ -132,7 +132,7 @@ public:
     //! \brief Get the SimParticipant by name. If it does not exist yet, create a SimParticipant with the specified name and provide its ParticipantConfiguration as a string.
     SimParticipant* GetParticipant(const std::string& participantName, const std::string& participantConfiguration);
 
-    auto GetRegistryUri() -> std::string;
+    auto GetRegistryUri() const -> std::string;
 
     // clear everything and destroy participants:
     void Reset();

--- a/SilKit/IntegrationTests/SimTestHarness/SimTestHarness.hpp
+++ b/SilKit/IntegrationTests/SimTestHarness/SimTestHarness.hpp
@@ -132,6 +132,8 @@ public:
     //! \brief Get the SimParticipant by name. If it does not exist yet, create a SimParticipant with the specified name and provide its ParticipantConfiguration as a string.
     SimParticipant* GetParticipant(const std::string& participantName, const std::string& participantConfiguration);
 
+    auto GetRegistryUri() -> std::string;
+
     // clear everything and destroy participants:
     void Reset();
     void ResetRegistry();


### PR DESCRIPTION
remove the `MakeTestRegistryUri`  function from all tests.
Use the dynamically allocated registry port instead.