### PR TITLE
docs: add myst-parser and let cmake find python

### DIFF
--- a/.github/workflows/build-win.yml
+++ b/.github/workflows/build-win.yml
@@ -32,7 +32,7 @@ jobs:
       run: |
         # HOTFIX: github hosted runners have upgraded to CMake 4.0.0 which
         #         breaks building yaml-cpp
-        choco uninstall cmake
+        choco uninstall cmake.install
         choco install cmake --version 3.31.6
 
         choco install -y ninja
@@ -67,7 +67,7 @@ jobs:
       run: |
         # HOTFIX: github hosted runners have upgraded to CMake 4.0.0 which
         #         breaks building yaml-cpp
-        choco uninstall cmake
+        choco uninstall cmake.install
         choco install cmake --version 3.31.6
 
         choco install -y ninja

--- a/SilKit/ci/docker/docs_requirements.txt
+++ b/SilKit/ci/docker/docs_requirements.txt
@@ -1,3 +1,4 @@
 breathe == 4.34.0
 sphinx == 5.1.1
 sphinx-rtd-theme == 1.0.0
+myst-parser == 1.0.0

--- a/SilKit/include/silkit/capi/Lin.h
+++ b/SilKit/include/silkit/capi/Lin.h
@@ -92,10 +92,12 @@ typedef uint8_t SilKit_LinId;
  * This type is used to specify the Checksum model to be used for the LIN \ref SilKit_LinFrame.
  */
 typedef uint8_t SilKit_LinChecksumModel;
-#define SilKit_LinChecksumModel_Unknown \
-    ((SilKit_LinChecksumModel)0) //!< Unknown checksum model. If configured with this value, the checksum model of the first reception will be used.
-#define SilKit_LinChecksumModel_Enhanced ((SilKit_LinChecksumModel)1) //!< Enhanced checksum model
-#define SilKit_LinChecksumModel_Classic ((SilKit_LinChecksumModel)2) //!< Classic checksum model
+/*! Unknown checksum model. If configured with this value, the checksum model of the first reception will be used. */
+#define SilKit_LinChecksumModel_Unknown ((SilKit_LinChecksumModel)0)
+/*! Enhanced checksum model */
+#define SilKit_LinChecksumModel_Enhanced ((SilKit_LinChecksumModel)1)
+/*! Classic checksum model */
+#define SilKit_LinChecksumModel_Classic ((SilKit_LinChecksumModel)2)
 
 /*! \brief Controls the behavior of \ref SilKit_LinController_SendFrame()
  *

--- a/SilKit/include/silkit/capi/NetworkSimulator.h
+++ b/SilKit/include/silkit/capi/NetworkSimulator.h
@@ -74,13 +74,13 @@ typedef struct SilKit_Experimental_NetSim_CanConfigureBaudrate SilKit_Experiment
 
 typedef int32_t SilKit_Experimental_NetSim_CanControllerModeFlags;
 
+/*! Reset the error counters to zero and the error state to error active. */
 #define SilKit_Experimental_NetSim_CanControllerModeFlags_ResetErrorHandling \
-    ((SilKit_Experimental_NetSim_CanControllerModeFlags)BIT( \
-        0)) //!< Reset the error counters to zero and the error state to error active.
+    ((SilKit_Experimental_NetSim_CanControllerModeFlags)BIT(0)) 
 
+/*! Cancel all outstanding transmit requests (flush transmit queue of controller). */
 #define SilKit_Experimental_NetSim_CanControllerModeFlags_CancelTransmitRequests \
-    ((SilKit_Experimental_NetSim_CanControllerModeFlags)BIT( \
-        1)) //!< Cancel all outstanding transmit requests (flush transmit queue of controller).
+    ((SilKit_Experimental_NetSim_CanControllerModeFlags)BIT(1))
 
 struct SilKit_Experimental_NetSim_CanControllerMode
 {

--- a/docs/CMakeLists.txt
+++ b/docs/CMakeLists.txt
@@ -81,6 +81,9 @@ add_custom_command(OUTPUT ${DOXYGEN_INDEX_FILE}
                        ${SILKIT_API_HEADERS}
                        ${SPHINX_SOURCE_FILES}
                        ${SVG_FILES}
+                   # auto-upgrade the Doxyfile to the current configuration version
+                   COMMAND ${DOXYGEN_EXECUTABLE} -u ${DOXYFILE_OUT}
+                   # extract inline documentation from source code
                    COMMAND ${DOXYGEN_EXECUTABLE} ${DOXYFILE_OUT}
                    # generate docs
                    COMMAND "${Python3_EXECUTABLE}" -m sphinx.cmd.build

--- a/docs/CMakeLists.txt
+++ b/docs/CMakeLists.txt
@@ -20,10 +20,14 @@
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 
-Project(sil-kit-docs  NONE)
+project(sil-kit-docs NONE)
+
 include(SilKitVersion)
+
 configure_silkit_version(${PROJECT_NAME})
+
 find_package(Doxygen REQUIRED)
+find_package(Python3 COMPONENTS Interpreter)
 
 # Find all the public headers
 get_target_property(SILKIT_API_HEADERS SilKitApi SOURCES)
@@ -79,7 +83,8 @@ add_custom_command(OUTPUT ${DOXYGEN_INDEX_FILE}
                        ${SVG_FILES}
                    COMMAND ${DOXYGEN_EXECUTABLE} ${DOXYFILE_OUT}
                    # generate docs
-                   COMMAND sphinx-build -b html
+                   COMMAND "${Python3_EXECUTABLE}" -m sphinx.cmd.build
+                       -b html
                        # Tell Breathe where to find the Doxygen output
                        -Dbreathe_projects.SilKit=${DOXYGEN_OUTPUT_DIR}/xml
                        -Drelease=${PROJECT_VERSION}

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -43,7 +43,9 @@ master_doc = 'contents'
 extensions = [ 
     'sphinx_rtd_theme',
     'sphinx.ext.extlinks',
-    'breathe' ]
+    'breathe',
+    'myst_parser',
+]
 
 extlinks = {'repo-link': ('https://github.com/vectorgrp/sil-kit/tree/main/%s', '%s')}
 


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2023 Vector Informatik GmbH

SPDX-License-Identifier: MIT
-->

## Subject
<!--
    - What kind of changes does this pull request comprise?
    - Add a label like "Bugfix", "docs", etc. to this PR to give context.
 -->

- Add the `myst-parser` as a docs requirement (Markdown).
- Let CMake find the python interpreter used for building the HTML documentation. This should enable using virtual environments in the documentation build.
- Auto-upgrade the `Doxyfile` to support more modern `doxygen` versions
- Fix some documentation comments that are not supported by modern `doxygen` versions

## Developer checklist (address before review)

- [ ] Changelog.md updated
- [ ] Prepared update for depending repositories
- [ ] Documentation updated (public API changes only)
- [ ] API docstrings updated (public API changes only)
- [ ] Rebase &rarr; commit history clean
- [ ] Squash and merge &rarr; proper PR title
