### PR TITLE
dev: String definitions for SIL Kit error return codes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,7 +44,7 @@ option(SILKIT_ENABLE_TRACING_INSTRUMENTATION "Enable tracing instrumentation (_S
 option(SILKIT_LINK_LLD "Use the lld linker for SIL KIT" OFF)
 option(SILKIT_USE_SYSTEM_LIBRARIES "Use the libraries installed on the system for third party dependencies" OFF)
 option(SILKIT_BUILD_REPRODUCIBLE "Creates a reproducible build by ommiting timestamps/unique build ids" ON)
-option(SILKIT_BUILD_LINUX_PACKAGE "Creates SILKIT builds suitable for package managers in Linux Distributions (.deb)" OFF)
+option(SILKIT_BUILD_LINUX_PACKAGE "Creates SIL Kit builds suitable for package managers in Linux Distributions (.deb)" OFF)
 
 if(SILKIT_BUILD_LINUX_PACKAGE)
 

--- a/SilKit/IntegrationTests/ITest_CompatibilityWithWindowsHeaders.cpp
+++ b/SilKit/IntegrationTests/ITest_CompatibilityWithWindowsHeaders.cpp
@@ -19,13 +19,13 @@ LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE. */
 
-// This test ensures that the public SILKIT api is compatible with windows headers.
+// This test ensures that the public SIL Kit api is compatible with windows headers.
 
 // 1. include any relevant windows headers, that define some evil macros, e.g.,
 // max and min
 #include <windows.h>
 
-// 2. include all SILKIT headers
+// 2. include all SIL Kit headers
 #include "silkit/config/all.hpp"
 #include "silkit/participant/exception.hpp"
 #include "silkit/SilKitMacros.hpp"

--- a/SilKit/include/silkit/detail/impl/ThrowOnError.hpp
+++ b/SilKit/include/silkit/detail/impl/ThrowOnError.hpp
@@ -67,7 +67,7 @@ void ThrowOnError(SilKit_ReturnCode returnCode)
         }
 
         std::ostringstream os;
-        os << "SIL Kit: " << returnCodeCstr << " (" << returnCode << "): " << lastErrorCstr;
+        os << "SIL Kit: " << returnCodeCstr << " (" << returnCode << "):\n" << lastErrorCstr;
 
         switch (returnCode)
         {

--- a/SilKit/include/silkit/participant/exception.hpp
+++ b/SilKit/include/silkit/participant/exception.hpp
@@ -66,7 +66,7 @@ public:
     using SilKitError::SilKitError;
 
     ConfigurationError()
-        : ConfigurationError("SilKit: Configuration has syntactical or semantical errors.")
+        : ConfigurationError("Configuration has syntactical or semantical errors.")
     {
     }
 };

--- a/SilKit/source/CMakeLists.txt
+++ b/SilKit/source/CMakeLists.txt
@@ -41,7 +41,7 @@ set(GIT_DIR "${PROJECT_SOURCE_DIR}/../.git")
 set(GIT_HEAD_FILE "${GIT_DIR}/HEAD")
 set(VERSION_MACROS_HPP ${CMAKE_CURRENT_BINARY_DIR}/version_macros.hpp)
 if(EXISTS ${CMAKE_CURRENT_LIST_DIR}/version_macros.hpp)
-    message(STATUS "SILKIT: using deployed version_macros.hpp")
+    message(STATUS "SIL Kit: using deployed version_macros.hpp")
     set(VERSION_MACROS_HPP ${CMAKE_CURRENT_LIST_DIR}/version_macros.hpp)
 elseif(EXISTS "${GIT_HEAD_FILE}")
     configure_file(
@@ -58,7 +58,7 @@ elseif(EXISTS "${GIT_HEAD_FILE}")
         )
     endif()
 else()
-    message(STATUS "SILKIT: Cannot determine hash of current git head! GIT_HEAD_HASH will be set to UNKNOWN")
+    message(STATUS "SIL Kit: Cannot determine hash of current git head! GIT_HEAD_HASH will be set to UNKNOWN")
     set(GIT_HEAD_HASH "UNKNOWN")
     configure_file(
         version_macros.hpp.in
@@ -343,7 +343,7 @@ endif()
 #
 #   These files map the targets to the Release build. Without them, applications
 #   that are built as MinSizeRel or RelWithDebInfo will link against the Debug
-#   build of the SILKIT and will crash.
+#   build of the SIL Kit and will crash.
 install(
     FILES
         cmake/SilKitTargets-minsizerel.cmake

--- a/SilKit/source/MakeVersionMacros.cmake.in
+++ b/SilKit/source/MakeVersionMacros.cmake.in
@@ -33,7 +33,7 @@ if(GIT_HEAD_REF)
     if(NOT EXISTS "${linkedHeadFile}")
         # the workspace might have a .git/packed-refs file instead of
         # .git/refs/heads/master
-        message("-- SILKIT GIT Version: using ${GIT_DIR}/packed-refs")
+        message("-- SIL Kit GIT Version: using ${GIT_DIR}/packed-refs")
         file(READ ${GIT_DIR}/packed-refs packedRefs LIMIT 4096)
         string(REGEX MATCH "([abcdef0-9]+) ${linkedRef}" headHash ${packedRefs})
         if(NOT headHash)
@@ -41,7 +41,7 @@ if(GIT_HEAD_REF)
         endif()
         file(WRITE ${gitHashFile} "${CMAKE_MATCH_1}\n")
     else()
-        message("-- SILKIT GIT Version: using ${linkedHeadFile}")
+        message("-- SIL Kit GIT Version: using ${linkedHeadFile}")
         configure_file(
             "${linkedHeadFile}"
             ${gitHashFile}
@@ -57,7 +57,7 @@ endif()
 
 file(READ ${gitHashFile} GIT_HEAD_HASH LIMIT 512)
 string(STRIP "${GIT_HEAD_HASH}" GIT_HEAD_HASH)
-message(STATUS "SILKIT GIT Version: ${GIT_HEAD_HASH}")
+message(STATUS "SIL Kit GIT Version: ${GIT_HEAD_HASH}")
 configure_file(
     version_macros.hpp.in
     ${CMAKE_CURRENT_BINARY_DIR}/version_macros.hpp

--- a/SilKit/source/capi/CapiUtils.cpp
+++ b/SilKit/source/capi/CapiUtils.cpp
@@ -27,15 +27,23 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE. */
 
 thread_local std::string SilKit_error_string = "";
 
-#define SilKit_ReturnCode_SUCCESS_str "Operation succeeded."
-#define SilKit_ReturnCode_UNSPECIFIEDERROR_str "An unspecified error occured."
-#define SilKit_ReturnCode_NOTSUPPORTED_str "Operation is not supported."
-#define SilKit_ReturnCode_NOTIMPLEMENTED_str "Operation is not implemented."
-#define SilKit_ReturnCode_BADPARAMETER_str "Operation failed due to a bad parameter."
-#define SilKit_ReturnCode_BUFFERTOOSMALL_str "Operation failed because a buffer is too small."
-#define SilKit_ReturnCode_TIMEOUT_str "Operation timed out."
-#define SilKit_ReturnCode_UNSUPPORTEDSERVICE_str "The requested service is not supported."
-
+#define SilKit_ReturnCode_SUCCESS_str "Operation succeeded"
+#define SilKit_ReturnCode_UNSPECIFIEDERROR_str "An unspecified error occurred"
+#define SilKit_ReturnCode_NOTSUPPORTED_str "Operation is not supported"
+#define SilKit_ReturnCode_NOTIMPLEMENTED_str "Operation is not implemented"
+#define SilKit_ReturnCode_BADPARAMETER_str "Operation failed due to a bad parameter"
+#define SilKit_ReturnCode_BUFFERTOOSMALL_str "Operation failed because a buffer is too small"
+#define SilKit_ReturnCode_TIMEOUT_str "Operation timed out"
+#define SilKit_ReturnCode_UNSUPPORTEDSERVICE_str "The requested service is not supported"
+#define SilKit_ReturnCode_WRONGSTATE_str "State error"
+#define SilKit_ReturnCode_TYPECONVERSIONERROR_str "Invalid type conversion"
+#define SilKit_ReturnCode_CONFIGURATIONERROR_str "Configuration has errors"
+#define SilKit_ReturnCode_PROTOCOLERROR_str "Protocol error"
+#define SilKit_ReturnCode_ASSERTIONERROR_str "Assertion error"
+#define SilKit_ReturnCode_EXTENSIONERROR_str "Extension could not be loaded"
+#define SilKit_ReturnCode_LOGICERROR_str "Violation of logical preconditions"
+#define SilKit_ReturnCode_LENGTHERROR_str "Length limits violated"
+#define SilKit_ReturnCode_OUTOFRANGEERROR_str "Access of elements outside the defined range"
 
 SilKit_ReturnCode SilKitCALL SilKit_ReturnCodeToString(const char** outString, SilKit_ReturnCode returnCode)
 {
@@ -70,13 +78,39 @@ SilKit_ReturnCode SilKitCALL SilKit_ReturnCodeToString(const char** outString, S
     case SilKit_ReturnCode_UNSUPPORTEDSERVICE:
         *outString = SilKit_ReturnCode_UNSUPPORTEDSERVICE_str;
         break;
+    case SilKit_ReturnCode_WRONGSTATE:
+        *outString = SilKit_ReturnCode_WRONGSTATE_str;
+        break;
+    case SilKit_ReturnCode_TYPECONVERSIONERROR:
+        *outString = SilKit_ReturnCode_TYPECONVERSIONERROR_str;
+        break;
+    case SilKit_ReturnCode_CONFIGURATIONERROR:
+        *outString = SilKit_ReturnCode_CONFIGURATIONERROR_str;
+        break;
+    case SilKit_ReturnCode_PROTOCOLERROR:
+        *outString = SilKit_ReturnCode_PROTOCOLERROR_str;
+        break;
+    case SilKit_ReturnCode_ASSERTIONERROR:
+        *outString = SilKit_ReturnCode_ASSERTIONERROR_str;
+        break;
+    case SilKit_ReturnCode_EXTENSIONERROR:
+        *outString = SilKit_ReturnCode_EXTENSIONERROR_str;
+        break;
+    case SilKit_ReturnCode_LOGICERROR:
+        *outString = SilKit_ReturnCode_LOGICERROR_str;
+        break;
+    case SilKit_ReturnCode_LENGTHERROR:
+        *outString = SilKit_ReturnCode_LENGTHERROR_str;
+        break;
+    case SilKit_ReturnCode_OUTOFRANGEERROR:
+        *outString = SilKit_ReturnCode_OUTOFRANGEERROR_str;
+        break;
     default:
-        return SilKit_ReturnCode_BADPARAMETER;
+        return SilKit_ReturnCode_UNSPECIFIEDERROR;
     }
 
     return SilKit_ReturnCode_SUCCESS;
 }
-
 
 const char* SilKitCALL SilKit_GetLastErrorString()
 {

--- a/SilKit/source/capi/CapiUtils.cpp
+++ b/SilKit/source/capi/CapiUtils.cpp
@@ -106,7 +106,7 @@ SilKit_ReturnCode SilKitCALL SilKit_ReturnCodeToString(const char** outString, S
         *outString = SilKit_ReturnCode_OUTOFRANGEERROR_str;
         break;
     default:
-        return SilKit_ReturnCode_UNSPECIFIEDERROR;
+        return SilKit_ReturnCode_BADPARAMETER;
     }
 
     return SilKit_ReturnCode_SUCCESS;

--- a/SilKit/source/config/ParticipantConfiguration.hpp
+++ b/SilKit/source/config/ParticipantConfiguration.hpp
@@ -341,7 +341,7 @@ struct Experimental
 //  Root
 // ================================================================================
 
-//! \brief ParticipantConfiguration is the main configuration data object for a SILKIT participant.
+//! \brief ParticipantConfiguration is the main configuration data object for a SIL Kit participant.
 struct ParticipantConfiguration : public IParticipantConfiguration
 {
     ParticipantConfiguration() = default;

--- a/SilKit/source/config/ParticipantConfigurationFromXImpl.cpp
+++ b/SilKit/source/config/ParticipantConfigurationFromXImpl.cpp
@@ -121,11 +121,11 @@ void Validate(const std::string& text)
     SilKit::Config::YamlValidator validator;
     if (!validator.Validate(text, warnings))
     {
-        throw SilKit::ConfigurationError{"YAML validation returned errors: \n" + warnings.str()};
+        throw SilKit::ConfigurationError{"YAML validation returned errors:\n" + warnings.str()};
     }
     if (warnings.str().size() > 0)
     {
-        std::cout << "YAML validation returned warnings: \n" << warnings.str() << std::endl;
+        std::cout << "YAML validation returned warnings:\n" << warnings.str() << std::endl;
     }
 }
 

--- a/SilKit/source/config/SilKitYamlHelper.hpp
+++ b/SilKit/source/config/SilKitYamlHelper.hpp
@@ -96,12 +96,12 @@ DEFINE_SILKIT_PARSE_TYPE_NAME(std::string);
 } // namespace YAML
 
 ////////////////////////////////////////////////////////////////////////////////
-// Miscellaneous SILKIT Parsing Helper
+// Miscellaneous SIL Kit Parsing Helper
 ////////////////////////////////////////////////////////////////////////////////
 namespace SilKit {
 namespace Config {
 
-// Exception type for Bad SILKIT internal type conversion
+// Exception type for Bad SIL Kit internal type conversion
 class ConversionError : public YAML::BadConversion
 {
 public:
@@ -112,7 +112,7 @@ public:
     }
 };
 
-// Helper template function to convert SILKIT data types with nice error message
+// Helper template function to convert SIL Kit data types with nice error message
 template <typename ValueT>
 auto parse_as(const YAML::Node& node) -> ValueT
 {

--- a/SilKit/source/config/YamlValidator.cpp
+++ b/SilKit/source/config/YamlValidator.cpp
@@ -188,7 +188,7 @@ bool YamlValidator::Validate(const std::string& yamlString, std::ostream& warnin
             auto version = yamlDoc["SchemaVersion"].as<std::string>();
             if (!LoadSchema(version))
             {
-                warnings << "Error: Cannot load schema with SchemaVersion='" << version << "'" << "\n";
+                warnings << "Cannot load schema with SchemaVersion='" << version << "'" << "\n";
                 return false;
             }
         }
@@ -201,7 +201,7 @@ bool YamlValidator::Validate(const std::string& yamlString, std::ostream& warnin
     }
     catch (const std::exception& ex)
     {
-        warnings << "Error: caught exception: " << ex.what() << "\n";
+        warnings << ex.what() << "\n";
         return false;
     }
 }
@@ -211,7 +211,7 @@ auto YamlValidator::ParentName(const std::string& elementName) const -> std::str
     auto sep = elementName.rfind(_elementSeparator);
     if (sep == elementName.npos)
     {
-        throw SilKitError("Yaml Validation: elementName" + elementName + " has no parent");
+        throw ConfigurationError("elementName " + elementName + " has no parent");
     }
     else if (sep == 0)
     {

--- a/SilKit/source/core/vasio/VAsioDatatypes.hpp
+++ b/SilKit/source/core/vasio/VAsioDatatypes.hpp
@@ -39,7 +39,7 @@ static constexpr std::array<uint8_t, 4> REGISTRY_MESSAGE_HEADER_PREAMBLE_BYTES =
 struct RegistryMsgHeader
 {
     uint32_t preamble{REGISTRY_MESSAGE_HEADER_PREAMBLE_VALUE};
-    // If versionHigh/Low changes here, update SILKIT version range .
+    // If versionHigh/Low changes here, update SIL Kit version range .
     // Also, ensure backwards compatibility in the Ser/Des code path.
     // See VAsioProtcolVersion.hpp
     uint16_t versionHigh;

--- a/SilKit/source/core/vasio/VAsioProtocolVersion.hpp
+++ b/SilKit/source/core/vasio/VAsioProtocolVersion.hpp
@@ -57,7 +57,7 @@ auto MakeRegistryMsgHeader(ProtocolVersion version)
     return header;
 }
 
-//! Map ProtocolVersion ranges to SILKIT distribution releases
+//! Map ProtocolVersion ranges to SIL Kit distribution releases
 auto MapVersionToRelease(const SilKit::Core::RegistryMsgHeader& registryMsgHeader) -> std::string
 {
     const auto version = ExtractProtocolVersion(registryMsgHeader);

--- a/SilKit/source/core/vasio/VAsioSerdes_Protocol30.cpp
+++ b/SilKit/source/core/vasio/VAsioSerdes_Protocol30.cpp
@@ -90,7 +90,7 @@ struct ParticipantAnnouncement
 {
     RegistryMsgHeader messageHeader; //not changed
     VAsioPeerInfo peerInfo;
-    //!< additional field as of SILKIT >3.4.1, will be ignored by older participants
+    //!< additional field as of SIL Kit >3.4.1, will be ignored by older participants
     VAsioPeerUri peerUri;
 };
 
@@ -103,7 +103,7 @@ struct KnownParticipants
 {
     RegistryMsgHeader messageHeader;
     std::vector<VAsioPeerInfo> peerInfos;
-    //!< additional field as of SILKIT >3.4.1, will be ignored by older participants
+    //!< additional field as of SIL Kit >3.4.1, will be ignored by older participants
     std::vector<VAsioPeerUri> peerUris;
 };
 

--- a/SilKit/source/extensions/SilKitExtensionApi/SilKitExtensionABI.h
+++ b/SilKit/source/extensions/SilKitExtensionApi/SilKitExtensionABI.h
@@ -21,14 +21,14 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE. */
 #ifndef __SILKIT_EXTENSION_ABI_H__
 #define __SILKIT_EXTENSION_ABI_H__
 
-/*! SILKIT Extension Libraries
+/*! SIL Kit Extension Libraries
  *
  * This header defines the shared library interface in terms of C symbols, which
- * allow creation of SILKIT extensions as dynamic libraries.
+ * allow creation of SIL Kit extensions as dynamic libraries.
  * You have to implement the C functions listed below in your own library.
  *
  * Version Compatibility:
- * - SILKIT version must match, otherwise the extension will not be loaded.
+ * - SIL Kit version must match, otherwise the extension will not be loaded.
  * - newer versions of SilKitExtensionDescriptor must not change the existing struct
  *   layout, but may append to it.
  */

--- a/SilKit/source/extensions/SilKitExtensionApi/SilKitExtensionBase.hpp
+++ b/SilKit/source/extensions/SilKitExtensionApi/SilKitExtensionBase.hpp
@@ -23,7 +23,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE. */
 
 /*! SIL Kit Extension Implementations
  * Use the following SilKitExtensionBase class and to implement
- * shared libraries that act as SILKIT extensions.
+ * shared libraries that act as SIL Kit extensions.
  */
 
 #include <cstdint>

--- a/SilKit/source/extensions/SilKitExtensionImpl/DllCache.hpp
+++ b/SilKit/source/extensions/SilKitExtensionImpl/DllCache.hpp
@@ -64,7 +64,7 @@ public:
         catch (const SilKit::ExtensionError& err)
         {
             std::stringstream msg;
-            msg << "Error loading SILKIT extension '" << extensionName << "': " << err.what();
+            msg << "Error loading SIL Kit extension '" << extensionName << "': " << err.what();
             if (logger)
             {
                 logger->Error(msg.str());

--- a/SilKit/source/extensions/SilKitExtensionImpl/SilKitExtensionLoader.hpp
+++ b/SilKit/source/extensions/SilKitExtensionImpl/SilKitExtensionLoader.hpp
@@ -49,7 +49,7 @@ auto SilKitExtensionLoader(Services::Logging::ILogger* logger, const std::string
     catch (const std::bad_cast& err)
     {
         std::stringstream msg;
-        msg << "Error loading SILKIT extension '" << extensionName << "': " << err.what();
+        msg << "Error loading SIL Kit extension '" << extensionName << "': " << err.what();
         logger->Error(msg.str());
         throw ExtensionError(msg.str());
     }

--- a/SilKit/source/extensions/SilKitExtensions.cpp
+++ b/SilKit/source/extensions/SilKitExtensions.cpp
@@ -70,13 +70,13 @@ void VerifyExtension(SilKit::Services::Logging::ILogger* logger, const SilKitExt
     {
         throw ExtensionError("Extension returned invalid SilKitExtensionDescriptor");
     }
-    //verify the extensions SILKIT version to ours
+    //verify the extensions SIL Kit version to ours
     if (descr->silkit_version_major != SilKit::Version::MajorImpl()
         || descr->silkit_version_minor != SilKit::Version::MinorImpl()
         || descr->silkit_version_patch != SilKit::Version::PatchImpl())
     {
         std::stringstream ss;
-        ss << "Version mismatch: host SILKIT version is: " << SilKit::Version::MajorImpl() << "."
+        ss << "Version mismatch: host SIL Kit version is: " << SilKit::Version::MajorImpl() << "."
            << SilKit::Version::MinorImpl() << "." << SilKit::Version::PatchImpl()
            << " module has version: " << descr->silkit_version_major << "." << descr->silkit_version_minor << "."
            << descr->silkit_version_patch << ".";
@@ -106,14 +106,14 @@ void VerifyExtension(SilKit::Services::Logging::ILogger* logger, const SilKitExt
     {
         if (logger)
         {
-            logger->Warn("SILKIT extension verification: build system is misconfigured, the host system is UNKNOWN");
+            logger->Warn("SIL Kit extension verification: build system is misconfigured, the host system is UNKNOWN");
         }
     }
 
     if (my_sys != mod_sys)
     {
         std::stringstream msg;
-        msg << "SILKIT extension verification: Host system '" << my_sys << "' differs from module system '" << mod_sys
+        msg << "SIL Kit extension verification: Host system '" << my_sys << "' differs from module system '" << mod_sys
             << "'";
         if (logger)
         {
@@ -207,7 +207,7 @@ auto LoadExtension(Services::Logging::ILogger* logger, const std::string& name,
         catch (const ExtensionError& ex)
         {
             std::stringstream msg;
-            msg << "Failed to verify SILKIT extension located at path'" << path << "': " << ex.what();
+            msg << "Failed to verify SIL Kit extension located at path'" << path << "': " << ex.what();
             if (logger)
             {
                 logger->Debug(msg.str());
@@ -224,7 +224,7 @@ auto LoadExtension(Services::Logging::ILogger* logger, const std::string& name,
         if (lib_handle != nullptr)
         {
             std::stringstream msg;
-            msg << "Loaded SILKIT extension '" << name << "' from path '" << path << "'";
+            msg << "Loaded SIL Kit extension '" << name << "' from path '" << path << "'";
             if (logger)
             {
                 logger->Info(msg.str());

--- a/SilKit/source/extensions/SilKitExtensions.hpp
+++ b/SilKit/source/extensions/SilKitExtensions.hpp
@@ -40,7 +40,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE. */
  *   1.) loading dynamic, shared library (ie, *.so or *.dll), and
  *   2.) the extension points derived from ISilKitExtension.
  *
- * To create an extension for use inside of SILKIT create an interface as a
+ * To create an extension for use inside of SIL Kit create an interface as a
  * subclass of ISilKitExtension, and implement the interface in a
  * shared library.
  *

--- a/SilKit/source/tracing/CMakeLists.txt
+++ b/SilKit/source/tracing/CMakeLists.txt
@@ -20,7 +20,7 @@
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ######################################################################
-# SILKIT Tracing and Replay component
+# SIL Kit Tracing and Replay component
 # - Some tracing and replay functionality is implemented in
 #   the external sil-kit-mdf4tracing extension.
 ######################################################################

--- a/SilKit/source/tracing/IReplay.hpp
+++ b/SilKit/source/tracing/IReplay.hpp
@@ -65,7 +65,7 @@ public:
     virtual ~IReplayFile() = default;
     //! Get the filesystem path of the replay file
     virtual auto FilePath() const -> const std::string& = 0;
-    //! Returns embedded SILKIT config or empty string for non-SILKIT replay files
+    //! Returns embedded SIL Kit config or empty string for non SIL Kit replay files
     virtual auto SilKitConfig() const -> std::string = 0;
 
     //! Returns the file format type
@@ -78,7 +78,7 @@ public:
 
 //! Interface shared among all ReplayMessage types.
 
-//! Use a dynamic_cast to SILKIT message type to get actual data
+//! Use a dynamic_cast to SIL Kit message type to get actual data
 class IReplayMessage
 {
 public:

--- a/SilKit/source/tracing/ReplayScheduler.cpp
+++ b/SilKit/source/tracing/ReplayScheduler.cpp
@@ -163,7 +163,7 @@ private:
 
 private:
     const std::map<std::string, std::string>& _metaInfos;
-    //Used as default in SILKIT, CANoe
+    //Used as default in SIL Kit, CANoe
     const std::string _defaultSeparator{"/"};
 };
 
@@ -190,7 +190,7 @@ bool MatchMdfChannel(std::shared_ptr<IReplayChannel> channel, const Config::MdfC
     return result;
 }
 
-// Helper to identify Channel by its name in SILKIT format
+// Helper to identify Channel by its name in SIL Kit format
 bool MatchSilKitChannel(std::shared_ptr<IReplayChannel> channel, const std::string& networkName,
                         const std::string& participantName, const std::string& controllerName)
 {
@@ -267,7 +267,7 @@ auto FindReplayChannel(SilKit::Services::Logging::ILogger* log, IReplayFile* rep
         }
         else
         {
-            // SILKIT builtin channel lookup
+            // SIL Kit builtin channel lookup
             if (channel->Type() != type)
             {
                 Services::Logging::Trace(log, "Replay: skipping channel '{}' of type {}", channel->Name(),

--- a/docs/troubleshooting/interoperability.rst
+++ b/docs/troubleshooting/interoperability.rst
@@ -53,7 +53,7 @@ The second participant does not report a timeout anymore, but immediately report
 
 .. code-block:: powershell
 
-    SILKIT Connection Handshake: ParticipantAnnouncementReply contains unsupported version. participant=SilKitRegistry participant-version=3.1
+    SIL Kit Connection Handshake: ParticipantAnnouncementReply contains unsupported version. participant=SilKitRegistry participant-version=3.1
 
 Scenario D
 ----------


### PR DESCRIPTION
- Completed C strings in SilKit\source\capi\CapiUtils.cpp
- More clear exception message formatting
- Replaced `SILKIT` with `SIL Kit` 