### PR TITLE
hop-on: send current sim. task instead of next inside of sim. step

### DIFF
--- a/SilKit/source/services/orchestration/Test_TimeSyncService.cpp
+++ b/SilKit/source/services/orchestration/Test_TimeSyncService.cpp
@@ -51,21 +51,31 @@ using namespace SilKit::Util;
 using ::SilKit::Core::Tests::DummyParticipant;
 
 
+class MockParticipant : public DummyParticipant
+{
+public:
+    MOCK_METHOD(void, SendMsg,
+                (const SilKit::Core::IServiceEndpoint* from, const SilKit::Services::Orchestration::NextSimTask& msg),
+                (override));
+};
+
+
 class Test_TimeSyncService : public testing::Test
 {
-protected:
-    struct Callbacks
-    {
-        MOCK_METHOD(void, CommunicationReadyHandler, ());
-        MOCK_METHOD(void, StartingHandler, ());
-        MOCK_METHOD(void, StopHandler, ());
-        MOCK_METHOD(void, ShutdownHandler, ());
-        MOCK_METHOD(void, SimTask, (std::chrono::nanoseconds));
-    };
-
 protected: // CTor
     Test_TimeSyncService()
     {
+        ON_CALL(participant.mockServiceDiscovery, RegisterServiceDiscoveryHandler)
+            .WillByDefault([this](SilKit::Core::Discovery::ServiceDiscoveryHandler handler) {
+            serviceDiscoveryHandlers.emplace_back(std::move(handler));
+        });
+
+        ON_CALL(participant,
+                SendMsg(An<const SilKit::Core::IServiceEndpoint*>(), An<const Services::Orchestration::NextSimTask&>()))
+            .WillByDefault(
+                [this](const SilKit::Core::IServiceEndpoint* /* from */,
+                       const Services::Orchestration::NextSimTask& msg) { sentNextSimTasks.emplace_back(msg); });
+
         // this CTor calls CreateTimeSyncService implicitly
         lifecycleService = std::make_unique<LifecycleService>(&participant);
         lifecycleService->SetLifecycleConfiguration(LifecycleConfiguration{OperationMode::Coordinated});
@@ -96,9 +106,11 @@ protected:
     // Members
     NiceMock<MockServiceEndpoint> endpoint{"P1", "N1", "C1"};
 
-    NiceMock<DummyParticipant> participant;
-    Callbacks callbacks;
+    NiceMock<MockParticipant> participant;
     Config::HealthCheck healthCheckConfig;
+
+    std::vector<SilKit::Core::Discovery::ServiceDiscoveryHandler> serviceDiscoveryHandlers;
+    std::vector<SilKit::Services::Orchestration::NextSimTask> sentNextSimTasks;
 
     std::unique_ptr<LifecycleService> lifecycleService;
     TimeProvider timeProvider{};
@@ -159,6 +171,113 @@ TEST_F(Test_TimeSyncService, async_simtask_mismatching_number_of_complete_calls)
     timeSyncService->CompleteSimulationStep();
 
     ASSERT_EQ(numAsyncTaskCalled, 3) << "Calling too many CompleteSimulationStep() should not wreak havoc";
+}
+
+auto MakeTimeSyncServiceDescriptor() -> SilKit::Core::ServiceDescriptor
+{
+    SilKit::Core::ServiceDescriptor sd;
+    sd.SetServiceType(Core::ServiceType::InternalController);
+    sd.SetParticipantNameAndComputeId("Hopper");
+    sd.SetNetworkName("default");
+    sd.SetNetworkType(Config::NetworkType::Undefined);
+    sd.SetServiceName("XXX");
+    sd.SetServiceId(1234);
+    sd.SetSupplementalDataItem(SilKit::Core::Discovery::controllerType, "TimeSyncService");
+    sd.SetSupplementalDataItem(SilKit::Core::Discovery::timeSyncActive, "1");
+
+    return sd;
+}
+
+TEST_F(Test_TimeSyncService, hop_on_during_simulation_step)
+{
+    using SilKit::Core::Discovery::ServiceDiscoveryEvent;
+
+    ASSERT_EQ(serviceDiscoveryHandlers.size(), 1);
+
+    std::vector<std::chrono::nanoseconds> simulationStepNows;
+    timeSyncService->SetSimulationStepHandlerAsync([&simulationStepNows](auto now, auto) { simulationStepNows.emplace_back(now); }, 1ms);
+
+    PrepareLifecycle();
+
+    // After 'starting' the first (now == 0ns) NextSimTask message has been sent (which indicates that we're ready to
+    // execute the first step)
+    ASSERT_EQ(sentNextSimTasks.size(), 1);
+    ASSERT_EQ(sentNextSimTasks[0].timePoint, 0ms);
+    // The first simulation step is triggered by received NextSimTask message
+    ASSERT_EQ(simulationStepNows.size(), 0);
+
+    // Trigger the first simulation step
+    timeSyncService->ReceiveMsg(&endpoint, {0ms});
+    ASSERT_EQ(simulationStepNows.size(), 1);
+    ASSERT_EQ(simulationStepNows[0], 0ms);
+
+    // Complete the first simulation step
+    timeSyncService->CompleteSimulationStep();
+    // Completion triggers sending the next simulation step message
+    ASSERT_EQ(sentNextSimTasks.size(), 2);
+    ASSERT_EQ(sentNextSimTasks[1].timePoint, 1ms);
+
+    // Reception of the next simulation step message (from a remote peer) triggers the second simulation step
+    timeSyncService->ReceiveMsg(&endpoint, {1ms});
+    ASSERT_EQ(simulationStepNows.size(), 2);
+    ASSERT_EQ(simulationStepNows[1], 1ms);
+
+    // Trigger 'hop-on' which will cause an additional NextSimTask to be sent (with the 'current' timestamp)
+    serviceDiscoveryHandlers[0](ServiceDiscoveryEvent::Type::ServiceCreated, MakeTimeSyncServiceDescriptor());
+    ASSERT_EQ(sentNextSimTasks.size(), 3);
+    ASSERT_EQ(sentNextSimTasks[2].timePoint, 1ms);
+
+    // Complete the second simulation step
+    timeSyncService->CompleteSimulationStep();
+    // Completion triggers sending the next simulation step message
+    ASSERT_EQ(sentNextSimTasks.size(), 4);
+    ASSERT_EQ(sentNextSimTasks[3].timePoint, 2ms);
+}
+
+TEST_F(Test_TimeSyncService, hop_on_outside_simulation_step)
+{
+    using SilKit::Core::Discovery::ServiceDiscoveryEvent;
+
+    ASSERT_EQ(serviceDiscoveryHandlers.size(), 1);
+
+    std::vector<std::chrono::nanoseconds> simulationStepNows;
+    timeSyncService->SetSimulationStepHandlerAsync([&simulationStepNows](auto now, auto) { simulationStepNows.emplace_back(now); }, 1ms);
+
+    PrepareLifecycle();
+
+    // After 'starting' the first (now == 0ns) NextSimTask message has been sent (which indicates that we're ready to
+    // execute the first step)
+    ASSERT_EQ(sentNextSimTasks.size(), 1);
+    ASSERT_EQ(sentNextSimTasks[0].timePoint, 0ms);
+    // The first simulation step is triggered by received NextSimTask message
+    ASSERT_EQ(simulationStepNows.size(), 0);
+
+    // Trigger the first simulation step
+    timeSyncService->ReceiveMsg(&endpoint, {0ms});
+    ASSERT_EQ(simulationStepNows.size(), 1);
+    ASSERT_EQ(simulationStepNows[0], 0ms);
+
+    // Complete the first simulation step
+    timeSyncService->CompleteSimulationStep();
+    // Completion triggers sending the next simulation step message
+    ASSERT_EQ(sentNextSimTasks.size(), 2);
+    ASSERT_EQ(sentNextSimTasks[1].timePoint, 1ms);
+
+    // Reception of the next simulation step message (from a remote peer) triggers the second simulation step
+    timeSyncService->ReceiveMsg(&endpoint, {1ms});
+    ASSERT_EQ(simulationStepNows.size(), 2);
+    ASSERT_EQ(simulationStepNows[1], 1ms);
+
+    // Complete the second simulation step
+    timeSyncService->CompleteSimulationStep();
+    // Completion triggers sending the next simulation step message
+    ASSERT_EQ(sentNextSimTasks.size(), 3);
+    ASSERT_EQ(sentNextSimTasks[2].timePoint, 2ms);
+
+    // Trigger 'hop-on' which will cause an additional NextSimTask to be sent (with the 'next' timestamp)
+    serviceDiscoveryHandlers[0](ServiceDiscoveryEvent::Type::ServiceCreated, MakeTimeSyncServiceDescriptor());
+    ASSERT_EQ(sentNextSimTasks.size(), 4);
+    ASSERT_EQ(sentNextSimTasks[3].timePoint, 2ms);
 }
 
 } // namespace

--- a/SilKit/source/services/orchestration/TimeSyncService.cpp
+++ b/SilKit/source/services/orchestration/TimeSyncService.cpp
@@ -370,7 +370,17 @@ TimeSyncService::TimeSyncService(Core::IParticipantInternal* participant, ITimeP
                                   "Participant \'{}\' is joining an already running simulation. Resending our "
                                   "NextSimTask.",
                                   descriptorParticipantName);
-                            SendMsg(_timeConfiguration.NextSimStep());
+
+                            if (GetTimeSyncPolicy()->IsExecutingSimStep())
+                            {
+                                Debug(_participant->GetLogger(), "Sending currently executing simulation step");
+                                SendMsg(_timeConfiguration.CurrentSimStep());
+                            }
+                            else
+                            {
+                                Debug(_participant->GetLogger(), "Sending next simulation step");
+                                SendMsg(_timeConfiguration.NextSimStep());
+                            }
                         }
                     }
                     else if (discoveryEventType == Core::Discovery::ServiceDiscoveryEvent::Type::ServiceRemoved)


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2023 Vector Informatik GmbH

SPDX-License-Identifier: MIT
-->

## Subject
<!--
    - What kind of changes does this pull request comprise?
    - Add a label like "Bugfix", "docs", etc. to this PR to give context.
 -->

This change fixes an issue with hopping onto running time-synchronized simulations with a participant with an autonomous lifecycle.

The bug can cause a participant to release it's sim step 'early' and cause other participants to execute their next simulation step too early.

**TODO**:
 - [x] Rework the log messages

## Developer checklist (address before review)

- [ ] Changelog.md updated
- [ ] Prepared update for depending repositories
- [ ] Documentation updated (public API changes only)
- [ ] API docstrings updated (public API changes only)
- [ ] Rebase &rarr; commit history clean
- [ ] Squash and merge &rarr; proper PR title
