### PR TITLE
docs: fix warning in section heading

### DIFF
--- a/docs/troubleshooting/performance.rst
+++ b/docs/troubleshooting/performance.rst
@@ -1,7 +1,7 @@
 .. include:: /substitutions.rst
 
 Performance
-=========
+===========
 
 The following sections provide support for improving the performance of |ProductName|.
 


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2023 Vector Informatik GmbH

SPDX-License-Identifier: MIT
-->

## Subject

Fixes the build error that occured in the internal pipeline.

## Developer checklist (address before review)

- [ ] Changelog.md updated
- [ ] Prepared update for depending repositories
- [ ] Documentation updated (public API changes only)
- [ ] API docstrings updated (public API changes only)
- [ ] Rebase &rarr; commit history clean
- [ ] Squash and merge &rarr; proper PR title
