### PR TITLE
dev: Add missing controllerType in ServiceDescriptor of SimulatedController

### DIFF
--- a/SilKit/source/core/internal/ServiceDescriptor.hpp
+++ b/SilKit/source/core/internal/ServiceDescriptor.hpp
@@ -289,7 +289,7 @@ std::string ServiceDescriptor::to_string() const
     case ServiceType::SimulatedController:
         if (!GetSupplementalDataItem(SilKit::Core::Discovery::controllerType, controllerTypeName))
         {
-            throw LogicError("supplementalData.size() > 0");
+            throw LogicError("ServiceDescriptor::to_string() failed: No controller type defined in supplemental data.");
         }
 
         ss << separator << controllerTypeName << separator << GetNetworkName() << separator << GetServiceName();

--- a/SilKit/source/experimental/netsim/SimulatedNetworkInternal.hpp
+++ b/SilKit/source/experimental/netsim/SimulatedNetworkInternal.hpp
@@ -35,6 +35,8 @@ private:
                                     Core::EndpointId serviceId) -> std::pair<bool, ControllerDescriptor>;
     void RemoveControllerDescriptor(const std::string& fromParticipantName, Core::EndpointId serviceId);
 
+    auto ExtractControllerTypeName(const SilKit::Core::ServiceDescriptor& serviceDescriptor) -> std::string;
+
     Core::IParticipantInternal* _participant = nullptr;
     SilKit::Services::Logging::ILogger* _logger;
 

--- a/SilKit/source/experimental/netsim/SimulatedNetworkRouter.cpp
+++ b/SilKit/source/experimental/netsim/SimulatedNetworkRouter.cpp
@@ -7,6 +7,7 @@
 #include "NetworkSimulatorDatatypesInternal.hpp"
 #include "Configuration.hpp"
 #include "silkit/experimental/netsim/string_utils.hpp"
+#include "ServiceConfigKeys.hpp"
 
 namespace SilKit {
 namespace Experimental {
@@ -52,7 +53,8 @@ bool SimulatedNetworkRouter::AllowReception(const SilKit::Core::IServiceEndpoint
 }
 
 void SimulatedNetworkRouter::AddSimulatedController(const std::string& fromParticipantName,
-                                                    const std::string& controllerName, Core::EndpointId serviceId,
+                                                    const std::string& controllerName,
+                                                    const std::string& controllerTypeName, Core::EndpointId serviceId,
                                                     ControllerDescriptor controllerDescriptor,
                                                     ISimulatedController* userSimulatedController)
 {
@@ -65,7 +67,8 @@ void SimulatedNetworkRouter::AddSimulatedController(const std::string& fromParti
     fromCopy.SetServiceId(serviceId);
     fromCopy.SetServiceType(Core::ServiceType::SimulatedController);
     fromCopy.SetServiceName(controllerName);
-
+    fromCopy.SetSupplementalDataItem(SilKit::Core::Discovery::controllerType, controllerTypeName);
+    
     targetController->SetServiceDescriptor(std::move(fromCopy));
     _targetControllers.insert({controllerDescriptor, std::move(targetController)});
 }

--- a/SilKit/source/experimental/netsim/SimulatedNetworkRouter.hpp
+++ b/SilKit/source/experimental/netsim/SimulatedNetworkRouter.hpp
@@ -93,6 +93,7 @@ public:
     inline auto GetServiceDescriptor() const -> const Core::ServiceDescriptor& override;
 
     void AddSimulatedController(const std::string& fromParticipantName, const std::string& controllerName,
+                                const std::string& controllerTypeName,
                                 Core::EndpointId serviceId, ControllerDescriptor controllerDescriptor,
                                 ISimulatedController* userSimulatedController);
     void RemoveSimulatedController(const std::string& fromParticipantName, Core::EndpointId serviceId,

--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -28,6 +28,11 @@ Changed
 - Implemented the union (de-)serialization stubs in the ``silkit/util/serdes`` headers.
 
 
+Fixed
+~~~~~
+
+- Fixed an issue with the NetSim API that caused an exception when used with log level `trace`.
+
 [4.0.52] - 2024-09-02 
 ---------------------
 


### PR DESCRIPTION
## Subject

Using Trace Logging in the NetSim API caused the exception `supplementalData.size() > 0`

## Description

This was the case because the controllerType (by name) was not saved on the supplemental data of the mirrored controller in the NetSim API when a new controller got discovered. 

With log level Trace, the mirrored controller then caused the exeption when trying to log the controller type in its service descriptor.

Finally, the exception got catched in the hourglass `CAPI_CATCH_EXCEPTIONS`.

Fixed by writing the controller type in the suppl. info map of the mirrored controller. Also made the exception more specific.

## Instructions for review / testing

- Code Review
- Build this branch, make sure the NetSim uses the SilKit.dll with the fix.
- Run a Demo with NetSim and  `-l trace` on the Netsim.exe (or via trace lvl in the participant config). No exception must appear. 
  
## Developer checklist (address before review)

- [x] Changelog.md updated
- [ ] Prepared update for depending repositories
- [ ] Documentation updated (public API changes only)
- [ ] API docstrings updated (public API changes only)
- [ ] Rebase &rarr; commit history clean
- [ ] Squash and merge &rarr; proper PR title
