### PR TITLE
docs: fix invalid reference causing warning

### DIFF
--- a/docs/api/capi/capi-lin.rst
+++ b/docs/api/capi/capi-lin.rst
@@ -83,7 +83,7 @@ Enumerations and Typedefs
 .. doxygentypedef:: SilKit_LinFrameResponseType
 .. doxygentypedef:: SilKit_LinFrameStatus
 .. doxygentypedef:: SilKit_LinDataLength
-.. doxygenvariable:: SilKit_LinDataLengthUnknown
+.. doxygendefine:: SilKit_LinDataLengthUnknown
 
 .. doxygentypedef:: SilKit_LinFrameStatusHandler_t
 .. doxygentypedef:: SilKit_LinGoToSleepHandler_t


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2023 Vector Informatik GmbH

SPDX-License-Identifier: MIT
-->

## Subject
<!--
    - What kind of changes does this pull request comprise?
    - Add a label like "Bugfix", "docs", etc. to this PR to give context.
 -->

Fixes warning caused by invalid doxygen reference. Fallout from the lin-header fix (`doxygenvariable` does not reference `#define`s).


## Developer checklist (address before review)

- [ ] Changelog.md updated
- [ ] Prepared update for depending repositories
- [x] Documentation updated (public API changes only)
- [ ] API docstrings updated (public API changes only)
- [ ] Rebase &rarr; commit history clean
- [x] Squash and merge &rarr; proper PR title
