### PR TITLE
SILKIT-1660: SystemMonitor: query older participants from VAsio

### DIFF
--- a/SilKit/source/core/mock/nullconnection/NullConnectionParticipant.cpp
+++ b/SilKit/source/core/mock/nullconnection/NullConnectionParticipant.cpp
@@ -80,6 +80,12 @@ struct NullConnection
         return 0;
     }
 
+    std::vector<std::string> GetConnectedParticipantsNames()
+    {
+        std::vector<std::string> tmp;
+        return tmp;
+    }
+
     size_t GetNumberOfRemoteReceivers(const IServiceEndpoint* /*service*/, const std::string& /*msgTypeName*/)
     {
         return 0;

--- a/SilKit/source/core/participant/Participant_impl.hpp
+++ b/SilKit/source/core/participant/Participant_impl.hpp
@@ -899,7 +899,15 @@ auto Participant<SilKitConnectionT>::GetSystemMonitor() -> Services::Orchestrati
             controller->OnParticipantDisconnected(
                 Services::Orchestration::ParticipantConnectionInformation{peer->GetInfo().participantName});
         });
+
+        // Get Participant which joined the Simulation earlier
+        std::vector<std::string> knownNames = _connection.GetConnectedParticipantsNames();
+        for (const auto& name : knownNames)
+        {
+            controller->OnParticipantConnected(Services::Orchestration::ParticipantConnectionInformation{name});
+        }
     }
+
     return controller;
 }
 

--- a/SilKit/source/core/vasio/VAsioConnection.cpp
+++ b/SilKit/source/core/vasio/VAsioConnection.cpp
@@ -1678,6 +1678,24 @@ void VAsioConnection::AddAsyncSubscriptionsCompletionHandler(std::function<void(
     }
 }
 
+std::vector<std::string> VAsioConnection::GetConnectedParticipantsNames()
+{
+    std::vector<std::string> participants;
+
+    {
+        std::unique_lock<decltype(_mutex)> lock{_mutex};
+        for (const auto& item : _participantNameToPeer)
+        {
+            for(const auto& peer: item.second)
+            {
+                participants.push_back(peer.first);
+            }
+        }
+    }
+
+    return participants;
+}
+
 auto VAsioConnection::GetNumberOfRemoteReceivers(const IServiceEndpoint* service,
                                                  const std::string& msgTypeName) -> size_t
 {

--- a/SilKit/source/core/vasio/VAsioConnection.hpp
+++ b/SilKit/source/core/vasio/VAsioConnection.hpp
@@ -216,6 +216,8 @@ public:
         return _peers.size();
     };
 
+    std::vector<std::string> GetConnectedParticipantsNames();
+
     auto GetNumberOfRemoteReceivers(const IServiceEndpoint* service, const std::string& msgTypeName) -> size_t;
     auto GetParticipantNamesOfRemoteReceivers(const IServiceEndpoint* service,
                                               const std::string& msgTypeName) -> std::vector<std::string>;

--- a/SilKit/source/services/orchestration/SystemMonitor.cpp
+++ b/SilKit/source/services/orchestration/SystemMonitor.cpp
@@ -84,14 +84,15 @@ auto SystemMonitor::AddParticipantStatusHandler(ParticipantStatusHandler handler
         for (const auto& participantConnectionInformation : _connectedParticipants)
         {
             const auto& participantName{participantConnectionInformation.second.participantName};
-            const auto* const participantStatus{_systemStateTracker.GetParticipantStatus(participantName)};
+            struct ParticipantStatus participantStatus;
+            const bool present = _systemStateTracker.GetParticipantStatus(participantName, participantStatus);
 
-            if (participantStatus == nullptr || participantStatus->state == ParticipantState::Invalid)
+            if (!present || participantStatus.state == ParticipantState::Invalid)
             {
                 continue;
             }
 
-            handler(*participantStatus);
+            handler(participantStatus);
         }
     }
 

--- a/SilKit/source/services/orchestration/SystemStateTracker.cpp
+++ b/SilKit/source/services/orchestration/SystemStateTracker.cpp
@@ -263,6 +263,20 @@ auto SystemStateTracker::GetParticipantStatus(const std::string& participantName
     return &it->second;
 }
 
+bool SystemStateTracker::GetParticipantStatus(const std::string& participantName, ParticipantStatus& status) const
+{
+    std::lock_guard<decltype(_mutex)> lock{_mutex};
+
+    const auto it{_participantStatusCache.find(participantName)};
+    if (it == _participantStatusCache.end())
+    {
+        return false;
+    }
+
+    status = it->second;
+    return true;
+}
+
 auto SystemStateTracker::GetSystemState() const -> SystemState
 {
     std::lock_guard<decltype(_mutex)> lock{_mutex};

--- a/SilKit/source/services/orchestration/SystemStateTracker.hpp
+++ b/SilKit/source/services/orchestration/SystemStateTracker.hpp
@@ -55,6 +55,7 @@ public:
 
     auto IsRequiredParticipant(const std::string& participantName) const -> bool;
     auto GetParticipantStatus(const std::string& participantName) const -> const ParticipantStatus*;
+    bool GetParticipantStatus(const std::string& participantName, ParticipantStatus& status) const;
     auto GetSystemState() const -> SystemState;
 
 private:

--- a/SilKit/source/services/rpc/RpcTestUtilities.hpp
+++ b/SilKit/source/services/rpc/RpcTestUtilities.hpp
@@ -149,6 +149,12 @@ struct MockConnection
         return 0;
     }
 
+    std::vector<std::string> GetConnectedParticipantsNames()
+    {
+        std::vector<std::string> tmp;
+        return tmp;
+    }
+
     size_t GetNumberOfRemoteReceivers(const SilKit::Core::IServiceEndpoint* /*service*/,
                                       const std::string& /*msgTypeName*/)
     {


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2023 Vector Informatik GmbH

SPDX-License-Identifier: MIT
-->

## Subject
The SystemMonitor does not know about participants which are "older" than the current participants since he misses the Announcement and AnnouncementReplies

## Description
Get the list of all connected peers/particpants, that have joined the simulation before, from the VAsioConnection. This ensures that the SystemMonitor also knows about other Participants whose Announcement/AnnouncementReply we missed!

Issues: SILKIT-1660

## Developer checklist (address before review)

- [ ] Changelog.md updated
- [ ] Prepared update for depending repositories
- [ ] Documentation updated (public API changes only)
- [ ] API docstrings updated (public API changes only)
- [ ] Rebase &rarr; commit history clean
- [ ] Squash and merge &rarr; proper PR title
