### PR TITLE
cmake: don`t use linker map on Android

### DIFF
--- a/SilKit/source/CMakeLists.txt
+++ b/SilKit/source/CMakeLists.txt
@@ -243,7 +243,7 @@ if (MSVC)
             PDB_OUTPUT_DIRECTORY_DEBUG ${SILKIT_SYMBOLS_DIR}/Debug
             LINK_FLAGS "/DEBUG" #make sure the resulting .dll has a .pdb file
     )
-elseif(UNIX AND NOT APPLE)
+elseif(UNIX AND NOT APPLE AND NOT (CMAKE_SYSTEM_NAME MATCHES Android))
     #for reproducible builds
     if(SILKIT_BUILD_REPRODUCIBLE)
         target_link_options(SilKit


### PR DESCRIPTION
The linker map is not working as intended on an Android NDK build.

## Repro
1. fetch android-ndk
2. export ANDROID_NDK_HOME=android-ndk-r27c
3. cd sil-kit && cmake -DCMAKE_TOOLCHAIN_FILE=$ANDROID_NDK_HOME/build/cmake/android.toolchain.cmake -DANDROID_PLATFORM=android-34 -DANDROID_ABI=arm64-v8a -DANDROID_NDK=$ANDROID_NDK_HOME  -DSILKIT_BUILD_DEMOS=OFF -DSILKIT_BUILD_STATIC=OFF -DSILKIT_BUILD_TESTS=OFF -B _build/android -S .

The shared library should build cleanly (note, there are some warnings with LLVM18)