### PR TITLE
SILKIT-1612 log: add participant name to file names

### DIFF
--- a/SilKit/source/core/vasio/VAsioConnection.cpp
+++ b/SilKit/source/core/vasio/VAsioConnection.cpp
@@ -41,6 +41,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE. */
 #include "Uri.hpp"
 #include "Assert.hpp"
 #include "TransformAcceptorUris.hpp"
+#include "StringHelpers.hpp"
 
 #include "ConnectPeer.hpp"
 #include "util/TracingMacros.hpp"
@@ -63,27 +64,6 @@ namespace fs = SilKit::Filesystem;
 
 namespace {
 
-auto printableName(const std::string& participantName) -> std::string
-{
-    std::string safeName;
-    for (const auto& ch : participantName)
-    {
-        // do not use std::isalnum, as it may sensitive to the current locale
-        const bool isAlphaNumeric{('a' <= ch && ch <= 'z') || ('A' <= ch && ch <= 'Z') || ('0' <= ch && ch <= '9')
-                                  || (ch == '_' || ch == '-' || ch == '.' || ch == '~')};
-
-        if (isAlphaNumeric)
-        {
-            safeName.push_back(ch);
-        }
-        else
-        {
-            safeName += fmt::format("{:02X}", static_cast<unsigned char>(ch));
-        }
-    }
-    return safeName;
-}
-
 //Debug  print of given peer infos
 
 auto printUris(const std::vector<std::string>& uris)
@@ -99,7 +79,7 @@ auto makeLocalEndpoint(const std::string& participantName, const SilKit::Core::P
 {
     asio::local::stream_protocol::endpoint result;
     // Ensure the participantName is in a useful encoding
-    const auto safe_name = printableName(participantName);
+    const auto safe_name = SilKit::Util::PrintableString(participantName);
     const auto bounded_name = safe_name.substr(0, std::min<size_t>(safe_name.size(), 10));
 
     // We hash the participant name, ID and the current working directory

--- a/SilKit/source/services/logging/Logger.cpp
+++ b/SilKit/source/services/logging/Logger.cpp
@@ -330,7 +330,7 @@ Logger::Logger(const std::string& participantName, Config::Logging config)
         {
             if (sink.format == Config::Sink::Format::Json)
             {
-                auto filename = fmt::format("{}_{}_{}.jsonl", sink.logName, participantName, logFileTimestamp);
+                auto filename = fmt::format("{}_{}_{}.jsonl", sink.logName, SilKit::Util::PrintableString(participantName), logFileTimestamp);
                 auto fileSink = std::make_shared<spdlog::sinks::basic_file_sink_mt>(filename);
                 using spdlog::details::make_unique; // for pre c++14
                 auto formatter = make_unique<spdlog::pattern_formatter>();
@@ -342,7 +342,7 @@ Logger::Logger(const std::string& participantName, Config::Logging config)
             }
             else
             {
-                auto filename = fmt::format("{}_{}_{}.txt", sink.logName, participantName, logFileTimestamp);
+                auto filename = fmt::format("{}_{}_{}.txt", sink.logName, SilKit::Util::PrintableString(participantName), logFileTimestamp);
                 auto fileSink = std::make_shared<spdlog::sinks::basic_file_sink_mt>(filename);
                 fileSink->set_level(log_level);
                 _loggerSimple->sinks().push_back(fileSink);

--- a/SilKit/source/services/logging/Logger.cpp
+++ b/SilKit/source/services/logging/Logger.cpp
@@ -330,7 +330,7 @@ Logger::Logger(const std::string& participantName, Config::Logging config)
         {
             if (sink.format == Config::Sink::Format::Json)
             {
-                auto filename = fmt::format("{}_{}_{}.jsonl", sink.logName, participantName logFileTimestamp);
+                auto filename = fmt::format("{}_{}_{}.jsonl", sink.logName, participantName, logFileTimestamp);
                 auto fileSink = std::make_shared<spdlog::sinks::basic_file_sink_mt>(filename);
                 using spdlog::details::make_unique; // for pre c++14
                 auto formatter = make_unique<spdlog::pattern_formatter>();
@@ -342,7 +342,7 @@ Logger::Logger(const std::string& participantName, Config::Logging config)
             }
             else
             {
-                auto filename = fmt::format("{}_{}.txt", sink.logName, logFileTimestamp);
+                auto filename = fmt::format("{}_{}_{}.txt", sink.logName, participantName, logFileTimestamp);
                 auto fileSink = std::make_shared<spdlog::sinks::basic_file_sink_mt>(filename);
                 fileSink->set_level(log_level);
                 _loggerSimple->sinks().push_back(fileSink);

--- a/SilKit/source/services/logging/Logger.cpp
+++ b/SilKit/source/services/logging/Logger.cpp
@@ -330,7 +330,7 @@ Logger::Logger(const std::string& participantName, Config::Logging config)
         {
             if (sink.format == Config::Sink::Format::Json)
             {
-                auto filename = fmt::format("{}_{}.jsonl", sink.logName, logFileTimestamp);
+                auto filename = fmt::format("{}_{}_{}.jsonl", sink.logName, participantName logFileTimestamp);
                 auto fileSink = std::make_shared<spdlog::sinks::basic_file_sink_mt>(filename);
                 using spdlog::details::make_unique; // for pre c++14
                 auto formatter = make_unique<spdlog::pattern_formatter>();

--- a/SilKit/source/util/StringHelpers.cpp
+++ b/SilKit/source/util/StringHelpers.cpp
@@ -119,6 +119,26 @@ auto LowerCase(std::string input) -> std::string
     return input;
 }
 
+auto PrintableString(const std::string& participantName) -> std::string
+{
+    std::string safeName;
+    for (const auto& ch : participantName)
+    {
+        // do not use std::isalnum, as it may sensitive to the current locale
+        const bool isAlphaNumeric{('a' <= ch && ch <= 'z') || ('A' <= ch && ch <= 'Z') || ('0' <= ch && ch <= '9')
+                                  || (ch == '_' || ch == '-' || ch == '.' || ch == '~')};
+
+        if (isAlphaNumeric)
+        {
+            safeName.push_back(ch);
+        }
+        else
+        {
+            safeName += fmt::format("{:02X}", static_cast<unsigned char>(ch));
+        }
+    }
+    return safeName;
+}
 
 } // namespace Util
 } // namespace SilKit

--- a/SilKit/source/util/StringHelpers.hpp
+++ b/SilKit/source/util/StringHelpers.hpp
@@ -41,6 +41,8 @@ auto CurrentTimestampString() -> std::string;
 
 auto LowerCase(std::string input) -> std::string;
 
+auto PrintableString(const std::string& input) -> std::string;
+
 
 } // namespace Util
 } // namespace SilKit

--- a/docs/configuration/logging-configuration.rst
+++ b/docs/configuration/logging-configuration.rst
@@ -74,4 +74,4 @@ logs to a file, the following configuration could be used:
        *Error*, *Warn*, *Info*, *Debug*, *Trace*, and *Off*.
    * - LogName
      - The filename used by sinks of type *File*. The
-       resulting filename is ``<LogName>_<ISO-TimeStamp>.txt``.
+       resulting filename is ``<LogName>_<Sanitized-Participant-Name>_<ISO-TimeStamp>.txt``.


### PR DESCRIPTION
Ensure that filenames are (more) unique, just in case multiple log files are opened in quick succession.
In the future we might want to provide some templating for the user to choose the file name.