### PR TITLE
Fix double free reported on Fedora 40

### DIFF
--- a/SilKit/source/config/SilKitYamlHelper.hpp
+++ b/SilKit/source/config/SilKitYamlHelper.hpp
@@ -186,9 +186,9 @@ void optional_decode(ConfigT& value, const YAML::Node& node, const std::string& 
     }
 }
 
-template <typename ConfigT>
+template <typename ConfigT, size_t N>
 void optional_decode_deprecated_alternative(ConfigT& value, const YAML::Node& node, const std::string& fieldName,
-                                            std::initializer_list<std::string> deprecatedFieldNames)
+                                            std::array<std::string, N> deprecatedFieldNames)
 {
     if (node.IsMap())
     {

--- a/SilKit/source/config/YamlConversion.cpp
+++ b/SilKit/source/config/YamlConversion.cpp
@@ -770,7 +770,9 @@ template <>
 bool Converter::decode(const Node& node, RpcServer& obj)
 {
     obj.name = parse_as<std::string>(node["Name"]);
-    optional_decode_deprecated_alternative(obj.functionName, node, "FunctionName", {"Channel", "RpcChannel"});
+
+    auto deprecatedRPCFields = std::array<std::string, 2> {"Channel", "RpcChannel"};
+    optional_decode_deprecated_alternative(obj.functionName, node, "FunctionName", deprecatedRPCFields);
     optional_decode(obj.useTraceSinks, node, "UseTraceSinks");
     optional_decode(obj.replay, node, "Replay");
     return true;
@@ -791,7 +793,9 @@ template <>
 bool Converter::decode(const Node& node, RpcClient& obj)
 {
     obj.name = parse_as<std::string>(node["Name"]);
-    optional_decode_deprecated_alternative(obj.functionName, node, "FunctionName", {"Channel", "RpcChannel"});
+
+    auto deprecatedRPCFields = std::array<std::string, 2> {"Channel", "RpcChannel"};
+    optional_decode_deprecated_alternative(obj.functionName, node, "FunctionName", deprecatedRPCFields);
     optional_decode(obj.useTraceSinks, node, "UseTraceSinks");
     optional_decode(obj.replay, node, "Replay");
     return true;
@@ -1221,7 +1225,9 @@ bool Converter::decode(const Node& node, ParticipantConfiguration& obj)
     optional_decode(obj.canControllers, node, "CanControllers");
     optional_decode(obj.linControllers, node, "LinControllers");
     optional_decode(obj.ethernetControllers, node, "EthernetControllers");
-    optional_decode_deprecated_alternative(obj.flexrayControllers, node, "FlexrayControllers", {"FlexRayControllers"});
+
+    auto depecratedFlexrayFields = std::array<std::string, 1>{"FlexRayControllers"};
+    optional_decode_deprecated_alternative(obj.flexrayControllers, node, "FlexrayControllers", depecratedFlexrayFields);
     optional_decode(obj.dataPublishers, node, "DataPublishers");
     optional_decode(obj.dataSubscribers, node, "DataSubscribers");
     optional_decode(obj.rpcServers, node, "RpcServers");


### PR DESCRIPTION
## description
Running the tests under Fedora 40 revealed a double free (confirmed by valgrind) with the initializer_list arg for
	optional_decode_deprecated_alternative
This commit changes the arg to an std::array, which should behave equal to the initializer_list without the syntactic sugar.

