### PR TITLE
maintenance: fix registry port number used in benchmark demo

### DIFF
--- a/Demos/Benchmark/BenchmarkDemo.cpp
+++ b/Demos/Benchmark/BenchmarkDemo.cpp
@@ -63,7 +63,7 @@ void PrintUsage(const std::string& executableName)
         << " [registryURi]" << std::endl
         << "If no arguments are given, default values will be used." << std::endl
         << "\t--help\tshow this message." << std::endl
-        << "\t--registry-uri\tThe URI of the registry to start. Default: silkit://localhost:8500" << std::endl
+        << "\t--registry-uri\tThe URI of the registry to start. Default: silkit://localhost:8600" << std::endl
         << "\t--message-size\tSets the message size to BYTES. Default: 1000" << std::endl
         << "\t--message-count\tSets the number of messages to be send per participant in each simulation step to "
            "NUM. Default: 50"
@@ -83,7 +83,7 @@ struct BenchmarkConfig
     uint32_t numberOfParticipants = 2;
     uint32_t messageCount = 50;
     uint32_t messageSizeInBytes = 1000;
-    std::string registryUri = "silkit://localhost:8500";
+    std::string registryUri = "silkit://localhost:8600";
     std::string silKitConfigPath = "";
     std::string writeCsv = "";
 };


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2023 Vector Informatik GmbH

SPDX-License-Identifier: MIT
-->

## Subject

Do not use port number used by autostarted registry (8500), but port number 8600 instead.


## Developer checklist (address before review)

- [ ] Changelog.md updated
- [ ] Prepared update for depending repositories
- [ ] Documentation updated (public API changes only)
- [ ] API docstrings updated (public API changes only)
- [ ] Rebase &rarr; commit history clean
- [ ] Squash and merge &rarr; proper PR title
