### PR TITLE
c-api: turn const global into define

### DIFF
--- a/SilKit/include/silkit/capi/Lin.h
+++ b/SilKit/include/silkit/capi/Lin.h
@@ -161,7 +161,7 @@ typedef uint8_t SilKit_LinFrameStatus;
 typedef uint8_t SilKit_LinDataLength;
 
 //! \brief If configured for reception with this value, the data length validation of incoming frames is skipped.
-const SilKit_LinDataLength SilKit_LinDataLengthUnknown = 255u;
+#define SilKit_LinDataLengthUnknown ((SilKit_LinDataLength)255)
 
 /*! \brief A LIN SilKit_LinFrame
  *

--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -14,7 +14,11 @@ Fixed
 
 - **Important** ``SilKit_LinDataLengthUnknown`` in the C header ``Lin.h`` used to be a ``const`` global, which could cause
   linker issues if the header file is used in multiple translation units in the same binary.
+
   It has been turned into a ``#define``, like all the other constants in the C header files.
+
+  The symbol was not present in the dynamic symbol table of the ``SilKit.dll`` / ``.so``, so this change
+  does not break the ABI of the shared libraries.
 
 
 [4.0.54] - 2024-11-11

--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -9,6 +9,12 @@ The format is based on `Keep a Changelog (http://keepachangelog.com/en/1.0.0/) <
 [4.0.55] - Unreleased
 ---------------------
 
+Fixed
+~~~~~
+
+- **Important** ``SilKit_LinDataLengthUnknown`` in the C header ``Lin.h`` used to be a ``const`` global, which could cause
+  linker issues if the header file is used in multiple translation units in the same binary.
+  It has been turned into a ``#define``, like all the other constants in the C header files.
 
 
 [4.0.54] - 2024-11-11


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2023 Vector Informatik GmbH

SPDX-License-Identifier: MIT
-->

## Subject
<!--
    - What kind of changes does this pull request comprise?
    - Add a label like "Bugfix", "docs", etc. to this PR to give context.
 -->

When linking two separately compiled object files, both using the C-API, the linker informed me about a multiply defined symbol. This turned out to be the `const` global `SilKit_LinDataLengthUnknown`.

I did grep through the C headers and haven't found another one of those.

Neither the `.dll` nor the `.so` export this symbol so no trouble there.

Issue: SILKIT-1654

## Developer checklist (address before review)

- [ ] Changelog.md updated
- [ ] Prepared update for depending repositories
- [ ] Documentation updated (public API changes only)
- [ ] API docstrings updated (public API changes only)
- [ ] Rebase &rarr; commit history clean
- [x] Squash and merge &rarr; proper PR title
