### PR TITLE
SILKIT-1667: Fix hop on with wall clock coupling

### DIFF
--- a/SilKit/source/services/orchestration/TimeConfiguration.hpp
+++ b/SilKit/source/services/orchestration/TimeConfiguration.hpp
@@ -55,7 +55,8 @@ public: //Methods
     bool ShouldResendNextSimStep();
 
     // Returns true (only once) in the step the actual hop-on happened
-    bool HandleHopOn();
+    bool IsHopOn();
+    bool HoppedOn();
 
 private: //Members
     mutable std::mutex _mx;

--- a/SilKit/source/services/orchestration/TimeSyncService.hpp
+++ b/SilKit/source/services/orchestration/TimeSyncService.hpp
@@ -110,6 +110,7 @@ public:
     auto GetCurrentWallClockSyncPoint() const -> std::chrono::nanoseconds;
 
     bool IsBlocking() const;
+    void StartWallClockCouplingThread(std::chrono::nanoseconds startTimeOffset);
 
 private:
     // ----------------------------------------
@@ -122,7 +123,6 @@ private:
     inline auto GetTimeSyncPolicy() const -> ITimeSyncPolicy*;
 
     void StopWallClockCouplingThread();
-    void StartWallClockCouplingThread();
     void HybridWait(std::chrono::nanoseconds targetWaitDuration);
 
     void LogicalSimStepCompleted(std::chrono::duration<double, std::milli> logicalSimStepExecutionTimeMs);


### PR DESCRIPTION
Before, participants with wall clock coupling (enabled via `Experimental | TimeSynchronization | AnimationFactor`) would wait to catch up on the elapsed time if joining a already running simulation with time sync. (aka hop-on). 

Now, the thread that handles the wall clock coupling is only started after the evaluation if it is a hop-on scenario or not. If so, the already elapsed simulation time is used as an offset for the wall clock coupling.