### PR TITLE
cmake: don`t split debug symbols off of static libs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,7 +38,7 @@ option(SILKIT_ENABLE_UBSAN "Enable -f sanitize=undefined for builds (requires gc
 option(SILKIT_ENABLE_THREADSAN "Enable -f sanitize=thread for builds (requires gcc, clang)" OFF)
 option(SILKIT_ENABLE_COVERAGE "Enable coverage for builds (requires gcc, clang)" OFF)
 option(SILKIT_WARNINGS_AS_ERRORS "Treat compiler warnings as errors" OFF)
-option(SILKIT_PACKAGE_SYMBOLS "Add a post-build step to create PDB/Symbol archives" ON)
+option(SILKIT_PACKAGE_SYMBOLS "Add a post-build step to create PDB/Symbol archives" OFF)
 option(SILKIT_BUILD_DASHBOARD "Build the SIL Kit Dashboard client." ON)
 option(SILKIT_ENABLE_TRACING_INSTRUMENTATION "Enable tracing instrumentation (_SILKIT_TRACE_CLASS_NAMES)." OFF)
 option(SILKIT_LINK_LLD "Use the lld linker for SIL KIT" OFF)

--- a/SilKit/cmake/SilKitBuildTools.cmake
+++ b/SilKit/cmake/SilKitBuildTools.cmake
@@ -17,7 +17,6 @@ macro(silkit_split_debugsymbols targetName)
     )
 endmacro()
 
-
 macro(silkit_package_debugsymbols targetName)
     if(MSVC)
         message(STATUS "Creating symbol package ${SILKIT_SYMBOLS_DIR_NAME}")
@@ -33,6 +32,11 @@ macro(silkit_package_debugsymbols targetName)
         return()
     endif()
     if(UNIX AND CMAKE_BUILD_TYPE MATCHES "Debug")
+        get_target_property(targetType ${targetName} TYPE)
+        if(targetType STREQUAL STATIC_LIBRARY)
+            message(STATUS "SIL Kit: splitting debug symbols on static libraries is not supported")
+            return()
+        endif()
 
         silkit_split_debugsymbols("${targetName}")
 


### PR DESCRIPTION
Splitting archives is not supported. Only ELF shared objects in Debug builds