### PR TITLE
ci: clean up build workflows

### DIFF
--- a/.github/actions/build-cmake-preset/action.yml
+++ b/.github/actions/build-cmake-preset/action.yml
@@ -13,21 +13,21 @@ inputs:
     required: false
     default: true
     type: boolean
-  toolset:
-    type: string
-    default: '14.1'
-    description: "MSVC tool set to use"
-    required: false
-  build-arch:
-    type: string
-    default: "x64"
-    description: "MSVC build architecture to use"
-    required: false
   artifact-label:
     type: string
     default: ""
     description: "Name of the artifact label to attach to uploads"
     required: true
+  shell:
+    type: string
+    default: "bash"
+    required: false
+    description: "Explicitly set the shell to use for running cmake"
+  extra-path:
+    type: string
+    default: ""
+    required: false
+    description: "Prepends this string to $PATH"
  
 outputs:
   package-name:
@@ -42,51 +42,32 @@ outputs:
   symbols-package-name:
     description: artifact name of the symbols zip
     value: "${{ steps.cmake-package.outputs.symbols-package-name }}"
- 
+
 runs:
   using: composite
   steps:
 
-    - name: Setup host
-      if: runner.os == 'Windows'
-      run: |
-        choco install -y ninja
-        choco install -y doxygen.install
-        pip install breathe==4.34.0
-        pip install sphinx==5.1.1
-        pip install sphinx-rtd-theme==1.0.0
-      id: setup-host-windows
-      shell: powershell
-
-    - name: Setup host
-      if: runner.os == 'macOS'
-      run: brew install ninja doxygen
-      id: setup-host-macos
-      shell: bash
-
-    - name: Prepare build env on Windows
-      if: runner.os == 'Windows'
-      uses: ilammy/msvc-dev-cmd@v1.12.0
-      with:
-        arch: ${{ inputs.build-arch }}
-        toolset: ${{ inputs.toolset }}
-      id: setup-env-windows
-
     - name: Configure ${{ inputs.preset-name }}
-      run: cmake --preset ${{ inputs.preset-name }} ${{ inputs.cmake-args }}
-      id: cmake-configure
-      shell: bash
+      run: |
+        export PATH=${{ inputs.extra-path }}$PATH
+        cmake --preset ${{ inputs.preset-name }} ${{ inputs.cmake-args }}
+      shell: ${{ inputs.shell }}
 
     - name: Build ${{ inputs.preset-name }}
-      id: cmake-build
-      run: cmake --build --preset ${{ inputs.preset-name }}
-      shell: bash
+      run: |
+        export PATH=${{ inputs.extra-path }}$PATH
+        cmake --build --preset ${{ inputs.preset-name }}
+
+      shell: ${{ inputs.shell }}
 
     - name: test ${{ inputs.preset-name }}
       if: ${{ inputs.run-tests == 'true' }}
       id: ctests
-      run: ctest --preset ${{ inputs.preset-name }} --output-on-failure -R '^(I|T)'
-      shell: bash
+      run: |
+        export PATH=${{ inputs.extra-path }}$PATH
+        ctest --preset ${{ inputs.preset-name }} --output-on-failure -R '^(I|T)'
+
+      shell: ${{ inputs.shell }}
 
     - name: stash test reports ${{ inputs.preset-name }}
       uses: actions/upload-artifact@v4
@@ -98,11 +79,12 @@ runs:
     - name: create cmake package for ${{ inputs.preset-name }}
       id: cmake-package
       run: |
+        export PATH=${{ inputs.extra-path }}$PATH
         cmake --build --preset ${{ inputs.preset-name }} --target package
         echo "package-name=$(basename _build/${{inputs.preset-name}}/_CPack_Packages/*/ZIP/SilKit-*-*/)-${{ inputs.artifact-label }}" >> $GITHUB_OUTPUT
         # keep our original zip, otherwise the execute bits are lost
         echo "package-path=$(echo _build/${{inputs.preset-name}}/_CPack_Packages/*/ZIP/SilKit-*-*.zip)" >> $GITHUB_OUTPUT
-      shell: bash
+      shell: ${{ inputs.shell }}
 
     - name: upload package ${{ inputs.preset-name }}
       uses: actions/upload-artifact@v4

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -13,6 +13,9 @@ jobs:
       with:
         submodules: true
 
+    - name: Setup host
+      run: brew install ninja doxygen
+
     - uses: ./.github/actions/build-cmake-preset
       with:
         preset-name: clang-release

--- a/.github/workflows/build-mingw64.yml
+++ b/.github/workflows/build-mingw64.yml
@@ -1,60 +1,45 @@
-name: 'mingw64 release Builds'
+name: 'mingw64-x86_64'
 on:
   workflow_call:
     inputs:
-      do_package:
-        required: false
-        type: boolean
-        default: false
-      do_package_symbols:
-        required: false
-        type: boolean
-        default: false
-      retention_days:
-        required: false
-        type: number
-        default: 14
       run_build:
         required: true
         type: boolean
-
+  workflow_dispatch:
+    inputs:
+      run_build:
+        default: true
 jobs:
-  gcc13-release:
-    name: GCC 13.2 release Builds for mingw64
+  mingw:
+    name: msys2/mingw64 ${{ matrix.builds.arch }}
+    defaults:
+      run:
+        shell:  C:\shells\msys2bash.cmd {0}
+
+    strategy:
+      matrix:
+        builds:
+          - arch: x86_64
+            bin: /mingw64/bin
+          #- arch: i686
+          #  bin: /mingw32/bin
 
     runs-on: windows-latest
     if: inputs.run_build == true
     steps:
-      - name: setup
-        run: |
-          echo "C:\msys64" >> $GITHUB_PATH
-          echo "C:\msys64\mingw64\bin\" >> $GITHUB_PATH
-      - name: Install Dependencies
-        run: |
-          pacman -S mingw-w64-x86_64-gcc mingw-w64-x86_64-cmake mingw-w64-x86_64-ninja --noconfirm
-          export PATH="/mingw64/bin/:$PATH"
-        shell:  C:\shells\msys2bash.cmd {0}
-      - uses: actions/checkout@v4
-        with:
-          submodules: true
-      - name: Configure
-        id: cmake-configure-mingw64
-        run: |
-          export PATH="/mingw64/bin/:$PATH"
-          echo "PATH: $PATH"
-          cmake --preset gcc-release -DSILKIT_BUILD_DOCS=OFF
-        shell:  C:\shells\msys2bash.cmd {0}
-      - name: Build
-        id: cmake-build-mingw64
-        run: |
-          export PATH="/mingw64/bin/:$PATH"
-          echo "PATH: $PATH"
-          cmake --build --preset gcc-release
-        shell:  C:\shells\msys2bash.cmd {0}
-      - name: Test
-        id: cmake-test-mingw64
-        run: |
-          export PATH="/mingw64/bin/:$PATH"
-          echo "PATH: $PATH"
-          ctest --preset gcc-release --output-on-failure
-        shell:  C:\shells\msys2bash.cmd {0}
+    - name: Setup host
+      run: |
+        pacman -S mingw-w64-${{ matrix.builds.arch }}-gcc mingw-w64-${{ matrix.builds.arch }}-cmake mingw-w64-${{ matrix.builds.arch }}-ninja --noconfirm
+
+
+    - uses: actions/checkout@v4
+      with:
+        submodules: true
+
+    - uses: ./.github/actions/build-cmake-preset
+      with:
+        preset-name: gcc-release
+        artifact-label: ${{ github.job }}-${{ matrix.builds.arch }}
+        cmake-args: -D SILKIT_BUILD_DOCS=OFF
+        extra-path: "${{ matrix.builds.bin }}:"
+        shell: C:\shells\msys2bash.cmd {0}

--- a/.github/workflows/build-win.yml
+++ b/.github/workflows/build-win.yml
@@ -28,6 +28,21 @@ jobs:
       with:
         submodules: true
 
+    - name: Setup host
+      run: |
+        choco install -y ninja
+        choco install -y doxygen.install
+        pip install breathe==4.34.0
+        pip install sphinx==5.1.1
+        pip install sphinx-rtd-theme==1.0.0
+      shell: powershell
+
+    - name: Prepare build env on Windows
+      uses: ilammy/msvc-dev-cmd@v1.12.0
+      with:
+        arch: x64
+        toolset: 14.1
+
     - uses: ./.github/actions/build-cmake-preset
       with:
         preset-name: vs141-x64-release
@@ -43,8 +58,22 @@ jobs:
       with:
         submodules: true
 
+    - name: Setup host
+      run: |
+        choco install -y ninja
+        choco install -y doxygen.install
+        pip install breathe==4.34.0
+        pip install sphinx==5.1.1
+        pip install sphinx-rtd-theme==1.0.0
+      shell: powershell
+
+    - name: Prepare build env on Windows
+      uses: ilammy/msvc-dev-cmd@v1.12.0
+      with:
+        arch: x86
+        toolset: 14.1
+
     - uses: ./.github/actions/build-cmake-preset
       with:
         preset-name: vs141-x86-release
-        build-arch: x86
         artifact-label: ${{ github.job }}


### PR DESCRIPTION
Move the runner setup into the workflows and keep the build-cmake-preset
action as simple as possible.
Add workflow_dispatch to mingw so we can run it manually.