### PR TITLE
Heads-up: we are sunsetting distribution of Ubuntu 18.04 binary packages

### DIFF
--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -13,7 +13,8 @@ The format is based on `Keep a Changelog (http://keepachangelog.com/en/1.0.0/) <
 .. admonition:: Note: Support for Ubuntu 18.04 binary distribution packages is deprecated
 
    We are sunsetting the distribution of Ubuntu 18.04 packages with this release.
-   In the future, we will provide Ubuntu 24.04 binary distribution packages.
+   With the next release, we will provide Ubuntu 24.04 binary distribution packages instead.
+   
 
 Fixed
 ~~~~~

--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -10,11 +10,11 @@ The format is based on `Keep a Changelog (http://keepachangelog.com/en/1.0.0/) <
 [4.0.56] - UNRELEASED
 ---------------------
 
-.. admonition:: Note: Support for Ubuntu 18.04 binary distribution packages is deprecated
+.. admonition:: Note: the Ubuntu 18.04 binary distribution package is deprecated
 
    We are sunsetting the distribution of Ubuntu 18.04 packages with this release.
    With the next release, we will provide Ubuntu 24.04 binary distribution packages instead.
-   
+
 
 Fixed
 ~~~~~

--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -10,6 +10,11 @@ The format is based on `Keep a Changelog (http://keepachangelog.com/en/1.0.0/) <
 [4.0.56] - UNRELEASED
 ---------------------
 
+.. admonition:: Note: Support for Ubuntu 18.04 binary distribution packages is deprecated
+
+   We are sunsetting the distribution of Ubuntu 18.04 packages with this release.
+   In the future, we will provide Ubuntu 24.04 binary distribution packages.
+
 Fixed
 ~~~~~
 


### PR DESCRIPTION
Ubuntu 18.04 is EOL, and we should provide up-to-date Ubuntu binary packages.
