### PR TITLE
bump version to 4.0.53

### DIFF
--- a/SilKit/cmake/SilKitVersion.cmake
+++ b/SilKit/cmake/SilKitVersion.cmake
@@ -27,7 +27,7 @@
 macro(configure_silkit_version project_name)
     set(SILKIT_VERSION_MAJOR 4)
     set(SILKIT_VERSION_MINOR 0)
-    set(SILKIT_VERSION_PATCH 52)
+    set(SILKIT_VERSION_PATCH 53)
     set(SILKIT_BUILD_NUMBER 0 CACHE STRING "The build number")
     set(SILKIT_VERSION_SUFFIX "")
 

--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -6,7 +6,7 @@ All notable changes to the Vector SIL Kit project shall be documented in this fi
 
 The format is based on `Keep a Changelog (http://keepachangelog.com/en/1.0.0/) <http://keepachangelog.com/en/1.0.0/>`_.
 
-[4.0.53] - UNRELEASED
+[unreleased]
 ---------------------
 
 

--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -6,6 +6,10 @@ All notable changes to the Vector SIL Kit project shall be documented in this fi
 
 The format is based on `Keep a Changelog (http://keepachangelog.com/en/1.0.0/) <http://keepachangelog.com/en/1.0.0/>`_.
 
+[4.0.53] - UNRELEASED
+---------------------
+
+
 [4.0.52] - 2024-09-02 
 ---------------------
 


### PR DESCRIPTION
Halite is out and we need to update the version number at the beginning of the development cycle.