### PR TITLE
ci: update docker images

### DIFF
--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -39,7 +39,7 @@ jobs:
     environment: public-github-runners
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/vectorgrp/sil-kit-docker-build/sil-kit-ci-public-runner:main
+      image: ghcr.io/vectorgrp/sil-kit-docker-build/sil-kit-ci-ubuntu-22.04:main
     if: inputs.run_build == true
     steps:
       - name: git checkout

--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -39,7 +39,7 @@ jobs:
     environment: public-github-runners
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/mariusbgm/sil-kit-ci-ubuntu-22.04:main
+      image: ghcr.io/vectorgrp/sil-kit-docker-build/sil-kit-ci-public-runner:main
     if: inputs.run_build == true
     steps:
       - name: git checkout

--- a/.github/workflows/build-release-packages.yml
+++ b/.github/workflows/build-release-packages.yml
@@ -8,7 +8,7 @@ jobs:
     environment: public-github-runners
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/mariusbgm/sil-kit-ci-ubuntu-18.04:main
+      image: ghcr.io/vectorgrp/sil-kit-docker-build/sil-kit-ci-ubuntu-18.04:main
     outputs:
         package-name: ${{ steps.build.outputs.package-name}}
     steps:
@@ -30,7 +30,7 @@ jobs:
     environment: public-github-runners
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/mariusbgm/sil-kit-ci-ubuntu-18.04:main
+      image: ghcr.io/vectorgrp/sil-kit-docker-build/sil-kit-ci-ubuntu-18.04:main
     outputs:
         package-name: ${{ steps.build.outputs.package-name}}
     steps:

--- a/.github/workflows/sil-kit-ci.yml
+++ b/.github/workflows/sil-kit-ci.yml
@@ -51,7 +51,7 @@ jobs:
     name: Format checks for SIL Kit sources
     runs-on: ubuntu-22.04
     container:
-      image: ghcr.io/mariusbgm/sil-kit-ci-clangformat-22.04:dev_clangformat_ubuntu
+      image: ghcr.io/vectorgrp/sil-kit-docker-build/sil-kit-ci-public-runner:main
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
use the newly  created images from the dedicated sil-kit-docker-build repo for CI/CT purposes.