### PR TITLE
ci: don`t run CI and workflows on push to main

### DIFF
--- a/.github/workflows/build-linux-arm64.yml
+++ b/.github/workflows/build-linux-arm64.yml
@@ -5,6 +5,8 @@ on:
       run_build:
         required: true
         type: boolean
+  push:
+    branches: [ 'main' ]
 
 jobs:
   ubuntu-arm-release:

--- a/.github/workflows/build-win.yml
+++ b/.github/workflows/build-win.yml
@@ -18,10 +18,6 @@ on:
   push:
     branches: [ 'main' ]
 
-concurrency:
-  group: ${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true
-
 jobs:
   build-win-x64:
     runs-on: windows-2019

--- a/.github/workflows/sil-kit-ci.yml
+++ b/.github/workflows/sil-kit-ci.yml
@@ -4,9 +4,6 @@ on:
   pull_request:
     branches: [ 'main' ]
 
-  push:
-    branches: [ 'main' ]
-
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true


### PR DESCRIPTION
Make sure that we don't run the `sil-kit-ci` workflow and the individual `build-win` workflows on pushes to main.
Also remove the concurrency group from `build-win`, because it'll get canceled if CI runs in parallel.