### PR TITLE
api: serdes: allow union (de)serialization

### DIFF
--- a/SilKit/include/silkit/util/serdes/Deserializer.hpp
+++ b/SilKit/include/silkit/util/serdes/Deserializer.hpp
@@ -37,6 +37,8 @@ inline namespace v1 {
 
 class Deserializer
 {
+    using UnionDiscriminator = uint32_t;
+
 public:
     // ----------------------------------------
     // CTOR, DTOR, Copy Operators
@@ -157,13 +159,19 @@ public:
     /*! \brief Deserializes the end of an optional value. */
     void EndOptional() {}
 
+    /*! \brief Deserializes the start of a union and returns the discriminator.
+     * Only the active union member must be deserialized before calling EndUnion.
+     * \returns index of the active union member
+     */
     auto BeginUnion() -> int
     {
-        throw SilKitError("Unions are currently not supported.");
+        const auto discriminator = DeserializeAligned<UnionDiscriminator>(sizeof(UnionDiscriminator));
+        return static_cast<int>(discriminator);
     }
+
+    /*! \brief Deserializes the end of a union. */
     void EndUnion()
     {
-        throw SilKitError("Unions are currently not supported.");
     }
 
     /*! \brief Resets the buffer and replaces it with another one.

--- a/SilKit/include/silkit/util/serdes/Deserializer.hpp
+++ b/SilKit/include/silkit/util/serdes/Deserializer.hpp
@@ -161,7 +161,7 @@ public:
 
     /*! \brief Deserializes the start of a union and returns the discriminator.
      * Only the active union member must be deserialized before calling EndUnion.
-     * \returns 1-based index of the active union member
+     * \returns 1-based index of the active union member or 0 for an invalid 'empty' union
      */
     auto BeginUnion() -> int
     {

--- a/SilKit/include/silkit/util/serdes/Deserializer.hpp
+++ b/SilKit/include/silkit/util/serdes/Deserializer.hpp
@@ -161,7 +161,7 @@ public:
 
     /*! \brief Deserializes the start of a union and returns the discriminator.
      * Only the active union member must be deserialized before calling EndUnion.
-     * \returns index of the active union member
+     * \returns 1-based index of the active union member
      */
     auto BeginUnion() -> int
     {

--- a/SilKit/include/silkit/util/serdes/Serializer.hpp
+++ b/SilKit/include/silkit/util/serdes/Serializer.hpp
@@ -38,6 +38,8 @@ inline namespace v1 {
 
 class Serializer
 {
+    using UnionDiscriminator = uint32_t;
+
 public:
     // ----------------------------------------
     // CTOR, DTOR, Copy Operators
@@ -151,13 +153,24 @@ public:
     /*! \brief Serializes the end of an optional value. */
     void EndOptional() {}
 
-    void BeginUnion(int)
+    /*! \brief Serialize the start of a union with a particular discriminator.
+     * Only the active union member must be serialized prior to calling EndUnion.
+     * \param discriminator index of the active union member
+     */
+    void BeginUnion(const int discriminator)
     {
-        throw SilKitError("Unions are currently not supported.");
+#ifndef NDEBUG
+        if (discriminator < 0)
+            throw SilKitError{"Union discriminator is negative"};
+        if (static_cast<unsigned>(discriminator) > (std::numeric_limits<UnionDiscriminator>::max)())
+            throw LengthError{"Union discriminator is too big"};
+#endif
+        SerializeAligned<UnionDiscriminator>(static_cast<UnionDiscriminator>(discriminator), sizeof(UnionDiscriminator));
     }
+
+    /*! \brief Serialize the end of a union. */
     void EndUnion()
     {
-        throw SilKitError("Unions are currently not supported.");
     }
 
     /*! \brief Resets the buffer. */

--- a/SilKit/include/silkit/util/serdes/Serializer.hpp
+++ b/SilKit/include/silkit/util/serdes/Serializer.hpp
@@ -155,15 +155,13 @@ public:
 
     /*! \brief Serialize the start of a union with a particular discriminator.
      * Only the active union member must be serialized prior to calling EndUnion.
-     * \param discriminator 1-based index of the active union member
+     * \param discriminator 1-based index of the active union member or 0 for an invalid 'empty' union
      */
     void BeginUnion(const int discriminator)
     {
 #ifndef NDEBUG
         if (discriminator < 0)
             throw SilKitError{"Union discriminator is negative"};
-        if (discriminator == 0)
-            throw SilKitError{"Union discriminator is zero"};
         if (static_cast<unsigned>(discriminator) > (std::numeric_limits<UnionDiscriminator>::max)())
             throw LengthError{"Union discriminator is too big"};
 #endif

--- a/SilKit/include/silkit/util/serdes/Serializer.hpp
+++ b/SilKit/include/silkit/util/serdes/Serializer.hpp
@@ -155,13 +155,15 @@ public:
 
     /*! \brief Serialize the start of a union with a particular discriminator.
      * Only the active union member must be serialized prior to calling EndUnion.
-     * \param discriminator index of the active union member
+     * \param discriminator 1-based index of the active union member
      */
     void BeginUnion(const int discriminator)
     {
 #ifndef NDEBUG
         if (discriminator < 0)
             throw SilKitError{"Union discriminator is negative"};
+        if (discriminator == 0)
+            throw SilKitError{"Union discriminator is zero"};
         if (static_cast<unsigned>(discriminator) > (std::numeric_limits<UnionDiscriminator>::max)())
             throw LengthError{"Union discriminator is too big"};
 #endif

--- a/SilKit/source/util/tests/Test_SilSerDes.cpp
+++ b/SilKit/source/util/tests/Test_SilSerDes.cpp
@@ -287,4 +287,18 @@ TEST(Test_SilSerDes, serdes_array)
     deserializer.EndArray();
 }
 
+TEST(Test_SilSerDes, serdes_union)
+{
+    Serializer serializer;
+    serializer.BeginUnion(124);
+    serializer.Serialize(1001, 32);
+    serializer.EndUnion();
+
+    Deserializer deserializer;
+    deserializer.Reset(serializer.ReleaseBuffer());
+    EXPECT_EQ(124, deserializer.BeginUnion());
+    EXPECT_EQ(1001, deserializer.Deserialize<int32_t>(32));
+    deserializer.EndUnion();
+}
+
 } // anonymous namespace

--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -25,6 +25,8 @@ Changed
   - Old: Registry, Monitor and System Controller prompt the user by default to press `[Enter]`` to end process after shutdown.
   - New: All utilities terminate without prompting for user input. SystemController option '-ni, --non-interactive' is deprecated.
 
+- Implemented the union (de-)serialization stubs in the ``silkit/util/serdes`` headers.
+
 
 [4.0.52] - 2024-09-02 
 ---------------------


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2023 Vector Informatik GmbH

SPDX-License-Identifier: MIT
-->

## Subject
<!--
    - What kind of changes does this pull request comprise?
    - Add a label like "Bugfix", "docs", etc. to this PR to give context.
 -->

This change allows to (de-)serialize unions using the public serdes headers. It does not change the API of the `Serializer` / `Deserializer` classes, but only implements the existing member functions.

The index is 1-based, since a related piece of software already uses 1-based indices for union discriminators.

## Instructions for review / testing
<!--
    - Hilight some of the important changes, which reviewers should focus on
    - Which parts should be reviewed in detail? For example: content of console output, correct semantics of changes
    - Test steps and test setup description. For example: which programs or configs to use
-->

## Developer checklist (address before review)

- [ ] Changelog.md updated
- [ ] Prepared update for depending repositories
- [ ] Documentation updated (public API changes only)
- [ ] API docstrings updated (public API changes only)
- [ ] Rebase &rarr; commit history clean
- [ ] Squash and merge &rarr; proper PR title
