### PR TITLE
SILKIT-1676: Block participants from joining the same simulation multiple times

### DIFF
--- a/SilKit/source/core/vasio/VAsioRegistry.cpp
+++ b/SilKit/source/core/vasio/VAsioRegistry.cpp
@@ -290,11 +290,21 @@ void VAsioRegistry::OnPeerShutdown(IVAsioPeer* peer)
     const auto& simulationName{peer->GetSimulationName()};
     const auto& participantName{peer->GetInfo().participantName};
 
-    if (FindConnectedParticipant(participantName, simulationName) == nullptr)
+    const auto connectedParticipant = FindConnectedParticipant(participantName, simulationName);
+
+    if (connectedParticipant == nullptr)
     {
         Log::Debug(_logger.get(), "Peer '{}' has shut down, which had no participant information", participantName);
         return;
     }
+
+    if (connectedParticipant->peer != peer)
+    {
+        Log::Debug(_logger.get(), "Duplicate peer '{}' has shut down, which had no participant information", participantName);
+        return;
+    }
+
+    Log::Debug(_logger.get(), "Peer '{}' has shut down", participantName);
 
     if (_registryEventListener != nullptr)
     {

--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -51,7 +51,13 @@ Added
   - SimpleCan
   - Orchestration demos  
 
-- Sample participant configurations  
+- Sample participant configurations
+
+Fixed
+~~~~~
+
+- Block multiple attempts to connect with an already present participant name, not just the first.
+
 
 [4.0.54] - 2024-11-11
 ---------------------


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2023 Vector Informatik GmbH

SPDX-License-Identifier: MIT
-->

## Subject
<!--
    - What kind of changes does this pull request comprise?
    - Add a label like "Bugfix", "docs", etc. to this PR to give context.
 -->

The first attempt to connect to a simulation where a participant with the same name was present was blocked, but subsequent attempts were not blocked.

This change fixes this behavior, by checking that the disconnecting peer is actually the peer that connected initially before removing the connection information on peer shutdown.

## Developer checklist (address before review)

- [x] Changelog.md updated
- [ ] Prepared update for depending repositories
- [ ] Documentation updated (public API changes only)
- [ ] API docstrings updated (public API changes only)
- [ ] Rebase &rarr; commit history clean
- [x] Squash and merge &rarr; proper PR title
