### PR TITLE
demos: fix schedule used for sending lin frames

### DIFF
--- a/Demos/communication/Lin/LinMasterDemo.cpp
+++ b/Demos/communication/Lin/LinMasterDemo.cpp
@@ -70,12 +70,12 @@ private:
 
         _schedule = std::make_unique<LinDemoCommon::Schedule>(
             std::initializer_list<std::pair<std::chrono::nanoseconds, std::function<void(std::chrono::nanoseconds)>>>{
-                {5ms, [this](std::chrono::nanoseconds /*now*/) { SendFrame_16(); }},
-                {5ms, [this](std::chrono::nanoseconds /*now*/) { SendFrame_17(); }},
-                {5ms, [this](std::chrono::nanoseconds /*now*/) { SendFrame_18(); }},
-                {5ms, [this](std::chrono::nanoseconds /*now*/) { SendFrame_19(); }},
-                {5ms, [this](std::chrono::nanoseconds /*now*/) { SendFrame_34(); }},
-                {5ms, [this](std::chrono::nanoseconds /*now*/) { GoToSleep(); }}});
+                {10ms, [this](std::chrono::nanoseconds /*now*/) { SendFrame_16(); }},
+                {20ms, [this](std::chrono::nanoseconds /*now*/) { SendFrame_17(); }},
+                {10ms, [this](std::chrono::nanoseconds /*now*/) { SendFrame_18(); }},
+                {10ms, [this](std::chrono::nanoseconds /*now*/) { SendFrame_19(); }},
+                {10ms, [this](std::chrono::nanoseconds /*now*/) { SendFrame_34(); }},
+                {10ms, [this](std::chrono::nanoseconds /*now*/) { GoToSleep(); }}});
     }
 
     void InitControllers() override

--- a/Demos/communication/Lin/LinMasterDynamicDemo.cpp
+++ b/Demos/communication/Lin/LinMasterDynamicDemo.cpp
@@ -134,12 +134,12 @@ private:
 
         _schedule = std::make_unique<LinDemoCommon::Schedule>(
             std::initializer_list<std::pair<std::chrono::nanoseconds, std::function<void(std::chrono::nanoseconds)>>>{
-            {5ms, [this](std::chrono::nanoseconds /*now*/) { SendFrameHeader(16); }},
-            {5ms, [this](std::chrono::nanoseconds /*now*/) { SendFrameHeader(17); }},
-            {5ms, [this](std::chrono::nanoseconds /*now*/) { SendFrameHeader(18); }},
-            {5ms, [this](std::chrono::nanoseconds /*now*/) { SendFrameHeader(19); }},
-            {5ms, [this](std::chrono::nanoseconds /*now*/) { SendFrameHeader(34); }},
-            {5ms, [this](std::chrono::nanoseconds /*now*/) { GoToSleep(); }}
+            {10ms, [this](std::chrono::nanoseconds /*now*/) { SendFrameHeader(16); }},
+            {20ms, [this](std::chrono::nanoseconds /*now*/) { SendFrameHeader(17); }},
+            {10ms, [this](std::chrono::nanoseconds /*now*/) { SendFrameHeader(18); }},
+            {10ms, [this](std::chrono::nanoseconds /*now*/) { SendFrameHeader(19); }},
+            {10ms, [this](std::chrono::nanoseconds /*now*/) { SendFrameHeader(34); }},
+            {10ms, [this](std::chrono::nanoseconds /*now*/) { GoToSleep(); }}
         }, false);
 
     }


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2023 Vector Informatik GmbH

SPDX-License-Identifier: MIT
-->

## Subject
<!--
    - What kind of changes does this pull request comprise?
    - Add a label like "Bugfix", "docs", etc. to this PR to give context.
 -->

Fixes (corretly) dropped frames caused by using too tight of a schedule in the LIN demo.

## Developer checklist (address before review)

- [ ] Changelog.md updated
- [ ] Prepared update for depending repositories
- [ ] Documentation updated (public API changes only)
- [ ] API docstrings updated (public API changes only)
- [ ] Rebase &rarr; commit history clean
- [x] Squash and merge &rarr; proper PR title
