### PR TITLE
dev: Allow to explicitly reset the static signal handler

### DIFF
--- a/Demos/communication/include/ApplicationBase.hpp
+++ b/Demos/communication/include/ApplicationBase.hpp
@@ -767,6 +767,8 @@ public:
             // async: Join worker thread
             WaitUntilDone();
 
+            ShutdownSignalHandler();
+
             return 0;
         }
         catch (const std::exception& error)

--- a/Demos/communication/include/SignalHandler.hpp
+++ b/Demos/communication/include/SignalHandler.hpp
@@ -255,6 +255,7 @@ void RegisterSignalHandler(SignalHandler handler)
 {
     gSignalMonitor.reset(new SignalMonitor(std::move(handler)));
 }
+
 void ShutdownSignalHandler()
 {
     gSignalMonitor.reset();

--- a/Demos/communication/include/SignalHandler.hpp
+++ b/Demos/communication/include/SignalHandler.hpp
@@ -255,3 +255,7 @@ void RegisterSignalHandler(SignalHandler handler)
 {
     gSignalMonitor.reset(new SignalMonitor(std::move(handler)));
 }
+void ShutdownSignalHandler()
+{
+    gSignalMonitor.reset();
+}

--- a/SilKit/source/util/SignalHandler.cpp
+++ b/SilKit/source/util/SignalHandler.cpp
@@ -72,7 +72,10 @@ public:
     {
         SetConsoleCtrlHandler(systemHandler, false);
         Notify(INVALID_SIGNAL_NUMBER);
-        _worker.join();
+        if (_worker.joinable())
+        {
+            _worker.join();
+        }
         CloseHandle(_writeEnd);
         CloseHandle(_readEnd);
     }
@@ -173,7 +176,7 @@ public:
 
     ~SignalMonitor()
     {
-        // Restore default actio0ns
+        // Restore default actions
         setSignalAction(SIGINT, nullptr);
         setSignalAction(SIGTERM, nullptr);
         Notify(INVALID_SIGNAL_NUMBER);
@@ -264,6 +267,12 @@ void RegisterSignalHandler(SignalHandler handler)
 {
     gSignalMonitor.reset(new SignalMonitor(std::move(handler)));
 }
+
+void ShutdownSignalHandler()
+{
+    gSignalMonitor.reset();
+}
+
 
 } // namespace Util
 } // namespace SilKit

--- a/SilKit/source/util/SignalHandler.hpp
+++ b/SilKit/source/util/SignalHandler.hpp
@@ -29,6 +29,7 @@ namespace Util {
 
 using SignalHandler = std::function<void(int)>;
 void RegisterSignalHandler(SignalHandler handler);
+void ShutdownSignalHandler();
 
 } // namespace Util
 } // namespace SilKit

--- a/Utilities/SilKitSystemController/SystemController.cpp
+++ b/Utilities/SilKitSystemController/SystemController.cpp
@@ -388,6 +388,8 @@ int main(int argc, char** argv)
         std::cout << "Press Ctrl-C to end the simulation..." << std::endl;
         controller.RegisterSignalHandler();
         controller.WaitForFinalState();
+
+        SilKit::Util::ShutdownSignalHandler();
     }
     catch (const std::exception& error)
     {


### PR DESCRIPTION
The worker thread of the static signal handler (holding user callbacks) is potentially destruced after the participant. TSAN runs showed use-after-free problems in the `sil-kit-system-controller` when using CTRL-C on it in a running simulation (EthernetDemo). 

Here a explicit function `SilKit::Util::ShutdownSignalHandler` is introduced that destroys the `gSignalMonitor`. Using this at the end of the `sil-kit-system-controller` resolves the TSAN issue. Same is applied to the `ApplicationBase` of the communication demos that also uses the signal handler.