### PR TITLE
hourglass: calling convention of trampoline functions (#188)

### DIFF
--- a/SilKit/include/silkit/detail/impl/services/pubsub/DataSubscriber.hpp
+++ b/SilKit/include/silkit/detail/impl/services/pubsub/DataSubscriber.hpp
@@ -22,6 +22,7 @@
 #pragma once
 
 #include "silkit/capi/DataPubSub.h"
+#include "silkit/capi/SilKitMacros.h"
 
 #include "silkit/services/pubsub/IDataSubscriber.hpp"
 
@@ -46,8 +47,8 @@ public:
     inline void SetDataMessageHandler(SilKit::Services::PubSub::DataMessageHandler handler) override;
 
 private:
-    inline static void TheDataMessageHandler(void* context, SilKit_DataSubscriber* subscriber,
-                                             const SilKit_DataMessageEvent* dataMessageEvent);
+    inline static void SilKitCALL TheDataMessageHandler(void* context, SilKit_DataSubscriber* subscriber,
+                                                        const SilKit_DataMessageEvent* dataMessageEvent);
 
 private:
     template <typename HandlerFunction>

--- a/SilKit/include/silkit/detail/impl/services/rpc/RpcClient.hpp
+++ b/SilKit/include/silkit/detail/impl/services/rpc/RpcClient.hpp
@@ -22,6 +22,7 @@
 #pragma once
 
 #include "silkit/capi/Rpc.h"
+#include "silkit/capi/SilKitMacros.h"
 
 #include "silkit/services/rpc/IRpcClient.hpp"
 
@@ -51,8 +52,8 @@ public:
     inline void SetCallResultHandler(SilKit::Services::Rpc::RpcCallResultHandler handler) override;
 
 private:
-    inline static void TheRpcCallResultHandler(void* context, SilKit_RpcClient* server,
-                                               const SilKit_RpcCallResultEvent* rpcCallResultEvent);
+    inline static void SilKitCALL TheRpcCallResultHandler(void* context, SilKit_RpcClient* server,
+                                                          const SilKit_RpcCallResultEvent* rpcCallResultEvent);
 
 private:
     template <typename HandlerFunction>

--- a/SilKit/include/silkit/detail/impl/services/rpc/RpcServer.hpp
+++ b/SilKit/include/silkit/detail/impl/services/rpc/RpcServer.hpp
@@ -22,6 +22,7 @@
 #pragma once
 
 #include "silkit/capi/Rpc.h"
+#include "silkit/capi/SilKitMacros.h"
 
 #include "silkit/services/rpc/IRpcServer.hpp"
 
@@ -49,8 +50,8 @@ public:
     inline void SetCallHandler(SilKit::Services::Rpc::RpcCallHandler handler) override;
 
 private:
-    inline static void TheRpcCallHandler(void* context, SilKit_RpcServer* server,
-                                         const SilKit_RpcCallEvent* rpcCallEvent);
+    inline static void SilKitCALL TheRpcCallHandler(void* context, SilKit_RpcServer* server,
+                                                    const SilKit_RpcCallEvent* rpcCallEvent);
 
     inline static auto CallHandleFromC(SilKit_RpcCallHandle* rpcCallHandle) -> SilKit::Services::Rpc::IRpcCallHandle*;
 


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2023 Vector Informatik GmbH

SPDX-License-Identifier: MIT
-->

## Subject
<!--
    - What kind of changes does this pull request comprise?
    - Add a label like "Bugfix", "docs", etc. to this PR to give context.
 -->

Adds the calling convention macro on the trampoline functions of the hourglass API. This was reported in issue #188.

## Developer checklist (address before review)

- [ ] Changelog.md updated
- [ ] Prepared update for depending repositories
- [ ] Documentation updated (public API changes only)
- [ ] API docstrings updated (public API changes only)
- [ ] Rebase &rarr; commit history clean
- [ ] Squash and merge &rarr; proper PR title
