### PR TITLE
SILKIT-1608: disable nagle algorithm by default

### DIFF
--- a/SilKit/source/config/ParticipantConfiguration.hpp
+++ b/SilKit/source/config/ParticipantConfiguration.hpp
@@ -301,7 +301,7 @@ struct Middleware
     int connectAttempts{1}; //!<  Number of connection attempts to the registry a participant should perform.
     int tcpReceiveBufferSize{-1};
     int tcpSendBufferSize{-1};
-    bool tcpNoDelay{false}; //!< Disables Nagle's algorithm.
+    bool tcpNoDelay{true}; //!< Nagle's algorithm disabled by default.
     bool tcpQuickAck{false}; //!< Setting this Linux specific flag disables delayed TCP/IP acknowledgements.
     bool enableDomainSockets{true}; //!< By default local domain socket is preferred to TCP/IP sockets.
     std::vector<std::string>

--- a/docs/configuration/middleware-configuration.rst
+++ b/docs/configuration/middleware-configuration.rst
@@ -33,7 +33,7 @@ running on 'localhost' listening on port 8500. These values can be changed via t
     Middleware:
       RegistryUri: silkit://localhost:8500
       ConnectAttempts: 1
-      TcpNoDelay: false
+      TcpNoDelay: true
       TcpQuickAck: false
       TcpSendBufferSize: 1024
       TcpReceiveBufferSize: 1024
@@ -57,7 +57,7 @@ running on 'localhost' listening on port 8500. These values can be changed via t
        By default, only a single connect is attempted.
 
    * - TcpNoDelay
-     - Enable the TCP_NODELAY flag on TCP sockets. This disables Nagle's algorithm.
+     - Disable the TCP_NODELAY flag on TCP sockets. This enables Nagle's algorithm.
 
    * - TcpQuickAck
      - Enable the TCP_QUICKACK flag on TCP sockets (Linux only). Disables delayed

--- a/docs/faq/faq.rst
+++ b/docs/faq/faq.rst
@@ -93,6 +93,8 @@ Finally, the hardware being used, the network infrastructure and the distributio
 
 To get a first impression of the performance that can be expected of the |ProductName| in your use case, refer to the :ref:`Benchmark Demo<sec:benchmark-demo>` where you can specify a set of relevant parameters and get real performance measurements for your setup.
 
+You can find further information on performance aspects in the :doc:`troubleshooting<../troubleshooting/performance>` section.
+
 Can I control the order in which simulation participants execute their simulation steps, in case they occur at the same time?
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/docs/troubleshooting/performance.rst
+++ b/docs/troubleshooting/performance.rst
@@ -1,0 +1,21 @@
+.. include:: /substitutions.rst
+
+Performance
+=========
+
+The following sections provide support for improving the performance of |ProductName|.
+
+Configuration of TCP Stack (Kernel)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The TCP stack of the kernel can be configured via the participant configuration file, more precisely the :doc:`middleware<../configuration/middleware-configuration>` options. 
+This configuration needs to be done carefully. In particular, Nagle's algorithm (``TcpNoDelay``) and delayed acknowledgements (``TcpQuickAck``) are known to interact badly. 
+Per default, Nagle's algorithm is disabled and delayed acknowledgements are enabled. Note that enabling both features may cause severe performance losses as well as non-deterministic behaviour.
+Latency peaks of 40 ms and a large throughput variance have been observed in this case so far.
+
+Message Aggregation
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+For the time-synchronized case, |ProductName| offers the possibility of aggregating messages prior to sending. 
+This feature can be enabled via the :doc:`EnableMessageAggregation<../configuration/experimental-configuration>` parameter in the participant configuration file.
+We mention that the message aggregation feature has a significant impact on the throughput, in particular if several small messages (<1kB) are sent within one simulation step.

--- a/docs/troubleshooting/troubleshooting.rst
+++ b/docs/troubleshooting/troubleshooting.rst
@@ -32,9 +32,11 @@ Most issues can be identified based on log messages by the application.
     lifecycle.rst
     interoperability.rst
     connection-guides.rst
+    performance.rst
 
 ..
     .. include:: connectivity.rst
     .. include:: lifecycle.rst
     .. include:: interoperability.rst
     .. include:: connection-guides.rst
+    .. include:: performance.rst


### PR DESCRIPTION


<!--
SPDX-FileCopyrightText: 2023 Vector Informatik GmbH

SPDX-License-Identifier: MIT
-->

## Subject
- Disable nagle algorithm by default (prevent bad interaction with delayed acks)
- Add performance section to troubleshooting in docs

## Description
See: https://jira.vg.vector.int/browse/SILKIT-1608
