### PR TITLE
demos: extend benchmark demo by can and ethernet

### DIFF
--- a/Demos/Benchmark/BenchmarkDemo.cpp
+++ b/Demos/Benchmark/BenchmarkDemo.cpp
@@ -466,6 +466,7 @@ void ParticipantsThread(std::shared_ptr<SilKit::Config::IParticipantConfiguratio
         case ServiceType::Ethernet:
         {
             SendEthernetFrames(ethernetController, benchmark.messageCount, benchmark.messageSizeInBytes);
+            break;
         }
         case ServiceType::Can:
         {

--- a/Demos/Benchmark/BenchmarkDemo.cpp
+++ b/Demos/Benchmark/BenchmarkDemo.cpp
@@ -471,6 +471,7 @@ void ParticipantsThread(std::shared_ptr<SilKit::Config::IParticipantConfiguratio
         case ServiceType::Can:
         {
             SendCanFrames(canController, benchmark.messageCount, benchmark.messageSizeInBytes);
+            break;
         }
         }
     }, benchmark.simulationStepSize);

--- a/Demos/Benchmark/BenchmarkDemo.cpp
+++ b/Demos/Benchmark/BenchmarkDemo.cpp
@@ -511,7 +511,7 @@ void PrintParameters(BenchmarkConfig benchmark)
               << std::endl
               << std::left << std::setw(39) << "- Number of participants: " << benchmark.numberOfParticipants
               << std::endl
-              << std::left << std::setw(39) << "- Messages per simulation step (1ms): " << benchmark.messageCount
+              << std::left << std::setw(39) << "- Messages per simulation step: " << benchmark.messageCount
               << std::endl
               << std::left << std::setw(39) << "- Message size (bytes): " << benchmark.messageSizeInBytes << std::endl
               << std::left << std::setw(39) << "- Registry URI: " << benchmark.registryUri << std::endl

--- a/Demos/Benchmark/BenchmarkDemo.cpp
+++ b/Demos/Benchmark/BenchmarkDemo.cpp
@@ -368,7 +368,7 @@ void SendEthernetFrames(IEthernetController* ethernetController, uint32_t messag
     for (uint32_t i = 0; i < messageCount; i++)
     {
         std::vector<uint8_t> frameData(messageSizeInBytes, '*');
-        ethernetController->SendFrame(std::move(EthernetFrame{frameData}));
+        ethernetController->SendFrame(EthernetFrame{frameData});
     }
 }
 
@@ -417,8 +417,9 @@ void ParticipantsThread(std::shared_ptr<SilKit::Config::IParticipantConfiguratio
         ethernetController = participant->CreateEthernetController("Eth1", "Eth1");
 
         ethernetController->AddFrameHandler(
-            [&messageCounter, participantName](IEthernetController* /*controller*/,
-                                               const EthernetFrameEvent& /*frameEvent*/) { messageCounter++; });
+            [&messageCounter](IEthernetController* /*controller*/, const EthernetFrameEvent& /*frameEvent*/) {
+            messageCounter++;
+        });
 
         lifecycleService->SetCommunicationReadyHandler([ethernetController]() { ethernetController->Activate(); });
         break;
@@ -428,9 +429,7 @@ void ParticipantsThread(std::shared_ptr<SilKit::Config::IParticipantConfiguratio
         canController = participant->CreateCanController("CAN1", "CAN1");
 
         canController->AddFrameHandler(
-            [&messageCounter, participantName](ICanController* /*ctrl*/, const CanFrameEvent& /*frameEvent*/) {
-            messageCounter++;
-        });
+            [&messageCounter](ICanController* /*ctrl*/, const CanFrameEvent& /*frameEvent*/) { messageCounter++; });
 
         lifecycleService->SetCommunicationReadyHandler([canController]() {
             canController->SetBaudRate(10'000, 1'000'000, 2'000'000);
@@ -511,8 +510,7 @@ void PrintParameters(BenchmarkConfig benchmark)
               << std::endl
               << std::left << std::setw(39) << "- Number of participants: " << benchmark.numberOfParticipants
               << std::endl
-              << std::left << std::setw(39) << "- Messages per simulation step: " << benchmark.messageCount
-              << std::endl
+              << std::left << std::setw(39) << "- Messages per simulation step: " << benchmark.messageCount << std::endl
               << std::left << std::setw(39) << "- Message size (bytes): " << benchmark.messageSizeInBytes << std::endl
               << std::left << std::setw(39) << "- Registry URI: " << benchmark.registryUri << std::endl
               << std::left << std::setw(39) << "- Configuration: " << benchmark.silKitConfigPath << std::endl

--- a/Demos/Benchmark/BenchmarkDemo.cpp
+++ b/Demos/Benchmark/BenchmarkDemo.cpp
@@ -421,6 +421,7 @@ void ParticipantsThread(std::shared_ptr<SilKit::Config::IParticipantConfiguratio
                                                const EthernetFrameEvent& /*frameEvent*/) { messageCounter++; });
 
         lifecycleService->SetCommunicationReadyHandler([ethernetController]() { ethernetController->Activate(); });
+        break;
     }
     case ServiceType::Can:
     {

--- a/Demos/Benchmark/BenchmarkDemo.cpp
+++ b/Demos/Benchmark/BenchmarkDemo.cpp
@@ -356,29 +356,29 @@ void CheckAndTruncateMessageSize(BenchmarkConfig& benchmark)
 
 void PublishMessages(IDataPublisher* publisher, uint32_t messageCount, uint32_t messageSizeInBytes)
 {
+    std::vector<uint8_t> data(messageSizeInBytes, '*');
     for (uint32_t i = 0; i < messageCount; i++)
-    {
-        std::vector<uint8_t> data(messageSizeInBytes, '*');
-        publisher->Publish(std::move(data));
+    {        
+        publisher->Publish(SilKit::Util::ToSpan(data));
     }
 }
 
 void SendEthernetFrames(IEthernetController* ethernetController, uint32_t messageCount, uint32_t messageSizeInBytes)
 {
+    std::vector<uint8_t> frameData(messageSizeInBytes, '*');
     for (uint32_t i = 0; i < messageCount; i++)
-    {
-        std::vector<uint8_t> frameData(messageSizeInBytes, '*');
-        ethernetController->SendFrame(EthernetFrame{frameData});
+    {        
+        ethernetController->SendFrame(EthernetFrame{SilKit::Util::ToSpan(frameData)});
     }
 }
 
 void SendCanFrames(ICanController* canController, uint32_t messageCount, uint32_t messageSizeInBytes)
 {
+    std::vector<uint8_t> frameData(messageSizeInBytes, '*');
     for (uint32_t i = 0; i < messageCount; i++)
     {
-        CanFrame canFrame{};
-        std::vector<uint8_t> frameData(messageSizeInBytes, '*');
-        canFrame.dataField = frameData;
+        CanFrame canFrame{};        
+        canFrame.dataField = SilKit::Util::ToSpan(frameData);
 
         canController->SendFrame(std::move(canFrame));
     }

--- a/Demos/Benchmark/BenchmarkDemo.cpp
+++ b/Demos/Benchmark/BenchmarkDemo.cpp
@@ -392,9 +392,9 @@ void ParticipantsThread(std::shared_ptr<SilKit::Config::IParticipantConfiguratio
     auto* lifecycleService = participant->CreateLifecycleService({OperationMode::Coordinated});
     auto* timeSyncService = lifecycleService->CreateTimeSyncService();
 
-    IDataPublisher* publisher;
-    IEthernetController* ethernetController;
-    ICanController* canController;
+    IDataPublisher* publisher = nullptr;
+    IEthernetController* ethernetController = nullptr;
+    ICanController* canController = nullptr;
 
     switch (benchmark.service)
     {

--- a/Demos/Benchmark/BenchmarkDemo.cpp
+++ b/Demos/Benchmark/BenchmarkDemo.cpp
@@ -461,6 +461,7 @@ void ParticipantsThread(std::shared_ptr<SilKit::Config::IParticipantConfiguratio
         case ServiceType::PubSub:
         {
             PublishMessages(publisher, benchmark.messageCount, benchmark.messageSizeInBytes);
+            break;
         }
         case ServiceType::Ethernet:
         {

--- a/Demos/Benchmark/BenchmarkDemo.cpp
+++ b/Demos/Benchmark/BenchmarkDemo.cpp
@@ -436,6 +436,7 @@ void ParticipantsThread(std::shared_ptr<SilKit::Config::IParticipantConfiguratio
             canController->SetBaudRate(10'000, 1'000'000, 2'000'000);
             canController->Start();
         });
+        break;
     }
     }
 

--- a/Demos/Benchmark/BenchmarkDemo.cpp
+++ b/Demos/Benchmark/BenchmarkDemo.cpp
@@ -410,6 +410,7 @@ void ParticipantsThread(std::shared_ptr<SilKit::Config::IParticipantConfiguratio
             // this is handled in I/O thread, so no data races on counter.
             messageCounter++;
         });
+        break;
     }
     case ServiceType::Ethernet:
     {


### PR DESCRIPTION
The Benchmark Demo has been extended by can and ethernet (so far only pubsub available). The service type can be determined via a command line argument (cf. silkit-1579).

Additional minor change: The simulation step size can be adapted via the command line.

<!--
SPDX-FileCopyrightText: 2023 Vector Informatik GmbH

SPDX-License-Identifier: MIT
-->

## Subject
<!--
    - What kind of changes does this pull request comprise?
    - Add a label like "Bugfix", "docs", etc. to this PR to give context.
 -->


## Description
<!--
    - Give a short summary of the intention of the changes.
    - Don't replicate the commit messages here.
    - Which Jira tickets are addressed with this pull request (list all if multiple tickets are affected)?
-->

## Instructions for review / testing
<!--
    - Hilight some of the important changes, which reviewers should focus on
    - Which parts should be reviewed in detail? For example: content of console output, correct semantics of changes
    - Test steps and test setup description. For example: which programs or configs to use
-->

## Developer checklist (address before review)

- [ ] Changelog.md updated
- [ ] Prepared update for depending repositories
- [ ] Documentation updated (public API changes only)
- [ ] API docstrings updated (public API changes only)
- [ ] Rebase &rarr; commit history clean
- [ ] Squash and merge &rarr; proper PR title
