### PR TITLE
capi: fix function pointer arguments in declaration

### DIFF
--- a/SilKit/include/silkit/capi/Can.h
+++ b/SilKit/include/silkit/capi/Can.h
@@ -353,6 +353,7 @@ SilKitAPI SilKit_ReturnCode SilKitCALL SilKit_CanController_AddFrameHandler(SilK
 typedef SilKit_ReturnCode(SilKitFPTR* SilKit_CanController_AddFrameHandler_t)(SilKit_CanController* controller,
                                                                               void* context,
                                                                               SilKit_CanFrameHandler_t handler,
+                                                                              SilKit_Direction directionMask,
                                                                               SilKit_HandlerId* outHandlerId);
 
 /*! \brief  Remove a \ref SilKit_CanFrameHandler_t by SilKit_HandlerId on this controller 

--- a/SilKit/include/silkit/capi/Orchestration.h
+++ b/SilKit/include/silkit/capi/Orchestration.h
@@ -467,7 +467,7 @@ SilKitAPI SilKit_ReturnCode SilKitCALL SilKit_TimeSyncService_Create(SilKit_Time
                                                                      SilKit_LifecycleService* lifecycleService);
 
 typedef SilKit_ReturnCode(SilKitFPTR* SilKit_TimeSyncService_Create_t)(SilKit_TimeSyncService** outTimeSyncService,
-                                                                       SilKit_Participant* lifecycleService);
+                                                                       SilKit_LifecycleService* lifecycleService);
 
 /*! \brief The handler to be called if the simulation task is due
  *


### PR DESCRIPTION
As reported by a user of the C-API, the pointer typedefs don't match the actual declarations.