### PR TITLE
dev: For SimStepAsync, measure execution time until call to CompleteSimStep

### DIFF
--- a/SilKit/source/services/orchestration/TimeSyncService.hpp
+++ b/SilKit/source/services/orchestration/TimeSyncService.hpp
@@ -125,6 +125,8 @@ private:
     void StartWallClockCouplingThread();
     void HybridWait(std::chrono::nanoseconds targetWaitDuration);
 
+    void LogicalSimStepCompleted(std::chrono::duration<double, std::milli> logicalSimStepExecutionTimeMs);
+
 private:
     // ----------------------------------------
     // private members
@@ -136,8 +138,10 @@ private:
     TimeConfiguration _timeConfiguration;
 
     VSilKit::ICounterMetric* _simStepCounterMetric;
-    VSilKit::IStatisticMetric* _simStepExecutionTimeStatisticMetric;
+    VSilKit::IStatisticMetric* _simStepHandlerExecutionTimeStatisticMetric;
+    VSilKit::IStatisticMetric* _simStepCompletionTimeStatisticMetric;
     VSilKit::IStatisticMetric* _simStepWaitingTimeStatisticMetric;
+    std::chrono::duration<double, std::milli> _lastHandlerExecutionTimeMs;
 
     mutable std::mutex _timeSyncPolicyMx;
     std::shared_ptr<ITimeSyncPolicy> _timeSyncPolicy{nullptr};
@@ -151,7 +155,8 @@ private:
     SimulationStepHandler _simTask;
     std::future<void> _asyncResult;
 
-    Util::PerformanceMonitor _execTimeMonitor;
+    Util::PerformanceMonitor _simStepHandlerExecTimeMonitor;
+    Util::PerformanceMonitor _simStepCompletionTimeMonitor;
     Util::PerformanceMonitor _waitTimeMonitor;
     WatchDog _watchDog;
     bool _isCoupledToWallClock{false};

--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -27,7 +27,7 @@ Changed
 
 - Implemented the union (de-)serialization stubs in the ``silkit/util/serdes`` headers.
 
-Fxed
+Fixed
 ~~~~~
 
 - If using the ``SimStepHandlerAsync``, the log message that reports the end of the simulation step is now printed after the call to ``CompleteSimulationStep``.

--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -27,6 +27,10 @@ Changed
 
 - Implemented the union (de-)serialization stubs in the ``silkit/util/serdes`` headers.
 
+Fxed
+~~~~~
+
+- If using the ``SimStepHandlerAsync``, the log message that reports the end of the simulation step is now printed after the call to ``CompleteSimulationStep``.
 
 [4.0.52] - 2024-09-02 
 ---------------------


### PR DESCRIPTION
## Subject

- The Log message "Finished Simulation Step. Execution time was: ..." measures the SimStepHandler execution time. This is misleading when using the  `SimStepHandlerAsync`, because the simulation step is actually not finished.

## Description

- If using the `SimStepHandlerAsync`, the Log Message "Finished Simulation Step. Execution time was: ..." is now printed after the call to `CompleteSimulationStep`.
- The metric to time the SimStepHandler execution has been renamed to _SimStepHandlerExecutionDuration_
- If using the `SimStepHandlerAsync`,  the new metric _SimStepCompletionDuration_ measure the interval between the end of the handler and the call to `CompleteSimulationStep`.

## Developer checklist (address before review)

- [x] Changelog.md updated
- [ ] Prepared update for depending repositories
- [ ] Rebase &rarr; commit history clean
- [ ] Squash and merge &rarr; proper PR title
