### PR TITLE
add metrics to dashboard

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -55,7 +55,7 @@
         },
         {
             "name": "x64-debug",
-            "inherits": ["windows-base", "mixin-dirs", "mixin-ninja"],
+            "inherits": ["windows-base", "mixin-dirs", "mixin-ninja", "mixin-werror"],
             "architecture": {
                 "value": "x64",
                 "strategy": "external"

--- a/SilKit/IntegrationTests/ITestFixture.hpp
+++ b/SilKit/IntegrationTests/ITestFixture.hpp
@@ -120,6 +120,7 @@ Experimental:
     CollectFromRemote: true
 )";
 
+    std::string _registryConfiguration = "";
 };
 
 } //namespace Tests

--- a/SilKit/IntegrationTests/ITestFixture.hpp
+++ b/SilKit/IntegrationTests/ITestFixture.hpp
@@ -88,27 +88,17 @@ protected:
 
 protected: // members
     std::string _dashboardUri;
-    const std::string _dashboardParticipantConfig = R"(
+    std::string _dashboardParticipantConfig = R"(
 Logging:
   Sinks:
   - Type: Stdout
     Level: Info
-Experimental:
-  Metrics:
-    Sinks:
-      - Name: Lala
-        Type: Remote
 )";
-    const std::string _participantConfig = R"(
+    std::string _participantConfig = R"(
 Logging:
   Sinks:
   - Type: Stdout
     Level: Info
-Experimental:
-  Metrics:
-    Sinks:
-      - Name: Lala
-        Type: Remote
 )";
     const std::string _registryParticipantConfig = R"(
 Logging:

--- a/SilKit/IntegrationTests/ITestFixture.hpp
+++ b/SilKit/IntegrationTests/ITestFixture.hpp
@@ -63,8 +63,6 @@ protected:
     ITest_DashboardTestHarness()
         : ITest_SimTestHarness()
         , _dashboardUri(MakeTestDashboardUri())
-        , _dashboardParticipantConfig(R"({"Logging": {"Sinks": [{"Type": "Stdout", "Level":"Info"}]}})")
-        , _participantConfig(R"({"Logging": {"Sinks": [{"Type": "Stdout", "Level":"Info"}]}})")
     {
     }
     ~ITest_DashboardTestHarness() {}
@@ -75,16 +73,53 @@ protected:
     {
         // create test harness with deferred participant and controller creation.
         // Will only create the SIL Kit Registry and tell the SystemController the participantNames
+        SimTestHarnessArgs args{};
+        args.syncParticipantNames = std::move(coordinatedParticipantNames);
+        args.asyncParticipantNames = std::move(autonomousParticipantNames);
+        args.registry.participantConfiguration = _registryParticipantConfig;
+        args.registry.listenUri = "silkit://localhost:0";
+        args.deferParticipantCreation = true;
+        args.deferSystemControllerCreation = true;
+
         _simTestHarness =
-            std::make_unique<SimTestHarness>(coordinatedParticipantNames, "silkit://localhost:0", true, true,
-                                                           autonomousParticipantNames);
+            std::make_unique<SimTestHarness>(args);
         _registryUri = _simTestHarness->GetRegistryUri();
     }
 
 protected: // members
     std::string _dashboardUri;
-    std::string _dashboardParticipantConfig;
-    std::string _participantConfig;
+    const std::string _dashboardParticipantConfig = R"(
+Logging:
+  Sinks:
+  - Type: Stdout
+    Level: Info
+Experimental:
+  Metrics:
+    Sinks:
+      - Name: Lala
+        Type: Remote
+)";
+    const std::string _participantConfig = R"(
+Logging:
+  Sinks:
+  - Type: Stdout
+    Level: Info
+Experimental:
+  Metrics:
+    Sinks:
+      - Name: Lala
+        Type: Remote
+)";
+    const std::string _registryParticipantConfig = R"(
+Logging:
+  Sinks:
+  - Type: Stdout
+    Level: Info
+Experimental:
+  Metrics:
+    CollectFromRemote: true
+)";
+
 };
 
 } //namespace Tests

--- a/SilKit/IntegrationTests/ITest_DashboardServerTimeout.cpp
+++ b/SilKit/IntegrationTests/ITest_DashboardServerTimeout.cpp
@@ -52,7 +52,7 @@ TEST_F(ITest_DashboardServerTimeout, dashboard_creationtimeout)
     const auto networkName = "CAN1";
     SetupFromParticipantLists({participantName}, {});
     auto testResult = SilKit::Dashboard::RunDashboardTest(
-        ParticipantConfigurationFromStringImpl(_dashboardParticipantConfig), _registryUri, _dashboardUri,
+        _dashboardParticipantConfig, _registryUri, _dashboardUri,
         [this, &participantName, &canonicalName, &networkName]() {
         _simTestHarness->CreateSystemController();
         auto&& simParticipant = _simTestHarness->GetParticipant(participantName, _participantConfig);
@@ -65,7 +65,8 @@ TEST_F(ITest_DashboardServerTimeout, dashboard_creationtimeout)
         auto ok = _simTestHarness->Run(5s);
         ASSERT_TRUE(ok) << "SimTestHarness should terminate without timeout";
         _simTestHarness->ResetParticipants();
-    }, 1, std::chrono::seconds{7}, std::chrono::seconds{0});
+        },
+        1, std::chrono::seconds{7}, std::chrono::seconds{0});
     ASSERT_FALSE(testResult.allSimulationsFinished) << "Simulation should not be finished!";
     _simTestHarness->ResetRegistry();
 }
@@ -77,7 +78,7 @@ TEST_F(ITest_DashboardServerTimeout, dashboard_updatetimeout)
     const auto networkName = "CAN1";
     SetupFromParticipantLists({participantName}, {});
     auto testResult = SilKit::Dashboard::RunDashboardTest(
-        ParticipantConfigurationFromStringImpl(_dashboardParticipantConfig), _registryUri, _dashboardUri,
+        _dashboardParticipantConfig, _registryUri, _dashboardUri,
         [this, &participantName, &canonicalName, &networkName]() {
         _simTestHarness->CreateSystemController();
         auto&& simParticipant = _simTestHarness->GetParticipant(participantName, _participantConfig);
@@ -90,7 +91,8 @@ TEST_F(ITest_DashboardServerTimeout, dashboard_updatetimeout)
         auto ok = _simTestHarness->Run(5s);
         ASSERT_TRUE(ok) << "SimTestHarness should terminate without timeout";
         _simTestHarness->ResetParticipants();
-    }, 1, std::chrono::seconds{0}, std::chrono::seconds{7});
+        },
+        1, std::chrono::seconds{0}, std::chrono::seconds{7});
     ASSERT_FALSE(testResult.allSimulationsFinished) << "Simulation should not be finished!";
     _simTestHarness->ResetRegistry();
 }

--- a/SilKit/IntegrationTests/SimTestHarness/SimTestHarness.hpp
+++ b/SilKit/IntegrationTests/SimTestHarness/SimTestHarness.hpp
@@ -133,6 +133,10 @@ public:
     SimParticipant* GetParticipant(const std::string& participantName, const std::string& participantConfiguration);
 
     auto GetRegistryUri() const -> std::string;
+    auto GetRegistry() const -> SilKit::Vendor::Vector::ISilKitRegistry*
+    {
+        return _registry.get();
+    }
 
     // clear everything and destroy participants:
     void Reset();

--- a/SilKit/source/CreateSilKitRegistryWithDashboard.cpp
+++ b/SilKit/source/CreateSilKitRegistryWithDashboard.cpp
@@ -14,9 +14,7 @@ auto CreateSilKitRegistryWithDashboard(std::shared_ptr<SilKit::Config::IParticip
                                        SilKit::Core::IRegistryEventListener* registryEventListener)
     -> std::unique_ptr<SilKit::Vendor::Vector::ISilKitRegistry>
 {
-    auto&& registry = std::make_unique<SilKit::Core::VAsioRegistry>(config); 
-    registry->SetRegistryEventListener(registryEventListener);
-    return registry;
+    return std::make_unique<SilKit::Core::VAsioRegistry>(config, registryEventListener);
 }
 
 

--- a/SilKit/source/CreateSilKitRegistryWithDashboard.cpp
+++ b/SilKit/source/CreateSilKitRegistryWithDashboard.cpp
@@ -14,7 +14,9 @@ auto CreateSilKitRegistryWithDashboard(std::shared_ptr<SilKit::Config::IParticip
                                        SilKit::Core::IRegistryEventListener* registryEventListener)
     -> std::unique_ptr<SilKit::Vendor::Vector::ISilKitRegistry>
 {
-    return std::make_unique<SilKit::Core::VAsioRegistry>(config, registryEventListener);
+    auto&& registry = std::make_unique<SilKit::Core::VAsioRegistry>(config); 
+    registry->SetRegistryEventListener(registryEventListener);
+    return registry;
 }
 
 

--- a/SilKit/source/config/ParticipantConfiguration.hpp
+++ b/SilKit/source/config/ParticipantConfiguration.hpp
@@ -278,6 +278,7 @@ struct Metrics
 {
     std::vector<MetricsSink> sinks;
     bool collectFromRemote{false};
+    std::chrono::seconds updateInterval{1};
 };
 
 // ================================================================================

--- a/SilKit/source/config/ParticipantConfigurationFromXImpl.cpp
+++ b/SilKit/source/config/ParticipantConfigurationFromXImpl.cpp
@@ -674,7 +674,6 @@ auto PaticipantConfigurationWithIncludes(const std::string& text, struct ConfigI
 
 
 } // anonymous namespace
-
 } // namespace V1
 
 // ============================================================================

--- a/SilKit/source/core/mock/participant/MockParticipant.hpp
+++ b/SilKit/source/core/mock/participant/MockParticipant.hpp
@@ -200,6 +200,13 @@ class DummyMetricsManager : public IMetricsManager
         void Add(const std::string&) override {}
     };
 
+    class DummyAttributeMetric : public IAttributeMetric
+    {
+    public:
+        void Clear() override {}
+        void Add(const std::string&) override {}
+    };
+
 public:
     auto GetCounter(const std::string& name) -> ICounterMetric* override
     {
@@ -231,12 +238,23 @@ public:
         return &(it->second);
     }
 
+    auto GetAttribute(const std::string& name) -> IAttributeMetric* override
+    {
+        auto it = _attributes.find(name);
+        if (it == _attributes.end())
+        {
+            it = _attributes.emplace().first;
+        }
+        return &(it->second);
+    }
+
     void SubmitUpdates() override {}
 
 private:
     std::unordered_map<std::string, DummyCounterMetric> _counters;
     std::unordered_map<std::string, DummyStatisticMetric> _statistics;
     std::unordered_map<std::string, DummyStringListMetric> _stringLists;
+    std::unordered_map<std::string, DummyAttributeMetric> _attributes;
 };
 
 class DummyParticipant : public IParticipantInternal

--- a/SilKit/source/core/mock/participant/MockParticipant.hpp
+++ b/SilKit/source/core/mock/participant/MockParticipant.hpp
@@ -62,6 +62,8 @@ namespace Core {
 namespace Tests {
 
 using SilKit::Util::HandlerId;
+using VSilKit::MetricName;
+using VSilKit::ToString;
 
 using SilKit::Services::Logging::MockLogger;
 
@@ -208,9 +210,9 @@ class DummyMetricsManager : public IMetricsManager
     };
 
 public:
-    auto GetCounter(const std::string& name) -> ICounterMetric* override
+    auto GetCounter(MetricName name) -> ICounterMetric* override
     {
-        auto it = _counters.find(name);
+        auto it = _counters.find(ToString(name));
         if (it == _counters.end())
         {
             it = _counters.emplace().first;
@@ -218,9 +220,9 @@ public:
         return &(it->second);
     }
 
-    auto GetStatistic(const std::string& name) -> IStatisticMetric* override
+    auto GetStatistic(MetricName name) -> IStatisticMetric* override
     {
-        auto it = _statistics.find(name);
+        auto it = _statistics.find(ToString(name));
         if (it == _statistics.end())
         {
             it = _statistics.emplace().first;
@@ -228,9 +230,9 @@ public:
         return &(it->second);
     }
 
-    auto GetStringList(const std::string& name) -> IStringListMetric* override
+    auto GetStringList(MetricName name) -> IStringListMetric* override
     {
-        auto it = _stringLists.find(name);
+        auto it = _stringLists.find(ToString(name));
         if (it == _stringLists.end())
         {
             it = _stringLists.emplace().first;
@@ -238,9 +240,9 @@ public:
         return &(it->second);
     }
 
-    auto GetAttribute(const std::string& name) -> IAttributeMetric* override
+    auto GetAttribute(MetricName name) -> IAttributeMetric* override
     {
-        auto it = _attributes.find(name);
+        auto it = _attributes.find(ToString(name));
         if (it == _attributes.end())
         {
             it = _attributes.emplace().first;

--- a/SilKit/source/core/participant/Participant.hpp
+++ b/SilKit/source/core/participant/Participant.hpp
@@ -435,7 +435,7 @@ private:
 
     auto GetOrCreateMetricsSender() -> VSilKit::IMetricsSender*;
 
-    void CreateSystemInformationMetrics();
+    void CreateParticipantAttributeMetrics();
 
     auto MakeTimerThread() -> std::unique_ptr<IMetricsTimerThread>;
 

--- a/SilKit/source/core/participant/Participant_impl.hpp
+++ b/SilKit/source/core/participant/Participant_impl.hpp
@@ -2024,7 +2024,8 @@ void Participant<SilKitConnectionT>::CreateParticipantAttributeMetrics()
         GetMetricsManager()->GetAttribute("SilKit/Process/Executable")->Add(ee.executable);
         GetMetricsManager()->GetAttribute("SilKit/Process/Username")->Add(ee.username);
     }
-    GetMetricsManager()->GetAttribute("SilKit/Participant/JsonConfig")->Add(R"({"TODO": true})");
+ 
+    GetMetricsManager()->GetAttribute("SilKit/Participant/JsonConfig")->Add(SilKit::Config::to_json(_participantConfig));
 }
 
 
@@ -2036,7 +2037,7 @@ auto Participant<SilKitConnectionT>::MakeTimerThread() -> std::unique_ptr<IMetri
         return nullptr;
     }
 
-    return std::make_unique<VSilKit::MetricsTimerThread>(
+    return std::make_unique<VSilKit::MetricsTimerThread>(_participantConfig.experimental.metrics.updateInterval,
         [this] { ExecuteDeferred([this] { GetMetricsManager()->SubmitUpdates(); }); });
 }
 

--- a/SilKit/source/core/participant/Participant_impl.hpp
+++ b/SilKit/source/core/participant/Participant_impl.hpp
@@ -167,7 +167,7 @@ void Participant<SilKitConnectionT>::OnSilKitSimulationJoined()
         _logger->Info("Replay Scheduler active.");
     }
 
-    CreateSystemInformationMetrics();
+    CreateParticipantAttributeMetrics();
 
     if (_metricsTimerThread)
     {
@@ -2010,18 +2010,21 @@ auto Participant<SilKitConnectionT>::GetOrCreateMetricsSender() -> VSilKit::IMet
 
 
 template <class SilKitConnectionT>
-void Participant<SilKitConnectionT>::CreateSystemInformationMetrics()
+void Participant<SilKitConnectionT>::CreateParticipantAttributeMetrics()
 {
-    auto ee = VSilKit::GetExecutionEnvironment();
+    {
+        auto ee = VSilKit::GetExecutionEnvironment();
 
-    GetMetricsManager()->GetStringList("SilKit/System/OperatingSystem")->Add(ee.operatingSystem);
-    GetMetricsManager()->GetStringList("SilKit/System/Hostname")->Add(ee.hostname);
-    GetMetricsManager()->GetStringList("SilKit/System/PageSize")->Add(ee.pageSize);
-    GetMetricsManager()->GetStringList("SilKit/System/ProcessorCount")->Add(ee.processorCount);
-    GetMetricsManager()->GetStringList("SilKit/System/ProcessorArchitecture")->Add(ee.processorArchitecture);
-    GetMetricsManager()->GetStringList("SilKit/System/PhysicalMemory")->Add(ee.physicalMemoryMiB + " MiB");
-    GetMetricsManager()->GetStringList("SilKit/Process/Executable")->Add(ee.executable);
-    GetMetricsManager()->GetStringList("SilKit/Process/Username")->Add(ee.username);
+        GetMetricsManager()->GetAttribute("SilKit/System/OperatingSystem")->Add(ee.operatingSystem);
+        GetMetricsManager()->GetAttribute("SilKit/System/Hostname")->Add(ee.hostname);
+        GetMetricsManager()->GetAttribute("SilKit/System/PageSize")->Add(ee.pageSize);
+        GetMetricsManager()->GetAttribute("SilKit/System/ProcessorCount")->Add(ee.processorCount);
+        GetMetricsManager()->GetAttribute("SilKit/System/ProcessorArchitecture")->Add(ee.processorArchitecture);
+        GetMetricsManager()->GetAttribute("SilKit/System/PhysicalMemory")->Add(ee.physicalMemoryMiB + " MiB");
+        GetMetricsManager()->GetAttribute("SilKit/Process/Executable")->Add(ee.executable);
+        GetMetricsManager()->GetAttribute("SilKit/Process/Username")->Add(ee.username);
+    }
+    GetMetricsManager()->GetAttribute("SilKit/Participant/JsonConfig")->Add(R"({"TODO": true})");
 }
 
 

--- a/SilKit/source/core/participant/Participant_impl.hpp
+++ b/SilKit/source/core/participant/Participant_impl.hpp
@@ -2040,7 +2040,10 @@ auto Participant<SilKitConnectionT>::MakeTimerThread() -> std::unique_ptr<IMetri
     }
 
     return std::make_unique<VSilKit::MetricsTimerThread>(_participantConfig.experimental.metrics.updateInterval,
-        [this] { ExecuteDeferred([this] { GetMetricsManager()->SubmitUpdates(); }); });
+        [this] { ExecuteDeferred([this] {
+            GetMetricsManager()->SubmitUpdates();
+            });
+        });
 }
 
 

--- a/SilKit/source/core/participant/Participant_impl.hpp
+++ b/SilKit/source/core/participant/Participant_impl.hpp
@@ -2015,17 +2015,19 @@ void Participant<SilKitConnectionT>::CreateParticipantAttributeMetrics()
     {
         auto ee = VSilKit::GetExecutionEnvironment();
 
-        GetMetricsManager()->GetAttribute("SilKit/System/OperatingSystem")->Add(ee.operatingSystem);
-        GetMetricsManager()->GetAttribute("SilKit/System/Hostname")->Add(ee.hostname);
-        GetMetricsManager()->GetAttribute("SilKit/System/PageSize")->Add(ee.pageSize);
-        GetMetricsManager()->GetAttribute("SilKit/System/ProcessorCount")->Add(ee.processorCount);
-        GetMetricsManager()->GetAttribute("SilKit/System/ProcessorArchitecture")->Add(ee.processorArchitecture);
-        GetMetricsManager()->GetAttribute("SilKit/System/PhysicalMemory")->Add(ee.physicalMemoryMiB + " MiB");
-        GetMetricsManager()->GetAttribute("SilKit/Process/Executable")->Add(ee.executable);
-        GetMetricsManager()->GetAttribute("SilKit/Process/Username")->Add(ee.username);
+        GetMetricsManager()->GetAttribute({"SilKit", "System", "OperatingSystem"})->Add(ee.operatingSystem);
+        GetMetricsManager()->GetAttribute({"SilKit", "System", "Hostname"})->Add(ee.hostname);
+        GetMetricsManager()->GetAttribute({"SilKit", "System", "PageSize"})->Add(ee.pageSize);
+        GetMetricsManager()->GetAttribute({"SilKit", "System", "ProcessorCount"})->Add(ee.processorCount);
+        GetMetricsManager()->GetAttribute({"SilKit", "System", "ProcessorArchitecture"})->Add(ee.processorArchitecture);
+        GetMetricsManager()->GetAttribute({"SilKit", "System", "PhysicalMemory"})->Add(ee.physicalMemoryMiB + " MiB");
+        GetMetricsManager()->GetAttribute({"SilKit", "Process", "Executable"})->Add(ee.executable);
+        GetMetricsManager()->GetAttribute({"SilKit", "Process", "Username"})->Add(ee.username);
     }
  
-    GetMetricsManager()->GetAttribute("SilKit/Participant/JsonConfig")->Add(SilKit::Config::to_json(_participantConfig));
+    GetMetricsManager()
+        ->GetAttribute({"SilKit", "Participant", "JsonConfig"})
+        ->Add(SilKit::Config::SerializeAsJson(_participantConfig));
 }
 
 

--- a/SilKit/source/core/vasio/CMakeLists.txt
+++ b/SilKit/source/core/vasio/CMakeLists.txt
@@ -107,7 +107,9 @@ add_library(O_SilKit_Core_VAsio OBJECT
     RingBuffer.hpp
     RingBuffer.cpp
 
+    IPeerMetrics.hpp
     PeerMetrics.hpp
+    PeerMetrics.cpp
 )
 
 target_link_libraries(O_SilKit_Core_VAsio

--- a/SilKit/source/core/vasio/CMakeLists.txt
+++ b/SilKit/source/core/vasio/CMakeLists.txt
@@ -106,6 +106,8 @@ add_library(O_SilKit_Core_VAsio OBJECT
 
     RingBuffer.hpp
     RingBuffer.cpp
+
+    PeerMetrics.hpp
 )
 
 target_link_libraries(O_SilKit_Core_VAsio
@@ -118,7 +120,6 @@ target_include_directories(O_SilKit_Core_VAsio
     PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}
     PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/io
 )
-
 
 if (SILKIT_BUILD_TESTS)
     add_library(I_SilKit_Core_VAsio_Testing INTERFACE

--- a/SilKit/source/core/vasio/CMakeLists.txt
+++ b/SilKit/source/core/vasio/CMakeLists.txt
@@ -169,7 +169,7 @@ add_silkit_test_to_executable(SilKitUnitTests SOURCES io/Test_AsioIoContext.cpp 
 add_silkit_test_to_executable(SilKitUnitTests SOURCES io/util/Test_TracingMacrosDetails.cpp LIBS S_SilKitImpl)
 
 add_silkit_test_to_executable(SilKitUnitTests SOURCES Test_ConnectPeer.cpp LIBS S_SilKitImpl I_SilKit_Services_Logging_Testing I_SilKit_Core_VAsio_Testing)
-add_silkit_test_to_executable(SilKitUnitTests SOURCES Test_ConnectKnownParticipants.cpp LIBS S_SilKitImpl I_SilKit_Services_Logging_Testing I_SilKit_Core_VAsio_Testing)
+add_silkit_test_to_executable(SilKitUnitTests SOURCES Test_ConnectKnownParticipants.cpp LIBS S_SilKitImpl I_SilKit_Services_Logging_Testing I_SilKit_Core_VAsio_Testing I_SilKit_Core_VAsio_Testing)
 
 # Testing interoperability between different protocol versions requires testing on a higher level:
 # We instantiate a complete Participant<VAsioConnection> with a specific version

--- a/SilKit/source/core/vasio/IPeerMetrics.hpp
+++ b/SilKit/source/core/vasio/IPeerMetrics.hpp
@@ -1,0 +1,22 @@
+#pragma once
+
+#include <string>
+
+#include "IMetricsManager.hpp"
+#include "IVAsioPeer.hpp"
+#include "SerializedMessage.hpp"
+
+namespace VSilKit {
+
+struct IPeerMetrics
+{
+    virtual ~IPeerMetrics() = default;
+    virtual void InitializeMetrics(const std::string& localParticipantName, VSilKit::IMetricsManager* manager,
+                                   SilKit::Core::IVAsioPeer* peer) = 0;
+    virtual void RxPacket() = 0;
+    virtual void TxPacket() = 0;
+    virtual void RxBytes(const SilKit::Core::SerializedMessage&) = 0;
+    virtual void TxBytes(const SilKit::Core::SerializedMessage&) = 0;
+};
+
+} // namespace VSilKit

--- a/SilKit/source/core/vasio/IPeerMetrics.hpp
+++ b/SilKit/source/core/vasio/IPeerMetrics.hpp
@@ -14,7 +14,7 @@ namespace VSilKit {
 struct IPeerMetrics
 {
     virtual ~IPeerMetrics() = default;
-    virtual void InitializeMetrics(const std::string& localParticipantName, VSilKit::IMetricsManager* manager,
+    virtual void InitializeMetrics(VSilKit::IMetricsManager* manager,
                                    SilKit::Core::IVAsioPeer* peer) = 0;
     virtual void RxPacket() = 0;
     virtual void TxPacket() = 0;

--- a/SilKit/source/core/vasio/IPeerMetrics.hpp
+++ b/SilKit/source/core/vasio/IPeerMetrics.hpp
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2025 Vector Informatik GmbH
+// SPDX-License-Identifier: MIT
+
 #pragma once
 
 #include <string>

--- a/SilKit/source/core/vasio/IPeerMetrics.hpp
+++ b/SilKit/source/core/vasio/IPeerMetrics.hpp
@@ -20,6 +20,7 @@ struct IPeerMetrics
     virtual void TxPacket() = 0;
     virtual void RxBytes(const SilKit::Core::SerializedMessage&) = 0;
     virtual void TxBytes(const SilKit::Core::SerializedMessage&) = 0;
+    virtual void TxQueueSize(size_t) = 0;
 };
 
 } // namespace VSilKit

--- a/SilKit/source/core/vasio/IVAsioPeer.hpp
+++ b/SilKit/source/core/vasio/IVAsioPeer.hpp
@@ -65,7 +65,7 @@ public:
 
     virtual void EnableAggregation() = 0;
 
-    virtual void InitializeMetrics(const std::string& localParticipantName, VSilKit::IMetricsManager*) = 0;
+    virtual void InitializeMetrics( VSilKit::IMetricsManager*) = 0;
 };
 
 

--- a/SilKit/source/core/vasio/IVAsioPeer.hpp
+++ b/SilKit/source/core/vasio/IVAsioPeer.hpp
@@ -30,6 +30,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE. */
 #include "VAsioProtocolVersion.hpp"
 
 #include "SerializedMessage.hpp"
+#include "IMetricsManager.hpp"
 
 namespace SilKit {
 namespace Core {
@@ -63,6 +64,8 @@ public:
     virtual auto GetProtocolVersion() const -> ProtocolVersion = 0;
 
     virtual void EnableAggregation() = 0;
+
+    virtual void InitializeMetrics(const std::string& localParticipantName, VSilKit::IMetricsManager*) = 0;
 };
 
 

--- a/SilKit/source/core/vasio/PeerMetrics.cpp
+++ b/SilKit/source/core/vasio/PeerMetrics.cpp
@@ -6,7 +6,7 @@
 
 namespace VSilKit
 {
-void NoMetrics::InitializeMetrics(const std::string&, VSilKit::IMetricsManager*, SilKit::Core::IVAsioPeer*)
+void NoMetrics::InitializeMetrics(VSilKit::IMetricsManager*, SilKit::Core::IVAsioPeer*)
 {
     // no op
 }
@@ -39,7 +39,7 @@ void NoMetrics::TxQueueSize(size_t)
 
 // PeerMetrics
 
-void PeerMetrics::InitializeMetrics(const std::string& localParticipantName, VSilKit::IMetricsManager* manager,
+void PeerMetrics::InitializeMetrics(VSilKit::IMetricsManager* manager,
                                     SilKit::Core::IVAsioPeer* peer)
 {
     if(_initialized)
@@ -50,11 +50,11 @@ void PeerMetrics::InitializeMetrics(const std::string& localParticipantName, VSi
     auto&& remoteParticipant = peer->GetServiceDescriptor().GetParticipantName();
     auto&& simulationName = peer->GetSimulationName();
 
-    _txBytes = manager->GetCounter({"Peer", simulationName, localParticipantName, remoteParticipant, "tx_bytes"});
-    _txPackets = manager->GetCounter({"Peer", simulationName, localParticipantName, remoteParticipant, "tx_packets"});
-    _rxBytes = manager->GetCounter({"Peer", simulationName, localParticipantName, remoteParticipant, "rx_bytes"});
-    _rxPackets = manager->GetCounter({"Peer", simulationName, localParticipantName, remoteParticipant, "rx_packets"});
-    _txQueueSize = manager->GetCounter({"Peer", simulationName, localParticipantName, remoteParticipant, "tx_queue_size"});
+    _txBytes = manager->GetCounter({"Peer", simulationName, remoteParticipant, "tx_bytes"});
+    _txPackets = manager->GetCounter({"Peer", simulationName, remoteParticipant, "tx_packets"});
+    _rxBytes = manager->GetCounter({"Peer", simulationName, remoteParticipant, "rx_bytes"});
+    _rxPackets = manager->GetCounter({"Peer", simulationName, remoteParticipant, "rx_packets"});
+    _txQueueSize = manager->GetCounter({"Peer", simulationName, remoteParticipant, "tx_queue_size"});
 
     _initialized = true;
 }

--- a/SilKit/source/core/vasio/PeerMetrics.cpp
+++ b/SilKit/source/core/vasio/PeerMetrics.cpp
@@ -42,6 +42,11 @@ void NoMetrics::TxQueueSize(size_t)
 void PeerMetrics::InitializeMetrics(const std::string& localParticipantName, VSilKit::IMetricsManager* manager,
                                     SilKit::Core::IVAsioPeer* peer)
 {
+    if(_initialized)
+    {
+        return;
+    }
+
     auto&& remoteParticipant = peer->GetServiceDescriptor().GetParticipantName();
     auto&& simulationName = peer->GetSimulationName();
 

--- a/SilKit/source/core/vasio/PeerMetrics.cpp
+++ b/SilKit/source/core/vasio/PeerMetrics.cpp
@@ -38,12 +38,12 @@ void PeerMetrics::InitializeMetrics(const std::string& localParticipantName, VSi
 {
     auto&& remoteParticipant = peer->GetServiceDescriptor().GetParticipantName();
     auto&& simulationName = peer->GetSimulationName();
-    auto&& prefix = "Peer/" + simulationName + "/" + localParticipantName + "/" + remoteParticipant;
+    MetricName prefix{"Peer", simulationName, localParticipantName, remoteParticipant};
 
-    _txBytes = manager->GetCounter(prefix + "/tx_bytes");
-    _txPackets = manager->GetCounter(prefix + "/tx_packets");
-    _rxBytes = manager->GetCounter(prefix + "/rx_bytes");
-    _rxPackets = manager->GetCounter(prefix + "/rx_packets");
+    _txBytes = manager->GetCounter({"Peer", simulationName, localParticipantName, remoteParticipant, "tx_bytes"});
+    _txPackets = manager->GetCounter({"Peer", simulationName, localParticipantName, remoteParticipant, "tx_packets"});
+    _rxBytes = manager->GetCounter({"Peer", simulationName, localParticipantName, remoteParticipant, "rx_bytes"});
+    _rxPackets = manager->GetCounter({"Peer", simulationName, localParticipantName, remoteParticipant, "rx_packets"});
 
     _initialized = true;
 }

--- a/SilKit/source/core/vasio/PeerMetrics.cpp
+++ b/SilKit/source/core/vasio/PeerMetrics.cpp
@@ -44,7 +44,6 @@ void PeerMetrics::InitializeMetrics(const std::string& localParticipantName, VSi
 {
     auto&& remoteParticipant = peer->GetServiceDescriptor().GetParticipantName();
     auto&& simulationName = peer->GetSimulationName();
-    MetricName prefix{"Peer", simulationName, localParticipantName, remoteParticipant};
 
     _txBytes = manager->GetCounter({"Peer", simulationName, localParticipantName, remoteParticipant, "tx_bytes"});
     _txPackets = manager->GetCounter({"Peer", simulationName, localParticipantName, remoteParticipant, "tx_packets"});

--- a/SilKit/source/core/vasio/PeerMetrics.cpp
+++ b/SilKit/source/core/vasio/PeerMetrics.cpp
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2025 Vector Informatik GmbH
+// SPDX-License-Identifier: MIT
+
 #include "PeerMetrics.hpp"
 
 

--- a/SilKit/source/core/vasio/PeerMetrics.cpp
+++ b/SilKit/source/core/vasio/PeerMetrics.cpp
@@ -1,0 +1,84 @@
+#include "PeerMetrics.hpp"
+
+
+namespace VSilKit
+{
+void NoMetrics::InitializeMetrics(const std::string&, VSilKit::IMetricsManager*, SilKit::Core::IVAsioPeer*)
+{
+    // no op
+}
+
+void NoMetrics::RxPacket()
+{
+    // no op
+}
+
+void NoMetrics::TxPacket()
+{
+    // no op
+}
+
+void NoMetrics::RxBytes(const SilKit::Core::SerializedMessage&)
+{
+    // no op
+}
+
+void NoMetrics::TxBytes(const SilKit::Core::SerializedMessage&)
+{
+    // no op
+}
+
+// PeerMetrics
+
+void PeerMetrics::InitializeMetrics(const std::string& localParticipantName, VSilKit::IMetricsManager* manager,
+                                    SilKit::Core::IVAsioPeer* peer)
+{
+    auto&& remoteParticipant = peer->GetServiceDescriptor().GetParticipantName();
+    auto&& simulationName = peer->GetSimulationName();
+    auto&& prefix = "Peer/" + simulationName + "/" + localParticipantName + "/" + remoteParticipant;
+
+    _txBytes = manager->GetCounter(prefix + "/tx_bytes");
+    _txPackets = manager->GetCounter(prefix + "/tx_packets");
+    _rxBytes = manager->GetCounter(prefix + "/rx_bytes");
+    _rxPackets = manager->GetCounter(prefix + "/rx_packets");
+
+    _initialized = true;
+}
+
+void PeerMetrics::RxPacket()
+{
+    if (!_initialized)
+    {
+        return;
+    }
+    _rxPackets->Add(1);
+}
+
+void PeerMetrics::TxPacket()
+{
+    if (!_initialized)
+    {
+        return;
+    }
+    _txPackets->Add(1);
+}
+
+void PeerMetrics::RxBytes(const SilKit::Core::SerializedMessage& msg)
+{
+    if (!_initialized)
+    {
+        return;
+    }
+    _rxBytes->Add(msg.GetStorageSize());
+}
+
+void PeerMetrics::TxBytes(const SilKit::Core::SerializedMessage& msg)
+{
+    if (!_initialized)
+    {
+        return;
+    }
+    _txBytes->Add(msg.GetStorageSize());
+}
+
+}

--- a/SilKit/source/core/vasio/PeerMetrics.cpp
+++ b/SilKit/source/core/vasio/PeerMetrics.cpp
@@ -31,6 +31,12 @@ void NoMetrics::TxBytes(const SilKit::Core::SerializedMessage&)
     // no op
 }
 
+void NoMetrics::TxQueueSize(size_t)
+{
+    // no op
+}
+
+
 // PeerMetrics
 
 void PeerMetrics::InitializeMetrics(const std::string& localParticipantName, VSilKit::IMetricsManager* manager,
@@ -44,6 +50,7 @@ void PeerMetrics::InitializeMetrics(const std::string& localParticipantName, VSi
     _txPackets = manager->GetCounter({"Peer", simulationName, localParticipantName, remoteParticipant, "tx_packets"});
     _rxBytes = manager->GetCounter({"Peer", simulationName, localParticipantName, remoteParticipant, "rx_bytes"});
     _rxPackets = manager->GetCounter({"Peer", simulationName, localParticipantName, remoteParticipant, "rx_packets"});
+    _txQueueSize = manager->GetCounter({"Peer", simulationName, localParticipantName, remoteParticipant, "tx_queue_size"});
 
     _initialized = true;
 }
@@ -83,5 +90,15 @@ void PeerMetrics::TxBytes(const SilKit::Core::SerializedMessage& msg)
     }
     _txBytes->Add(msg.GetStorageSize());
 }
+
+void PeerMetrics::TxQueueSize(size_t queueSize)
+{
+    if (!_initialized)
+    {
+        return;
+    }
+    _txQueueSize->Add(queueSize);
+}
+
 
 }

--- a/SilKit/source/core/vasio/PeerMetrics.hpp
+++ b/SilKit/source/core/vasio/PeerMetrics.hpp
@@ -14,7 +14,7 @@ namespace VSilKit {
 class NoMetrics final : public IPeerMetrics
 {
 public:
-    void InitializeMetrics(const std::string&, VSilKit::IMetricsManager* , SilKit::Core::IVAsioPeer* ) override;
+    void InitializeMetrics(VSilKit::IMetricsManager*, SilKit::Core::IVAsioPeer*) override;
     void RxPacket() override;
     void TxPacket() override;
     void RxBytes(const SilKit::Core::SerializedMessage& ) override;
@@ -35,7 +35,7 @@ private:
     VSilKit::ICounterMetric* _txQueueSize{nullptr};
 
 public:
-    void InitializeMetrics(const std::string& localParticipantName, VSilKit::IMetricsManager* manager,
+    void InitializeMetrics(VSilKit::IMetricsManager* manager,
                            SilKit::Core::IVAsioPeer* peer) override;
     void RxPacket() override;
     void TxPacket() override;

--- a/SilKit/source/core/vasio/PeerMetrics.hpp
+++ b/SilKit/source/core/vasio/PeerMetrics.hpp
@@ -19,6 +19,7 @@ public:
     void TxPacket() override;
     void RxBytes(const SilKit::Core::SerializedMessage& ) override;
     void TxBytes(const SilKit::Core::SerializedMessage&) override;
+    void TxQueueSize(size_t) override;
 };
 
 
@@ -31,6 +32,7 @@ private:
     VSilKit::ICounterMetric* _txPackets{nullptr};
     VSilKit::ICounterMetric* _rxBytes{nullptr};
     VSilKit::ICounterMetric* _txBytes{nullptr};
+    VSilKit::ICounterMetric* _txQueueSize{nullptr};
 
 public:
     void InitializeMetrics(const std::string& localParticipantName, VSilKit::IMetricsManager* manager,
@@ -39,6 +41,7 @@ public:
     void TxPacket() override;
     void RxBytes(const SilKit::Core::SerializedMessage& msg) override;
     void TxBytes(const SilKit::Core::SerializedMessage& msg) override;
+    void TxQueueSize(size_t queueSize) override;
 };
 
 } // namespace VSilKit

--- a/SilKit/source/core/vasio/PeerMetrics.hpp
+++ b/SilKit/source/core/vasio/PeerMetrics.hpp
@@ -1,0 +1,115 @@
+// SPDX-FileCopyrightText: 2025 Vector Informatik GmbH
+// SPDX-License-Identifier: MIT
+
+#pragma once
+
+#include "IMetricsManager.hpp"
+#include "ICounterMetric.hpp"
+#include "IVAsioPeer.hpp"
+#include "SerializedMessage.hpp"
+
+namespace VSilKit
+{
+
+struct IPeerMetrics
+{
+    virtual ~IPeerMetrics() = default;
+    virtual void InitializeMetrics(const std::string& localParticipantName, VSilKit::IMetricsManager* manager,
+                                   SilKit::Core::IVAsioPeer* peer) = 0;
+    virtual void RxPacket() = 0;
+    virtual void TxPacket() = 0;
+    virtual void RxBytes(const SilKit::Core::SerializedMessage&) = 0;
+    virtual void TxBytes(const SilKit::Core::SerializedMessage&) = 0;
+};
+
+//disable metrics collection 
+class NoMetrics final : public IPeerMetrics
+{
+public:
+    void InitializeMetrics(const std::string&, VSilKit::IMetricsManager* , SilKit::Core::IVAsioPeer* ) override
+    {
+        // no op
+    }
+
+    void RxPacket() override
+    {
+        // no op
+    }
+
+    void TxPacket() override
+    {
+        // no op
+    }
+    void RxBytes(const SilKit::Core::SerializedMessage& ) override
+    {
+        // no op
+    }
+    void TxBytes(const SilKit::Core::SerializedMessage&) override
+    {
+        // no op
+    }
+};
+
+
+// Metric collection for Rx/Tx paths
+class PeerMetrics final : public IPeerMetrics
+{
+private:
+    bool _initialized{false};
+    VSilKit::ICounterMetric* _rxPackets{nullptr};
+    VSilKit::ICounterMetric* _txPackets{nullptr};
+    VSilKit::ICounterMetric* _rxBytes{nullptr};
+    VSilKit::ICounterMetric* _txBytes{nullptr};
+
+public:
+    void InitializeMetrics(const std::string& localParticipantName, VSilKit::IMetricsManager* manager,
+                           SilKit::Core::IVAsioPeer* peer) override
+    {
+        auto&& remoteParticipant = peer->GetServiceDescriptor().GetParticipantName();
+        auto&& simulationName = peer->GetSimulationName();
+        auto&& prefix = "Peer/" + simulationName + "/" + localParticipantName + "/" + remoteParticipant;
+
+        _txBytes = manager->GetCounter(prefix + "/tx_bytes");
+        _txPackets = manager->GetCounter(prefix + "/tx_packets");
+        _rxBytes = manager->GetCounter(prefix + "/rx_bytes");
+        _rxPackets = manager->GetCounter(prefix + "/rx_packets");
+
+        _initialized = true;
+    }
+
+    void RxPacket() override
+    {
+        if (!_initialized)
+        {
+            return;
+        }
+        _rxPackets->Add(1);
+    }
+
+    void TxPacket() override
+    {
+        if (!_initialized)
+        {
+            return;
+        }
+        _txPackets->Add(1);
+    }
+    void RxBytes(const SilKit::Core::SerializedMessage& msg) override
+    {
+        if (!_initialized)
+        {
+            return;
+        }
+        _rxBytes->Add(msg.GetStorageSize());
+    }
+    void TxBytes(const SilKit::Core::SerializedMessage& msg) override
+    {
+        if (!_initialized)
+        {
+            return;
+        }
+        _txBytes->Add(msg.GetStorageSize());
+    }
+};
+
+} // namespace VSilKit

--- a/SilKit/source/core/vasio/PeerMetrics.hpp
+++ b/SilKit/source/core/vasio/PeerMetrics.hpp
@@ -3,51 +3,22 @@
 
 #pragma once
 
-#include "IMetricsManager.hpp"
+#include "IPeerMetrics.hpp"
 #include "ICounterMetric.hpp"
 #include "IVAsioPeer.hpp"
 #include "SerializedMessage.hpp"
 
-namespace VSilKit
-{
+namespace VSilKit {
 
-struct IPeerMetrics
-{
-    virtual ~IPeerMetrics() = default;
-    virtual void InitializeMetrics(const std::string& localParticipantName, VSilKit::IMetricsManager* manager,
-                                   SilKit::Core::IVAsioPeer* peer) = 0;
-    virtual void RxPacket() = 0;
-    virtual void TxPacket() = 0;
-    virtual void RxBytes(const SilKit::Core::SerializedMessage&) = 0;
-    virtual void TxBytes(const SilKit::Core::SerializedMessage&) = 0;
-};
-
-//disable metrics collection 
+// Used to disable metrics collection:
 class NoMetrics final : public IPeerMetrics
 {
 public:
-    void InitializeMetrics(const std::string&, VSilKit::IMetricsManager* , SilKit::Core::IVAsioPeer* ) override
-    {
-        // no op
-    }
-
-    void RxPacket() override
-    {
-        // no op
-    }
-
-    void TxPacket() override
-    {
-        // no op
-    }
-    void RxBytes(const SilKit::Core::SerializedMessage& ) override
-    {
-        // no op
-    }
-    void TxBytes(const SilKit::Core::SerializedMessage&) override
-    {
-        // no op
-    }
+    void InitializeMetrics(const std::string&, VSilKit::IMetricsManager* , SilKit::Core::IVAsioPeer* ) override;
+    void RxPacket() override;
+    void TxPacket() override;
+    void RxBytes(const SilKit::Core::SerializedMessage& ) override;
+    void TxBytes(const SilKit::Core::SerializedMessage&) override;
 };
 
 
@@ -63,53 +34,11 @@ private:
 
 public:
     void InitializeMetrics(const std::string& localParticipantName, VSilKit::IMetricsManager* manager,
-                           SilKit::Core::IVAsioPeer* peer) override
-    {
-        auto&& remoteParticipant = peer->GetServiceDescriptor().GetParticipantName();
-        auto&& simulationName = peer->GetSimulationName();
-        auto&& prefix = "Peer/" + simulationName + "/" + localParticipantName + "/" + remoteParticipant;
-
-        _txBytes = manager->GetCounter(prefix + "/tx_bytes");
-        _txPackets = manager->GetCounter(prefix + "/tx_packets");
-        _rxBytes = manager->GetCounter(prefix + "/rx_bytes");
-        _rxPackets = manager->GetCounter(prefix + "/rx_packets");
-
-        _initialized = true;
-    }
-
-    void RxPacket() override
-    {
-        if (!_initialized)
-        {
-            return;
-        }
-        _rxPackets->Add(1);
-    }
-
-    void TxPacket() override
-    {
-        if (!_initialized)
-        {
-            return;
-        }
-        _txPackets->Add(1);
-    }
-    void RxBytes(const SilKit::Core::SerializedMessage& msg) override
-    {
-        if (!_initialized)
-        {
-            return;
-        }
-        _rxBytes->Add(msg.GetStorageSize());
-    }
-    void TxBytes(const SilKit::Core::SerializedMessage& msg) override
-    {
-        if (!_initialized)
-        {
-            return;
-        }
-        _txBytes->Add(msg.GetStorageSize());
-    }
+                           SilKit::Core::IVAsioPeer* peer) override;
+    void RxPacket() override;
+    void TxPacket() override;
+    void RxBytes(const SilKit::Core::SerializedMessage& msg) override;
+    void TxBytes(const SilKit::Core::SerializedMessage& msg) override;
 };
 
 } // namespace VSilKit

--- a/SilKit/source/core/vasio/SerializedMessage.hpp
+++ b/SilKit/source/core/vasio/SerializedMessage.hpp
@@ -105,6 +105,11 @@ public: // Receiving a SerializedMessage: from binary blob to SilKitMessage<T>
 
     void SetAggregationKind(MessageAggregationKind msgAggregationKind);
 
+    auto GetStorageSize() const -> size_t
+    {
+        return _buffer.PeekData().size();
+    }
+
 private:
     void WriteNetworkHeaders();
     void ReadNetworkHeaders();

--- a/SilKit/source/core/vasio/Test_TransformAcceptorUris.cpp
+++ b/SilKit/source/core/vasio/Test_TransformAcceptorUris.cpp
@@ -195,7 +195,7 @@ struct DummyVAsioPeerBase : IVAsioPeer
         throw MethodNotImplementedError{};
     }
 
-    void InitializeMetrics(const std::string&, VSilKit::IMetricsManager*) override
+    void InitializeMetrics(VSilKit::IMetricsManager*) override
     {
         throw MethodNotImplementedError{};
     }

--- a/SilKit/source/core/vasio/Test_TransformAcceptorUris.cpp
+++ b/SilKit/source/core/vasio/Test_TransformAcceptorUris.cpp
@@ -194,6 +194,11 @@ struct DummyVAsioPeerBase : IVAsioPeer
     {
         throw MethodNotImplementedError{};
     }
+
+    void InitializeMetrics(const std::string&, VSilKit::IMetricsManager*) override
+    {
+        throw MethodNotImplementedError{};
+    }
 };
 
 struct AdvertisedVAsioPeer final : DummyVAsioPeerBase

--- a/SilKit/source/core/vasio/Test_VAsioConnection.cpp
+++ b/SilKit/source/core/vasio/Test_VAsioConnection.cpp
@@ -138,6 +138,7 @@ struct MockVAsioPeer : public IVAsioPeer
     MOCK_METHOD(ProtocolVersion, GetProtocolVersion, (), (const, override));
     MOCK_METHOD(void, Shutdown, (), (override));
     MOCK_METHOD(void, EnableAggregation, (), (override));
+    MOCK_METHOD(void, InitializeMetrics, (const std::string&, IMetricsManager*), (override));
 
     // IServiceEndpoint (via IVAsioPeer)
     MOCK_METHOD(void, SetServiceDescriptor, (const ServiceDescriptor& serviceDescriptor), (override));

--- a/SilKit/source/core/vasio/Test_VAsioConnection.cpp
+++ b/SilKit/source/core/vasio/Test_VAsioConnection.cpp
@@ -59,6 +59,8 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE. */
 
 #include <chrono>
 
+#include "MockVAsioPeer.hpp"
+
 #include "gtest/gtest.h"
 #include "gmock/gmock.h"
 
@@ -98,14 +100,15 @@ struct MockSilKitMessageReceiver
 };
 
 
-struct MockVAsioPeer : public IVAsioPeer
+// adds some more behavior to MockVasioPeer
+struct MockVAsioPeer2 : public MockVAsioPeer
 {
     VAsioPeerInfo _peerInfo;
     ServiceDescriptor _serviceDescriptor;
     ProtocolVersion _protocolVersion;
     std::string _simulationName;
 
-    MockVAsioPeer()
+    MockVAsioPeer2()
     {
         _peerInfo.participantId = 1234;
         _peerInfo.participantName = "MockVAsioPeer";
@@ -123,26 +126,6 @@ struct MockVAsioPeer : public IVAsioPeer
         ON_CALL(*this, GetServiceDescriptor()).WillByDefault(ReturnRef(_serviceDescriptor));
         ON_CALL(*this, GetProtocolVersion()).WillByDefault(Return(_protocolVersion));
     }
-
-    // IVAsioPeer
-    MOCK_METHOD(void, SendSilKitMsg, (SerializedMessage), (override));
-    MOCK_METHOD(void, Subscribe, (VAsioMsgSubscriber), (override));
-    MOCK_METHOD(const VAsioPeerInfo&, GetInfo, (), (const, override));
-    MOCK_METHOD(void, SetInfo, (VAsioPeerInfo), (override));
-    MOCK_METHOD(std::string, GetRemoteAddress, (), (const, override));
-    MOCK_METHOD(std::string, GetLocalAddress, (), (const, override));
-    MOCK_METHOD(void, SetSimulationName, (const std::string&), (override));
-    MOCK_METHOD(const std::string&, GetSimulationName, (), (const, override));
-    MOCK_METHOD(void, StartAsyncRead, (), (override));
-    MOCK_METHOD(void, SetProtocolVersion, (ProtocolVersion), (override));
-    MOCK_METHOD(ProtocolVersion, GetProtocolVersion, (), (const, override));
-    MOCK_METHOD(void, Shutdown, (), (override));
-    MOCK_METHOD(void, EnableAggregation, (), (override));
-    MOCK_METHOD(void, InitializeMetrics, (const std::string&, IMetricsManager*), (override));
-
-    // IServiceEndpoint (via IVAsioPeer)
-    MOCK_METHOD(void, SetServiceDescriptor, (const ServiceDescriptor& serviceDescriptor), (override));
-    MOCK_METHOD(const ServiceDescriptor&, GetServiceDescriptor, (), (override, const));
 };
 
 //////////////////////////////////////////////////////////////////////
@@ -186,7 +169,7 @@ protected:
     Tests::DummyMetricsManager _dummyMetricsManager;
     Services::Orchestration::TimeProvider _timeProvider;
     VAsioConnection _connection;
-    MockVAsioPeer _from;
+    MockVAsioPeer2 _from;
 
     //we are a friend class
     // - allow selected access to private member

--- a/SilKit/source/core/vasio/VAsioConnection.cpp
+++ b/SilKit/source/core/vasio/VAsioConnection.cpp
@@ -1848,12 +1848,12 @@ auto VAsioConnection::MakeVAsioPeer(std::unique_ptr<IRawByteStream> stream) -> s
     if(_config.experimental.metrics.sinks.empty())
     {
         return std::make_unique<VAsioPeer>(this, _ioContext.get(), std::move(stream), _logger,
-                                           std::move(std::make_unique<VSilKit::NoMetrics>()));
+                                           std::make_unique<VSilKit::NoMetrics>());
     }
     else
     {
         return std::make_unique<VAsioPeer>(this, _ioContext.get(), std::move(stream), _logger,
-                                           std::move(std::make_unique<VSilKit::PeerMetrics>()));
+                                           std::make_unique<VSilKit::PeerMetrics>());
 
     }
 }

--- a/SilKit/source/core/vasio/VAsioConnection.cpp
+++ b/SilKit/source/core/vasio/VAsioConnection.cpp
@@ -1065,6 +1065,7 @@ void VAsioConnection::HandleConnectedPeer(IVAsioPeer* peer)
     peer->SetServiceDescriptor(peerId);
 
     AssociateParticipantNameAndPeer(_simulationName, peer->GetInfo().participantName, peer);
+
 }
 
 
@@ -1086,7 +1087,7 @@ void VAsioConnection::AssociateParticipantNameAndPeer(const std::string& simulat
     metric->Add(peer->GetLocalAddress());
 
     metric =
-        _metricsManager->GetStringList({"Peer", simulationName, participantName, "LocalEndpoint", "/RemoteEndpoint"});
+        _metricsManager->GetStringList({"Peer", simulationName, participantName, "LocalEndpoint", "RemoteEndpoint"});
     metric->Add(peer->GetRemoteAddress());
 
     peer->InitializeMetrics(_participantName, _metricsManager);

--- a/SilKit/source/core/vasio/VAsioConnection.cpp
+++ b/SilKit/source/core/vasio/VAsioConnection.cpp
@@ -1087,7 +1087,7 @@ void VAsioConnection::AssociateParticipantNameAndPeer(const std::string& simulat
     metric->Add(peer->GetLocalAddress());
 
     metric =
-        _metricsManager->GetStringList({"Peer", simulationName, participantName, "LocalEndpoint", "RemoteEndpoint"});
+        _metricsManager->GetStringList({"Peer", simulationName, participantName, "RemoteEndpoint"});
     metric->Add(peer->GetRemoteAddress());
 
     peer->InitializeMetrics(_participantName, _metricsManager);

--- a/SilKit/source/core/vasio/VAsioConnection.cpp
+++ b/SilKit/source/core/vasio/VAsioConnection.cpp
@@ -1090,7 +1090,7 @@ void VAsioConnection::AssociateParticipantNameAndPeer(const std::string& simulat
         _metricsManager->GetStringList({"Peer", simulationName, participantName, "RemoteEndpoint"});
     metric->Add(peer->GetRemoteAddress());
 
-    peer->InitializeMetrics(_participantName, _metricsManager);
+    peer->InitializeMetrics(_metricsManager);
 }
 
 auto VAsioConnection::FindPeerByName(const std::string& simulationName,

--- a/SilKit/source/core/vasio/VAsioConnection.cpp
+++ b/SilKit/source/core/vasio/VAsioConnection.cpp
@@ -337,7 +337,7 @@ auto VAsioConnection::PrepareAcceptorEndpointUris(const std::string& connectUri)
 
 void VAsioConnection::OpenTcpAcceptors(const std::vector<std::string>& acceptorEndpointUris)
 {
-    auto metric = _metricsManager->GetStringList("TcpAcceptors");
+    auto metric = _metricsManager->GetStringList({"TcpAcceptors"});
     metric->Clear();
 
     for (const auto& uriString : acceptorEndpointUris)
@@ -386,7 +386,7 @@ void VAsioConnection::OpenTcpAcceptors(const std::vector<std::string>& acceptorE
 
 void VAsioConnection::OpenLocalAcceptors(const std::vector<std::string>& acceptorEndpointUris)
 {
-    auto metric = _metricsManager->GetStringList("LocalAcceptors");
+    auto metric = _metricsManager->GetStringList({"LocalAcceptors"});
     metric->Clear();
 
     for (const auto& uriString : acceptorEndpointUris)
@@ -1081,12 +1081,12 @@ void VAsioConnection::AssociateParticipantNameAndPeer(const std::string& simulat
         return;
     }
     IStringListMetric* metric;
-    auto metricNameBase = "Peer/" + simulationName + "/" + participantName;
 
-    metric = _metricsManager->GetStringList(metricNameBase + "/LocalEndpoint");
+    metric = _metricsManager->GetStringList({"Peer", simulationName, participantName, "LocalEndpoint"});
     metric->Add(peer->GetLocalAddress());
 
-    metric = _metricsManager->GetStringList(metricNameBase + "/RemoteEndpoint");
+    metric =
+        _metricsManager->GetStringList({"Peer", simulationName, participantName, "LocalEndpoint", "/RemoteEndpoint"});
     metric->Add(peer->GetRemoteAddress());
 
     peer->InitializeMetrics(_participantName, _metricsManager);

--- a/SilKit/source/core/vasio/VAsioPeer.cpp
+++ b/SilKit/source/core/vasio/VAsioPeer.cpp
@@ -146,6 +146,8 @@ void VAsioPeer::SendSilKitMsgInternal(std::vector<uint8_t> blob)
 
         _sendingQueue.emplace_back(std::move(blob));
 
+        _peerMetrics->TxQueueSize(_sendingQueue.size());
+
         lock.unlock();
 
         _ioContext->Dispatch([this] { StartAsyncWrite(); });

--- a/SilKit/source/core/vasio/VAsioPeer.cpp
+++ b/SilKit/source/core/vasio/VAsioPeer.cpp
@@ -368,6 +368,11 @@ void VAsioPeer::EnableAggregation()
     SilKit::Services::Logging::Debug(_logger, "VAsioPeer: Enable aggregation for peer {}", _info.participantName);
 }
 
+void VAsioPeer::InitializeMetrics(const std::string& localParticipantName, VSilKit::IMetricsManager* manager)
+{
+    _peerMetrics->InitializeMetrics(localParticipantName, manager, this);
+}
+
 } // namespace Core
 } // namespace SilKit
 

--- a/SilKit/source/core/vasio/VAsioPeer.cpp
+++ b/SilKit/source/core/vasio/VAsioPeer.cpp
@@ -372,7 +372,7 @@ void VAsioPeer::EnableAggregation()
 
 void VAsioPeer::InitializeMetrics(const std::string& localParticipantName, VSilKit::IMetricsManager* manager)
 {
-    _peerMetrics->InitializeMetrics(localParticipantName, manager, this);
+    _peerMetrics->InitializeMetrics(manager, this);
 }
 
 } // namespace Core

--- a/SilKit/source/core/vasio/VAsioPeer.cpp
+++ b/SilKit/source/core/vasio/VAsioPeer.cpp
@@ -150,7 +150,9 @@ void VAsioPeer::SendSilKitMsgInternal(std::vector<uint8_t> blob)
 
         lock.unlock();
 
-        _ioContext->Dispatch([this] { StartAsyncWrite(); });
+        _ioContext->Dispatch([this] {
+            StartAsyncWrite();
+            });
     }
 }
 

--- a/SilKit/source/core/vasio/VAsioPeer.cpp
+++ b/SilKit/source/core/vasio/VAsioPeer.cpp
@@ -370,7 +370,7 @@ void VAsioPeer::EnableAggregation()
     SilKit::Services::Logging::Debug(_logger, "VAsioPeer: Enable aggregation for peer {}", _info.participantName);
 }
 
-void VAsioPeer::InitializeMetrics(const std::string& localParticipantName, VSilKit::IMetricsManager* manager)
+void VAsioPeer::InitializeMetrics(VSilKit::IMetricsManager* manager)
 {
     _peerMetrics->InitializeMetrics(manager, this);
 }

--- a/SilKit/source/core/vasio/VAsioPeer.hpp
+++ b/SilKit/source/core/vasio/VAsioPeer.hpp
@@ -122,10 +122,6 @@ private: // IRawByteStreamListener
     void OnTimerExpired(ITimer& timer) override;
 
 private:
-
-    std::unique_ptr<VSilKit::IPeerMetrics> _peerMetrics;
-
-private:
     // ----------------------------------------
     // Private Members
     ProtocolVersion _protocolVersion{};
@@ -161,6 +157,7 @@ private:
     std::unique_ptr<ITimer> _flushTimer;
     const std::chrono::milliseconds _flushTimeout{50};
     bool _initialTimerStarted{false};
+    std::unique_ptr<VSilKit::IPeerMetrics> _peerMetrics;
 };
 
 // ================================================================================

--- a/SilKit/source/core/vasio/VAsioPeer.hpp
+++ b/SilKit/source/core/vasio/VAsioPeer.hpp
@@ -40,10 +40,10 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE. */
 #include "IRawByteStream.hpp"
 #include "ITimer.hpp"
 
+#include "PeerMetrics.hpp"
 
 namespace SilKit {
 namespace Core {
-
 
 class VAsioPeer
     : public IVAsioPeer
@@ -65,7 +65,7 @@ public:
     VAsioPeer& operator=(VAsioPeer&& other) = delete; //implicitly deleted because of mutex
 
     VAsioPeer(IVAsioPeerListener* listener, IIoContext* ioContext, std::unique_ptr<IRawByteStream> stream,
-              Services::Logging::ILogger* logger);
+              Services::Logging::ILogger* logger, std::unique_ptr<VSilKit::IPeerMetrics> metrics);
 
     ~VAsioPeer() override;
 
@@ -97,6 +97,11 @@ public:
 
     void EnableAggregation() override;
 
+    void InitializeMetrics(const std::string& localParticipantName, VSilKit::IMetricsManager* manager) override
+    {
+        _peerMetrics->InitializeMetrics(localParticipantName, manager, this);
+    }
+
 private:
     // ----------------------------------------
     // Private Methods
@@ -115,6 +120,10 @@ private: // IRawByteStreamListener
 
     // ITimerListener
     void OnTimerExpired(ITimer& timer) override;
+
+private:
+
+    std::unique_ptr<VSilKit::IPeerMetrics> _peerMetrics;
 
 private:
     // ----------------------------------------

--- a/SilKit/source/core/vasio/VAsioPeer.hpp
+++ b/SilKit/source/core/vasio/VAsioPeer.hpp
@@ -97,10 +97,7 @@ public:
 
     void EnableAggregation() override;
 
-    void InitializeMetrics(const std::string& localParticipantName, VSilKit::IMetricsManager* manager) override
-    {
-        _peerMetrics->InitializeMetrics(localParticipantName, manager, this);
-    }
+    void InitializeMetrics(const std::string& localParticipantName, VSilKit::IMetricsManager* manager) override;
 
 private:
     // ----------------------------------------

--- a/SilKit/source/core/vasio/VAsioPeer.hpp
+++ b/SilKit/source/core/vasio/VAsioPeer.hpp
@@ -97,7 +97,7 @@ public:
 
     void EnableAggregation() override;
 
-    void InitializeMetrics(const std::string& localParticipantName, VSilKit::IMetricsManager* manager) override;
+    void InitializeMetrics( VSilKit::IMetricsManager* manager) override;
 
 private:
     // ----------------------------------------

--- a/SilKit/source/core/vasio/VAsioProxyPeer.hpp
+++ b/SilKit/source/core/vasio/VAsioProxyPeer.hpp
@@ -61,7 +61,7 @@ public: // IVAsioPeer
     void SetSimulationName(const std::string& simulationName) override;
     auto GetSimulationName() const -> const std::string& override;
 
-    void InitializeMetrics(const std::string&, VSilKit::IMetricsManager*) override { }
+    void InitializeMetrics(VSilKit::IMetricsManager*) override { }
 
 public: // IVAsioPeer (IServiceEndpoint)
     void SetServiceDescriptor(const ServiceDescriptor& serviceDescriptor) override;

--- a/SilKit/source/core/vasio/VAsioProxyPeer.hpp
+++ b/SilKit/source/core/vasio/VAsioProxyPeer.hpp
@@ -61,6 +61,8 @@ public: // IVAsioPeer
     void SetSimulationName(const std::string& simulationName) override;
     auto GetSimulationName() const -> const std::string& override;
 
+    void InitializeMetrics(const std::string&, VSilKit::IMetricsManager*) override { }
+
 public: // IVAsioPeer (IServiceEndpoint)
     void SetServiceDescriptor(const ServiceDescriptor& serviceDescriptor) override;
     auto GetServiceDescriptor() const -> const ServiceDescriptor& override;

--- a/SilKit/source/core/vasio/VAsioRegistry.cpp
+++ b/SilKit/source/core/vasio/VAsioRegistry.cpp
@@ -26,6 +26,12 @@ namespace Core {
 
 
 VAsioRegistry::VAsioRegistry(std::shared_ptr<SilKit::Config::IParticipantConfiguration> cfg, ProtocolVersion version)
+    : VAsioRegistry(std::move(cfg), nullptr, version)
+{
+}
+
+VAsioRegistry::VAsioRegistry(std::shared_ptr<SilKit::Config::IParticipantConfiguration> cfg,
+                             IRegistryEventListener* registryEventListener, ProtocolVersion version)
     : _vasioConfig{std::dynamic_pointer_cast<SilKit::Config::ParticipantConfiguration>(cfg)}
     , _metricsProcessor{std::make_unique<VSilKit::MetricsProcessor>(REGISTRY_PARTICIPANT_NAME)}
     , _metricsManager{std::make_unique<VSilKit::MetricsManager>(REGISTRY_PARTICIPANT_NAME, *_metricsProcessor)}
@@ -38,6 +44,7 @@ VAsioRegistry::VAsioRegistry(std::shared_ptr<SilKit::Config::IParticipantConfigu
                   version}
 {
     _logger = std::make_unique<Services::Logging::Logger>(REGISTRY_PARTICIPANT_NAME, _vasioConfig->logging);
+    SetRegistryEventListener(registryEventListener);
 
     dynamic_cast<VSilKit::MetricsProcessor&>(*_metricsProcessor).SetLogger(*_logger);
     dynamic_cast<VSilKit::MetricsManager&>(*_metricsManager).SetLogger(*_logger);

--- a/SilKit/source/core/vasio/VAsioRegistry.cpp
+++ b/SilKit/source/core/vasio/VAsioRegistry.cpp
@@ -26,12 +26,6 @@ namespace Core {
 
 
 VAsioRegistry::VAsioRegistry(std::shared_ptr<SilKit::Config::IParticipantConfiguration> cfg, ProtocolVersion version)
-    : VAsioRegistry(std::move(cfg), nullptr, version)
-{
-}
-
-VAsioRegistry::VAsioRegistry(std::shared_ptr<SilKit::Config::IParticipantConfiguration> cfg,
-                             IRegistryEventListener* registryEventListener, ProtocolVersion version)
     : _vasioConfig{std::dynamic_pointer_cast<SilKit::Config::ParticipantConfiguration>(cfg)}
     , _metricsProcessor{std::make_unique<VSilKit::MetricsProcessor>(REGISTRY_PARTICIPANT_NAME)}
     , _metricsManager{std::make_unique<VSilKit::MetricsManager>(REGISTRY_PARTICIPANT_NAME, *_metricsProcessor)}
@@ -44,7 +38,6 @@ VAsioRegistry::VAsioRegistry(std::shared_ptr<SilKit::Config::IParticipantConfigu
                   version}
 {
     _logger = std::make_unique<Services::Logging::Logger>(REGISTRY_PARTICIPANT_NAME, _vasioConfig->logging);
-    SetRegistryEventListener(registryEventListener);
 
     dynamic_cast<VSilKit::MetricsProcessor&>(*_metricsProcessor).SetLogger(*_logger);
     dynamic_cast<VSilKit::MetricsManager&>(*_metricsManager).SetLogger(*_logger);

--- a/SilKit/source/core/vasio/VAsioRegistry.cpp
+++ b/SilKit/source/core/vasio/VAsioRegistry.cpp
@@ -32,8 +32,7 @@ VAsioRegistry::VAsioRegistry(std::shared_ptr<SilKit::Config::IParticipantConfigu
 
 VAsioRegistry::VAsioRegistry(std::shared_ptr<SilKit::Config::IParticipantConfiguration> cfg,
                              IRegistryEventListener* registryEventListener, ProtocolVersion version)
-    : _registryEventListener{registryEventListener}
-    , _vasioConfig{std::dynamic_pointer_cast<SilKit::Config::ParticipantConfiguration>(cfg)}
+    : _vasioConfig{std::dynamic_pointer_cast<SilKit::Config::ParticipantConfiguration>(cfg)}
     , _metricsProcessor{std::make_unique<VSilKit::MetricsProcessor>(REGISTRY_PARTICIPANT_NAME)}
     , _metricsManager{std::make_unique<VSilKit::MetricsManager>(REGISTRY_PARTICIPANT_NAME, *_metricsProcessor)}
     , _connection{nullptr,
@@ -45,11 +44,7 @@ VAsioRegistry::VAsioRegistry(std::shared_ptr<SilKit::Config::IParticipantConfigu
                   version}
 {
     _logger = std::make_unique<Services::Logging::Logger>(REGISTRY_PARTICIPANT_NAME, _vasioConfig->logging);
-
-    if (_registryEventListener != nullptr)
-    {
-        _registryEventListener->OnLoggerInternalCreated(_logger.get());
-    }
+    SetRegistryEventListener(registryEventListener);
 
     dynamic_cast<VSilKit::MetricsProcessor&>(*_metricsProcessor).SetLogger(*_logger);
     dynamic_cast<VSilKit::MetricsManager&>(*_metricsManager).SetLogger(*_logger);
@@ -67,6 +62,15 @@ VAsioRegistry::VAsioRegistry(std::shared_ptr<SilKit::Config::IParticipantConfigu
     _serviceDescriptor.SetServiceId(_localEndpointId++);
 
     SetupMetrics();
+}
+
+void VAsioRegistry::SetRegistryEventListener(IRegistryEventListener* listener)
+{
+    _registryEventListener = listener;
+    if (_registryEventListener != nullptr)
+    {
+        _registryEventListener->OnLoggerInternalCreated(_logger.get());
+    }
 }
 
 auto VAsioRegistry::StartListening(const std::string& listenUri) -> std::string

--- a/SilKit/source/core/vasio/VAsioRegistry.cpp
+++ b/SilKit/source/core/vasio/VAsioRegistry.cpp
@@ -408,6 +408,9 @@ void VAsioRegistry::OnMetricsUpdate(const std::string& participantName, const VS
         Log::Info(GetLogger(), "Metric Update: {} {} {} {} ({})", data.name, data.kind, data.value, data.timestamp,
                   participantName);
     }
+
+    dynamic_cast<VSilKit::MetricsProcessor&>(*_metricsProcessor).OnMetricsUpdate(participantName, metricsUpdate);
+    _registryEventListener->OnMetricsUpdate("", participantName, metricsUpdate);
 }
 
 

--- a/SilKit/source/core/vasio/VAsioRegistry.cpp
+++ b/SilKit/source/core/vasio/VAsioRegistry.cpp
@@ -413,7 +413,10 @@ void VAsioRegistry::OnMetricsUpdate(const std::string& simulationName, const std
     dynamic_cast<VSilKit::MetricsProcessor&>(*_metricsProcessor)
         .OnMetricsUpdate(simulationName, participantName, metricsUpdate);
 
-    _registryEventListener->OnMetricsUpdate(simulationName, participantName, metricsUpdate);
+    if (_registryEventListener != nullptr)
+    {
+        _registryEventListener->OnMetricsUpdate(simulationName, participantName, metricsUpdate);
+    }
 }
 
 

--- a/SilKit/source/core/vasio/VAsioRegistry.cpp
+++ b/SilKit/source/core/vasio/VAsioRegistry.cpp
@@ -400,7 +400,8 @@ auto VAsioRegistry::GetServiceDescriptor() const -> const ServiceDescriptor&
 }
 
 
-void VAsioRegistry::OnMetricsUpdate(const std::string& participantName, const VSilKit::MetricsUpdate& metricsUpdate)
+void VAsioRegistry::OnMetricsUpdate(const std::string& simulationName, const std::string& participantName,
+                                    const VSilKit::MetricsUpdate& metricsUpdate)
 {
     Log::Info(GetLogger(), "Participant {} updates {} metrics", participantName, metricsUpdate.metrics.size());
     for (const auto& data : metricsUpdate.metrics)
@@ -409,8 +410,10 @@ void VAsioRegistry::OnMetricsUpdate(const std::string& participantName, const VS
                   participantName);
     }
 
-    dynamic_cast<VSilKit::MetricsProcessor&>(*_metricsProcessor).OnMetricsUpdate(participantName, metricsUpdate);
-    _registryEventListener->OnMetricsUpdate("", participantName, metricsUpdate);
+    dynamic_cast<VSilKit::MetricsProcessor&>(*_metricsProcessor)
+        .OnMetricsUpdate(simulationName, participantName, metricsUpdate);
+
+    _registryEventListener->OnMetricsUpdate(simulationName, participantName, metricsUpdate);
 }
 
 

--- a/SilKit/source/core/vasio/VAsioRegistry.cpp
+++ b/SilKit/source/core/vasio/VAsioRegistry.cpp
@@ -42,9 +42,14 @@ VAsioRegistry::VAsioRegistry(std::shared_ptr<SilKit::Config::IParticipantConfigu
                   REGISTRY_PARTICIPANT_ID,
                   &_timeProvider,
                   version}
+    , _registryEventListener{registryEventListener}
 {
     _logger = std::make_unique<Services::Logging::Logger>(REGISTRY_PARTICIPANT_NAME, _vasioConfig->logging);
-    SetRegistryEventListener(registryEventListener);
+
+    if (_registryEventListener != nullptr)
+    {
+        _registryEventListener->OnLoggerInternalCreated(_logger.get());
+    }
 
     dynamic_cast<VSilKit::MetricsProcessor&>(*_metricsProcessor).SetLogger(*_logger);
     dynamic_cast<VSilKit::MetricsManager&>(*_metricsManager).SetLogger(*_logger);
@@ -62,15 +67,6 @@ VAsioRegistry::VAsioRegistry(std::shared_ptr<SilKit::Config::IParticipantConfigu
     _serviceDescriptor.SetServiceId(_localEndpointId++);
 
     SetupMetrics();
-}
-
-void VAsioRegistry::SetRegistryEventListener(IRegistryEventListener* listener)
-{
-    _registryEventListener = listener;
-    if (_registryEventListener != nullptr)
-    {
-        _registryEventListener->OnLoggerInternalCreated(_logger.get());
-    }
 }
 
 auto VAsioRegistry::StartListening(const std::string& listenUri) -> std::string

--- a/SilKit/source/core/vasio/VAsioRegistry.cpp
+++ b/SilKit/source/core/vasio/VAsioRegistry.cpp
@@ -325,7 +325,7 @@ void VAsioRegistry::SetupMetrics()
 
     if (_vasioConfig->experimental.metrics.collectFromRemote)
     {
-        auto metricsReceiver = std::make_unique<VSilKit::MetricsReceiver>(nullptr, processor);
+        auto metricsReceiver = std::make_unique<VSilKit::MetricsReceiver>(nullptr, *this);
 
         SilKit::Core::SupplementalData supplementalData;
         supplementalData[SilKit::Core::Discovery::controllerType] =

--- a/SilKit/source/core/vasio/VAsioRegistry.cpp
+++ b/SilKit/source/core/vasio/VAsioRegistry.cpp
@@ -32,7 +32,8 @@ VAsioRegistry::VAsioRegistry(std::shared_ptr<SilKit::Config::IParticipantConfigu
 
 VAsioRegistry::VAsioRegistry(std::shared_ptr<SilKit::Config::IParticipantConfiguration> cfg,
                              IRegistryEventListener* registryEventListener, ProtocolVersion version)
-    : _vasioConfig{std::dynamic_pointer_cast<SilKit::Config::ParticipantConfiguration>(cfg)}
+    : _registryEventListener{registryEventListener}
+    , _vasioConfig{std::dynamic_pointer_cast<SilKit::Config::ParticipantConfiguration>(cfg)}
     , _metricsProcessor{std::make_unique<VSilKit::MetricsProcessor>(REGISTRY_PARTICIPANT_NAME)}
     , _metricsManager{std::make_unique<VSilKit::MetricsManager>(REGISTRY_PARTICIPANT_NAME, *_metricsProcessor)}
     , _connection{nullptr,
@@ -42,7 +43,6 @@ VAsioRegistry::VAsioRegistry(std::shared_ptr<SilKit::Config::IParticipantConfigu
                   REGISTRY_PARTICIPANT_ID,
                   &_timeProvider,
                   version}
-    , _registryEventListener{registryEventListener}
 {
     _logger = std::make_unique<Services::Logging::Logger>(REGISTRY_PARTICIPANT_NAME, _vasioConfig->logging);
 

--- a/SilKit/source/core/vasio/VAsioRegistry.hpp
+++ b/SilKit/source/core/vasio/VAsioRegistry.hpp
@@ -121,7 +121,8 @@ private: // IServiceEndpoint
     auto GetServiceDescriptor() const -> const ServiceDescriptor& override;
 
 private: // IMetricsReceiverListener
-    void OnMetricsUpdate(const std::string& participantName, const VSilKit::MetricsUpdate& metricsUpdate) override;
+    void OnMetricsUpdate(const std::string& simulationName, const std::string& participantName,
+                         const VSilKit::MetricsUpdate& metricsUpdate) override;
 
 private:
     // ----------------------------------------

--- a/SilKit/source/core/vasio/VAsioRegistry.hpp
+++ b/SilKit/source/core/vasio/VAsioRegistry.hpp
@@ -60,6 +60,8 @@ struct IRegistryEventListener
     virtual void OnServiceDiscoveryEvent(
         const std::string& simulationName, const std::string& participantName,
         const SilKit::Core::Discovery::ServiceDiscoveryEvent& serviceDiscoveryEvent) = 0;
+    virtual void OnMetricsUpdate(const std::string& simulationName, const std::string& origin,
+                                 const VSilKit::MetricsUpdate& metricsUpdate) = 0;
 };
 
 class VAsioRegistry

--- a/SilKit/source/core/vasio/VAsioRegistry.hpp
+++ b/SilKit/source/core/vasio/VAsioRegistry.hpp
@@ -76,8 +76,6 @@ public: // CTor
     VAsioRegistry(VAsioRegistry&&) = delete;
     VAsioRegistry(std::shared_ptr<SilKit::Config::IParticipantConfiguration> cfg,
                   ProtocolVersion version = CurrentProtocolVersion());
-    VAsioRegistry(std::shared_ptr<SilKit::Config::IParticipantConfiguration> cfg,
-                  IRegistryEventListener* registryEventListener, ProtocolVersion version = CurrentProtocolVersion());
 
 public: // methods for test injection
     void SetRegistryEventListener(IRegistryEventListener* listener);

--- a/SilKit/source/core/vasio/VAsioRegistry.hpp
+++ b/SilKit/source/core/vasio/VAsioRegistry.hpp
@@ -79,6 +79,9 @@ public: // CTor
     VAsioRegistry(std::shared_ptr<SilKit::Config::IParticipantConfiguration> cfg,
                   IRegistryEventListener* registryEventListener, ProtocolVersion version = CurrentProtocolVersion());
 
+public: // methods for test injection
+    void SetRegistryEventListener(IRegistryEventListener* listener);
+
 public: // methods
     auto StartListening(const std::string& listenUri) -> std::string override;
 

--- a/SilKit/source/core/vasio/VAsioRegistry.hpp
+++ b/SilKit/source/core/vasio/VAsioRegistry.hpp
@@ -76,6 +76,8 @@ public: // CTor
     VAsioRegistry(VAsioRegistry&&) = delete;
     VAsioRegistry(std::shared_ptr<SilKit::Config::IParticipantConfiguration> cfg,
                   ProtocolVersion version = CurrentProtocolVersion());
+    VAsioRegistry(std::shared_ptr<SilKit::Config::IParticipantConfiguration> cfg,
+                  IRegistryEventListener* registryEventListener, ProtocolVersion version = CurrentProtocolVersion());
 
 public: // methods for test injection
     void SetRegistryEventListener(IRegistryEventListener* listener);

--- a/SilKit/source/core/vasio/VAsioRegistry.hpp
+++ b/SilKit/source/core/vasio/VAsioRegistry.hpp
@@ -79,9 +79,6 @@ public: // CTor
     VAsioRegistry(std::shared_ptr<SilKit::Config::IParticipantConfiguration> cfg,
                   IRegistryEventListener* registryEventListener, ProtocolVersion version = CurrentProtocolVersion());
 
-public: // methods for test injection
-    void SetRegistryEventListener(IRegistryEventListener* listener);
-
 public: // methods
     auto StartListening(const std::string& listenUri) -> std::string override;
 

--- a/SilKit/source/core/vasio/mock/MockVAsioPeer.hpp
+++ b/SilKit/source/core/vasio/mock/MockVAsioPeer.hpp
@@ -40,7 +40,7 @@ struct MockVAsioPeer : IVAsioPeer
     MOCK_METHOD(void, EnableAggregation, (), (override));
     MOCK_METHOD(void, SetProtocolVersion, (ProtocolVersion), (override));
     MOCK_METHOD(ProtocolVersion, GetProtocolVersion, (), (const, override));
-    MOCK_METHOD(void, InitializeMetrics, (const std::string&, VSilKit::IMetricsManager*), (override));
+    MOCK_METHOD(void, InitializeMetrics, (VSilKit::IMetricsManager*), (override));
 
     // IServiceEndpoint (via IVAsioPeer)
 

--- a/SilKit/source/core/vasio/mock/MockVAsioPeer.hpp
+++ b/SilKit/source/core/vasio/mock/MockVAsioPeer.hpp
@@ -39,6 +39,7 @@ struct MockVAsioPeer : IVAsioPeer
     MOCK_METHOD(void, EnableAggregation, (), (override));
     MOCK_METHOD(void, SetProtocolVersion, (ProtocolVersion), (override));
     MOCK_METHOD(ProtocolVersion, GetProtocolVersion, (), (const, override));
+    MOCK_METHOD(void, InitializeMetrics, (const std::string&, VSilKit::IMetricsManager*), (override));
 
     // IServiceEndpoint (via IVAsioPeer)
 

--- a/SilKit/source/core/vasio/mock/MockVAsioPeer.hpp
+++ b/SilKit/source/core/vasio/mock/MockVAsioPeer.hpp
@@ -24,6 +24,7 @@ namespace Core {
 
 struct MockVAsioPeer : IVAsioPeer
 {
+
     // IVAsioPeer
 
     MOCK_METHOD(void, SendSilKitMsg, (SerializedMessage), (override));

--- a/SilKit/source/dashboard/Client/DashboardSystemApiClient.hpp
+++ b/SilKit/source/dashboard/Client/DashboardSystemApiClient.hpp
@@ -163,7 +163,7 @@ class DashboardSystemApiClient : public oatpp::web::client::ApiClient
 
     // bulk update of simulation metrics
     API_CALL("POST", "system-service/v1.1/simulations/{simulationId}/metrics", updateSimulationMetrics,
-             PATH(UInt64, simulationId), BODY_DTO(oatpp::Vector<Object<MetricDataDto>>, simulation))
+             PATH(UInt64, simulationId), BODY_DTO(Object<MetricsUpdateDto>, simulation))
 };
 
 } // namespace Dashboard

--- a/SilKit/source/dashboard/Client/DashboardSystemApiClient.hpp
+++ b/SilKit/source/dashboard/Client/DashboardSystemApiClient.hpp
@@ -160,6 +160,10 @@ class DashboardSystemApiClient : public oatpp::web::client::ApiClient
     // bulk update of a simulation
     API_CALL("POST", "system-service/v1.1/simulations/{simulationId}", updateSimulation, PATH(UInt64, simulationId),
              BODY_DTO(Object<BulkSimulationDto>, simulation))
+
+    // bulk update of simulation metrics
+    API_CALL("POST", "system-service/v1.1/simulations/{simulationId}/metrics", updateSimulationMetrics,
+             PATH(UInt64, simulationId), BODY_DTO(oatpp::Vector<Object<MetricDataDto>>, simulation))
 };
 
 } // namespace Dashboard

--- a/SilKit/source/dashboard/Client/DashboardSystemServiceClient.cpp
+++ b/SilKit/source/dashboard/Client/DashboardSystemServiceClient.cpp
@@ -218,7 +218,7 @@ void DashboardSystemServiceClient::SetSimulationEnd(oatpp::UInt64 simulationId,
 void DashboardSystemServiceClient::UpdateSimulationMetrics(oatpp::UInt64 simulationId,
                                                            oatpp::Object<MetricsUpdateDto> metrics)
 {
-    auto response = _dashboardSystemApiClient->updateSimulationMetrics(simulationId, metrics->metrics);
+    auto response = _dashboardSystemApiClient->updateSimulationMetrics(simulationId, metrics);
     Log(response, "updating simulation metrics");
 }
 

--- a/SilKit/source/dashboard/Client/DashboardSystemServiceClient.cpp
+++ b/SilKit/source/dashboard/Client/DashboardSystemServiceClient.cpp
@@ -215,6 +215,14 @@ void DashboardSystemServiceClient::SetSimulationEnd(oatpp::UInt64 simulationId,
     Log(response, "setting simulation end");
 }
 
+void DashboardSystemServiceClient::UpdateSimulationMetrics(oatpp::UInt64 simulationId,
+                                                           oatpp::Object<MetricsUpdateDto> metrics)
+{
+    auto response = _dashboardSystemApiClient->updateSimulationMetrics(simulationId, metrics->metrics);
+    Log(response, "updating simulation metrics");
+}
+
+
 void DashboardSystemServiceClient::Log(std::shared_ptr<oatpp::web::client::RequestExecutor::Response> response,
                                        const std::string& message)
 {

--- a/SilKit/source/dashboard/Client/DashboardSystemServiceClient.hpp
+++ b/SilKit/source/dashboard/Client/DashboardSystemServiceClient.hpp
@@ -108,6 +108,8 @@ public:
 
     void SetSimulationEnd(oatpp::UInt64 simulationId, oatpp::Object<SimulationEndDto> simulation) override;
 
+    void UpdateSimulationMetrics(oatpp::UInt64 simulationId, oatpp::Object<MetricsUpdateDto> metrics) override;
+
 private:
     void Log(std::shared_ptr<oatpp::web::client::RequestExecutor::Response> response, const std::string& message);
 

--- a/SilKit/source/dashboard/Client/IDashboardSystemServiceClient.hpp
+++ b/SilKit/source/dashboard/Client/IDashboardSystemServiceClient.hpp
@@ -108,6 +108,8 @@ public:
                                                  oatpp::Object<SystemStatusDto> systemStatus) = 0;
 
     virtual void SetSimulationEnd(oatpp::UInt64 simulationId, oatpp::Object<SimulationEndDto> simulation) = 0;
+
+    virtual void UpdateSimulationMetrics(oatpp::UInt64 simulationId, oatpp::Object<MetricsUpdateDto> metrics) = 0;
 };
 
 } // namespace Dashboard

--- a/SilKit/source/dashboard/Client/Mocks/MockDashboardSystemServiceClient.hpp
+++ b/SilKit/source/dashboard/Client/Mocks/MockDashboardSystemServiceClient.hpp
@@ -37,6 +37,8 @@ public:
 
     MOCK_METHOD(void, UpdateSimulation, (oatpp::UInt64, oatpp::Object<BulkSimulationDto>), (override));
 
+    MOCK_METHOD(void, UpdateSimulationMetrics, (oatpp::UInt64, oatpp::Object<MetricsUpdateDto>), (override));
+
     MOCK_METHOD(void, AddParticipantToSimulation, (oatpp::UInt64, oatpp::String), (override));
 
     MOCK_METHOD(void, AddParticipantStatusForSimulation,

--- a/SilKit/source/dashboard/CreateDashboard.cpp
+++ b/SilKit/source/dashboard/CreateDashboard.cpp
@@ -29,6 +29,8 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE. */
 #include "DashboardSystemApiController.hpp"
 #include "DashboardTestComponents.hpp"
 
+#include "ParticipantConfigurationFromXImpl.hpp"
+
 
 namespace SilKit {
 namespace Dashboard {
@@ -40,11 +42,13 @@ auto CreateDashboard(std::shared_ptr<SilKit::Config::IParticipantConfiguration> 
     return std::make_unique<SilKit::Dashboard::OatppContext>(participantConfig, registryUri, dashboardUri);
 }
 
-auto RunDashboardTest(std::shared_ptr<SilKit::Config::IParticipantConfiguration> participantConfig,
-                      const std::string& registryUri, const std::string& dashboardUri, std::function<void()> testCode,
+auto RunDashboardTest(const std::string& participantConfigString, const std::string& registryUri,
+                      const std::string& dashboardUri, std::function<void()> testCode,
                       uint64_t expectedSimulationsCount, std::chrono::seconds creationTimeout,
                       std::chrono::seconds updateTimeout) -> TestResult
 {
+    //we need the internal ParticipantConfiguration struct
+    auto&& participantConfig = Config::ParticipantConfigurationFromStringImpl(participantConfigString);
     TestResult testResult{};
     oatpp::base::Environment::init();
     try

--- a/SilKit/source/dashboard/CreateDashboard.hpp
+++ b/SilKit/source/dashboard/CreateDashboard.hpp
@@ -37,8 +37,8 @@ auto CreateDashboard(std::shared_ptr<SilKit::Config::IParticipantConfiguration> 
                      const std::string& dashboardUri) -> std::unique_ptr<SilKit::Dashboard::IDashboard>;
 
 //! returns information about simulation, participants and networks
-auto RunDashboardTest(std::shared_ptr<SilKit::Config::IParticipantConfiguration> participantConfig,
-                      const std::string& registryUri, const std::string& dashboardUri, std::function<void()> testCode,
+auto RunDashboardTest(const std::string& participantConfig, const std::string& registryUri,
+                      const std::string& dashboardUri, std::function<void()> testCode,
                       uint64_t expectedSimulationsCount = 1,
                       std::chrono::seconds creationTimeout = std::chrono::seconds{0},
                       std::chrono::seconds updateTimeout = std::chrono::seconds{0}) -> TestResult;

--- a/SilKit/source/dashboard/DashboardInstance.cpp
+++ b/SilKit/source/dashboard/DashboardInstance.cpp
@@ -260,6 +260,13 @@ struct EventQueueWorkerThread
                 }
                 break;
 
+                case SilKitEventType::OnMetricUpdate:
+                {
+                    const auto &data = event.GetMetricsUpdate();
+                    eventHandler->OnMetricsUpdate(simulationId, data.first, data.second);
+                }
+                break;
+
                 default:
                 {
                     Log::Error(logger, "Dashboard: unexpected SilKitEventType");
@@ -549,6 +556,17 @@ void DashboardInstance::OnServiceDiscoveryEvent(
 
     _silKitEventQueue->Enqueue(
         SilKitEvent{simulationName, ServiceData{serviceDiscoveryEvent.type, serviceDiscoveryEvent.serviceDescriptor}});
+}
+
+void DashboardInstance::OnMetricsUpdate(const std::string &simulationName, const std::string &origin,
+                                        const VSilKit::MetricsUpdate &metricsUpdate)
+{
+    Log::Trace(_logger, "DashboardInstance::OnMetricsUpdate: simulationName={} origin={} metricsUpdate={}",
+               simulationName, origin, metricsUpdate);
+
+    std::pair<std::string, VSilKit::MetricsUpdate> data{origin, metricsUpdate};
+
+    _silKitEventQueue->Enqueue(SilKitEvent{simulationName, std::move(data)});
 }
 
 

--- a/SilKit/source/dashboard/DashboardInstance.hpp
+++ b/SilKit/source/dashboard/DashboardInstance.hpp
@@ -71,6 +71,7 @@ private: // SilKit::Core::IRegistryEventListener
         SilKit::Services::Orchestration::ParticipantStatus const& participantStatus) override;
     void OnServiceDiscoveryEvent(std::string const& simulationName, std::string const& participantName,
                                  SilKit::Core::Discovery::ServiceDiscoveryEvent const& serviceDiscoveryEvent) override;
+    void OnMetricsUpdate(const std::string &simulationName, const std::string &origin, const VSilKit::MetricsUpdate &metricsUpdate) override;
 
 private:
     /// Assigned in OnLoggerCreated

--- a/SilKit/source/dashboard/Dto/BulkUpdateDto.hpp
+++ b/SilKit/source/dashboard/Dto/BulkUpdateDto.hpp
@@ -127,6 +127,12 @@ class BulkSimulationDto : public oatpp::DTO
     }
 };
 
+ENUM(MetricKind, v_int32, //
+     VALUE(Unknown, 0, "unknown"), //
+     VALUE(Counter, 10, "counter"), //
+     VALUE(Statistic, 20, "statistic"), //
+     VALUE(StringList, 30, "stringlist"))
+
 class MetricDataDto : public oatpp::DTO
 {
     DTO_INIT(MetricDataDto, DTO)
@@ -134,7 +140,7 @@ class MetricDataDto : public oatpp::DTO
     DTO_FIELD(Int64, ts);
     DTO_FIELD(String, pn);
     DTO_FIELD(String, mn);
-    DTO_FIELD(String, mk);
+    DTO_FIELD(Enum<MetricKind>::AsString, mk);
     DTO_FIELD(String, mv);
 };
 

--- a/SilKit/source/dashboard/Dto/BulkUpdateDto.hpp
+++ b/SilKit/source/dashboard/Dto/BulkUpdateDto.hpp
@@ -127,6 +127,31 @@ class BulkSimulationDto : public oatpp::DTO
     }
 };
 
+class MetricDataDto : public oatpp::DTO
+{
+    DTO_INIT(MetricDataDto, DTO)
+
+    DTO_FIELD(Int64, ts);
+    DTO_FIELD(String, pn);
+    DTO_FIELD(String, mn);
+    DTO_FIELD(String, mk);
+    DTO_FIELD(String, mv);
+};
+
+class MetricsUpdateDto : public oatpp::DTO
+{
+    DTO_INIT(MetricsUpdateDto, DTO)
+
+    DTO_FIELD(Vector<Object<MetricDataDto>>, metrics);
+
+    static auto CreateEmpty() -> Wrapper
+    {
+        auto dto = createShared();
+        dto->metrics = Vector<Object<MetricDataDto>>::createShared();
+        return dto;
+    }
+};
+
 } // namespace Dashboard
 } // namespace SilKit
 

--- a/SilKit/source/dashboard/Dto/BulkUpdateDto.hpp
+++ b/SilKit/source/dashboard/Dto/BulkUpdateDto.hpp
@@ -66,42 +66,26 @@ class BulkParticipantDto : public oatpp::DTO
     DTO_INIT(BulkParticipantDto, DTO)
 
     DTO_FIELD(String, name);
-    DTO_FIELD(Vector<Object<ParticipantStatusDto>>, statuses);
-    DTO_FIELD(Vector<Object<BulkControllerDto>>, canControllers);
-    DTO_FIELD(Vector<Object<BulkControllerDto>>, ethernetControllers);
-    DTO_FIELD(Vector<Object<BulkControllerDto>>, flexrayControllers);
-    DTO_FIELD(Vector<Object<BulkControllerDto>>, linControllers);
-    DTO_FIELD(Vector<Object<BulkDataServiceDto>>, dataPublishers);
-    DTO_FIELD(Vector<Object<BulkDataServiceDto>>, dataSubscribers);
-    DTO_FIELD(Vector<Object<BulkServiceInternalDto>>, dataSubscriberInternals);
-    DTO_FIELD(Vector<Object<BulkRpcServiceDto>>, rpcClients);
-    DTO_FIELD(Vector<Object<BulkRpcServiceDto>>, rpcServers);
-    DTO_FIELD(Vector<Object<BulkServiceInternalDto>>, rpcServerInternals);
-    DTO_FIELD(Vector<String>, canNetworks);
-    DTO_FIELD(Vector<String>, ethernetNetworks);
-    DTO_FIELD(Vector<String>, flexrayNetworks);
-    DTO_FIELD(Vector<String>, linNetworks);
+    DTO_FIELD(Vector<Object<ParticipantStatusDto>>, statuses) = Vector<Object<ParticipantStatusDto>>::createShared();
+    DTO_FIELD(Vector<Object<BulkControllerDto>>, canControllers) = Vector<Object<BulkControllerDto>>::createShared();
+    DTO_FIELD(Vector<Object<BulkControllerDto>>,
+              ethernetControllers) = Vector<Object<BulkControllerDto>>::createShared();
+    DTO_FIELD(Vector<Object<BulkControllerDto>>,
+              flexrayControllers) = Vector<Object<BulkControllerDto>>::createShared();
+    DTO_FIELD(Vector<Object<BulkControllerDto>>, linControllers) = Vector<Object<BulkControllerDto>>::createShared();
+    DTO_FIELD(Vector<Object<BulkDataServiceDto>>, dataPublishers) = Vector<Object<BulkDataServiceDto>>::createShared();
+    DTO_FIELD(Vector<Object<BulkDataServiceDto>>, dataSubscribers) = Vector<Object<BulkDataServiceDto>>::createShared();
+    DTO_FIELD(Vector<Object<BulkServiceInternalDto>>,
+              dataSubscriberInternals) = Vector<Object<BulkServiceInternalDto>>::createShared();
+    DTO_FIELD(Vector<Object<BulkRpcServiceDto>>, rpcClients) = Vector<Object<BulkRpcServiceDto>>::createShared();
+    DTO_FIELD(Vector<Object<BulkRpcServiceDto>>, rpcServers) = Vector<Object<BulkRpcServiceDto>>::createShared();
+    DTO_FIELD(Vector<Object<BulkServiceInternalDto>>,
+              rpcServerInternals) = Vector<Object<BulkServiceInternalDto>>::createShared();
+    DTO_FIELD(Vector<String>, canNetworks) = Vector<String>::createShared();
+    DTO_FIELD(Vector<String>, ethernetNetworks) = Vector<String>::createShared();
+    DTO_FIELD(Vector<String>, flexrayNetworks) = Vector<String>::createShared();
+    DTO_FIELD(Vector<String>, linNetworks) = Vector<String>::createShared();
 
-    static auto CreateEmpty() -> Wrapper
-    {
-        auto dto = createShared();
-        dto->statuses = Vector<Object<ParticipantStatusDto>>::createShared();
-        dto->canControllers = Vector<Object<BulkControllerDto>>::createShared();
-        dto->ethernetControllers = Vector<Object<BulkControllerDto>>::createShared();
-        dto->flexrayControllers = Vector<Object<BulkControllerDto>>::createShared();
-        dto->linControllers = Vector<Object<BulkControllerDto>>::createShared();
-        dto->dataPublishers = Vector<Object<BulkDataServiceDto>>::createShared();
-        dto->dataSubscribers = Vector<Object<BulkDataServiceDto>>::createShared();
-        dto->dataSubscriberInternals = Vector<Object<BulkServiceInternalDto>>::createShared();
-        dto->rpcClients = Vector<Object<BulkRpcServiceDto>>::createShared();
-        dto->rpcServers = Vector<Object<BulkRpcServiceDto>>::createShared();
-        dto->rpcServerInternals = Vector<Object<BulkServiceInternalDto>>::createShared();
-        dto->canNetworks = Vector<String>::createShared();
-        dto->ethernetNetworks = Vector<String>::createShared();
-        dto->flexrayNetworks = Vector<String>::createShared();
-        dto->linNetworks = Vector<String>::createShared();
-        return dto;
-    }
 };
 
 class BulkSimulationDto : public oatpp::DTO

--- a/SilKit/source/dashboard/Dto/BulkUpdateDto.hpp
+++ b/SilKit/source/dashboard/Dto/BulkUpdateDto.hpp
@@ -157,13 +157,6 @@ class StatisticDataDto : public MetricDataDto
     DTO_FIELD(Vector<Float64>, mv) = Vector<Float64>::createShared();
 };
 
-class StringListDataDto : public MetricDataDto
-{
-    DTO_INIT(StringListDataDto, MetricDataDto)
-
-    DTO_FIELD(Vector<String>, mv) = Vector<String>::createShared();
-};
-
 
 class MetricsUpdateDto : public oatpp::DTO
 {
@@ -172,7 +165,6 @@ class MetricsUpdateDto : public oatpp::DTO
     DTO_FIELD(Vector<Object<AttributeDataDto>>, attributes) = Vector<Object<AttributeDataDto>>::createShared();
     DTO_FIELD(Vector<Object<CounterDataDto>>, counters) = Vector<Object<CounterDataDto>>::createShared();
     DTO_FIELD(Vector<Object<StatisticDataDto>>, statistics) = Vector<Object<StatisticDataDto>>::createShared();
-    DTO_FIELD(Vector<Object<StringListDataDto>>, stringLists) = Vector<Object<StringListDataDto>>::createShared();
 };
 } // namespace Dashboard
 } // namespace SilKit

--- a/SilKit/source/dashboard/Dto/BulkUpdateDto.hpp
+++ b/SilKit/source/dashboard/Dto/BulkUpdateDto.hpp
@@ -18,14 +18,8 @@ class BulkSystemDto : public oatpp::DTO
 {
     DTO_INIT(BulkSystemDto, DTO)
 
-    DTO_FIELD(Vector<Object<SystemStatusDto>>, statuses);
+    DTO_FIELD(Vector<Object<SystemStatusDto>>, statuses) = Vector<Object<SystemStatusDto>>::createShared();
 
-    static auto CreateEmpty() -> Wrapper
-    {
-        auto dto = createShared();
-        dto->statuses = Vector<Object<SystemStatusDto>>::createShared();
-        return dto;
-    }
 };
 
 class BulkControllerDto : public oatpp::DTO
@@ -116,15 +110,7 @@ class BulkSimulationDto : public oatpp::DTO
 
     DTO_FIELD(Int64, stopped);
     DTO_FIELD(Object<BulkSystemDto>, system);
-    DTO_FIELD(Vector<Object<BulkParticipantDto>>, participants);
-
-    static auto CreateEmpty() -> Wrapper
-    {
-        auto dto = createShared();
-        dto->system = BulkSystemDto::CreateEmpty();
-        dto->participants = Vector<Object<BulkParticipantDto>>::createShared();
-        return dto;
-    }
+    DTO_FIELD(Vector<Object<BulkParticipantDto>>, participants) = Vector<Object<BulkParticipantDto>>::createShared();
 };
 
 class MetricDataDto : public oatpp::DTO

--- a/SilKit/source/dashboard/Dto/BulkUpdateDto.hpp
+++ b/SilKit/source/dashboard/Dto/BulkUpdateDto.hpp
@@ -133,7 +133,7 @@ class MetricDataDto : public oatpp::DTO
 
     DTO_FIELD(Int64, ts);
     DTO_FIELD(String, pn);
-    DTO_FIELD(Vector<String>, mn);
+    DTO_FIELD(Vector<String>, mn) = Vector<String>::createShared();
 };
 
 class AttributeDataDto : public MetricDataDto
@@ -154,14 +154,14 @@ class StatisticDataDto : public MetricDataDto
 {
     DTO_INIT(StatisticDataDto, MetricDataDto)
 
-    DTO_FIELD(Vector<Float64>, mv);
+    DTO_FIELD(Vector<Float64>, mv) = Vector<Float64>::createShared();
 };
 
 class StringListDataDto : public MetricDataDto
 {
     DTO_INIT(StringListDataDto, MetricDataDto)
 
-    DTO_FIELD(Vector<String>, mv);
+    DTO_FIELD(Vector<String>, mv) = Vector<String>::createShared();
 };
 
 
@@ -169,21 +169,10 @@ class MetricsUpdateDto : public oatpp::DTO
 {
     DTO_INIT(MetricsUpdateDto, oatpp::DTO)
 
-    DTO_FIELD(Vector<Object<AttributeDataDto>>, attributes);
-    DTO_FIELD(Vector<Object<CounterDataDto>>, counters);
-    DTO_FIELD(Vector<Object<StatisticDataDto>>, statistics);
-    DTO_FIELD(Vector<Object<StringListDataDto>>, stringLists);
-
-    static auto CreateEmpty() -> Wrapper
-    {
-        auto dto = createShared();
-        dto->attributes = decltype(dto->attributes)::createShared();
-        dto->counters = decltype(dto->counters)::createShared();
-        dto->statistics = decltype(dto->statistics)::createShared();
-        dto->stringLists = decltype(dto->stringLists)::createShared();
-        return dto;
-    }
-
+    DTO_FIELD(Vector<Object<AttributeDataDto>>, attributes) = Vector<Object<AttributeDataDto>>::createShared();
+    DTO_FIELD(Vector<Object<CounterDataDto>>, counters) = Vector<Object<CounterDataDto>>::createShared();
+    DTO_FIELD(Vector<Object<StatisticDataDto>>, statistics) = Vector<Object<StatisticDataDto>>::createShared();
+    DTO_FIELD(Vector<Object<StringListDataDto>>, stringLists) = Vector<Object<StringListDataDto>>::createShared();
 };
 } // namespace Dashboard
 } // namespace SilKit

--- a/SilKit/source/dashboard/Dto/BulkUpdateDto.hpp
+++ b/SilKit/source/dashboard/Dto/BulkUpdateDto.hpp
@@ -127,11 +127,12 @@ class BulkSimulationDto : public oatpp::DTO
     }
 };
 
-ENUM(MetricKind, v_int32, //
-     VALUE(Unknown, 0, "unknown"), //
-     VALUE(Counter, 10, "counter"), //
-     VALUE(Statistic, 20, "statistic"), //
-     VALUE(StringList, 30, "stringlist"))
+ENUM(MetricKind, v_int32,
+     VALUE(Unknown, 0, "unknown"),
+     VALUE(Counter, 10, "counter"),
+     VALUE(Statistic, 20, "statistic"),
+     VALUE(StringList, 30, "stringlist"),
+     VALUE(Attribute, 40, "attribute"))
 
 class MetricDataDto : public oatpp::DTO
 {

--- a/SilKit/source/dashboard/Dto/BulkUpdateDto.hpp
+++ b/SilKit/source/dashboard/Dto/BulkUpdateDto.hpp
@@ -127,13 +127,6 @@ class BulkSimulationDto : public oatpp::DTO
     }
 };
 
-ENUM(MetricKind, v_int32,
-     VALUE(Unknown, 0, "unknown"),
-     VALUE(Counter, 10, "counter"),
-     VALUE(Statistic, 20, "statistic"),
-     VALUE(StringList, 30, "stringlist"),
-     VALUE(Attribute, 40, "attribute"))
-
 class MetricDataDto : public oatpp::DTO
 {
     DTO_INIT(MetricDataDto, DTO)
@@ -141,24 +134,47 @@ class MetricDataDto : public oatpp::DTO
     DTO_FIELD(Int64, ts);
     DTO_FIELD(String, pn);
     DTO_FIELD(Vector<String>, mn);
-    DTO_FIELD(Enum<MetricKind>::AsString, mk);
+};
+
+class AttributeDataDto : public MetricDataDto
+{
+    DTO_INIT(AttributeDataDto, MetricDataDto)
+
     DTO_FIELD(String, mv);
+};
+
+class CounterDataDto : public MetricDataDto
+{
+    DTO_INIT(CounterDataDto, MetricDataDto)
+
+    DTO_FIELD(Int64, mv);
+};
+
+class StatisticDataDto : public MetricDataDto
+{
+    DTO_INIT(StatisticDataDto, MetricDataDto)
+
+    DTO_FIELD(Vector<Float64>, mv);
 };
 
 class MetricsUpdateDto : public oatpp::DTO
 {
-    DTO_INIT(MetricsUpdateDto, DTO)
+    DTO_INIT(MetricsUpdateDto, oatpp::DTO)
 
-    DTO_FIELD(Vector<Object<MetricDataDto>>, metrics);
+    DTO_FIELD(Vector<Object<AttributeDataDto>>, attributes);
+    DTO_FIELD(Vector<Object<CounterDataDto>>, counters);
+    DTO_FIELD(Vector<Object<StatisticDataDto>>, statistics);
 
     static auto CreateEmpty() -> Wrapper
     {
         auto dto = createShared();
-        dto->metrics = Vector<Object<MetricDataDto>>::createShared();
+        dto->attributes = decltype(dto->attributes)::createShared();
+        dto->counters = decltype(dto->counters)::createShared();
+        dto->statistics = decltype(dto->statistics)::createShared();
         return dto;
     }
-};
 
+};
 } // namespace Dashboard
 } // namespace SilKit
 

--- a/SilKit/source/dashboard/Dto/BulkUpdateDto.hpp
+++ b/SilKit/source/dashboard/Dto/BulkUpdateDto.hpp
@@ -157,6 +157,14 @@ class StatisticDataDto : public MetricDataDto
     DTO_FIELD(Vector<Float64>, mv);
 };
 
+class StringListDataDto : public MetricDataDto
+{
+    DTO_INIT(StringListDataDto, MetricDataDto)
+
+    DTO_FIELD(Vector<String>, mv);
+};
+
+
 class MetricsUpdateDto : public oatpp::DTO
 {
     DTO_INIT(MetricsUpdateDto, oatpp::DTO)
@@ -164,6 +172,7 @@ class MetricsUpdateDto : public oatpp::DTO
     DTO_FIELD(Vector<Object<AttributeDataDto>>, attributes);
     DTO_FIELD(Vector<Object<CounterDataDto>>, counters);
     DTO_FIELD(Vector<Object<StatisticDataDto>>, statistics);
+    DTO_FIELD(Vector<Object<StringListDataDto>>, stringLists);
 
     static auto CreateEmpty() -> Wrapper
     {
@@ -171,6 +180,7 @@ class MetricsUpdateDto : public oatpp::DTO
         dto->attributes = decltype(dto->attributes)::createShared();
         dto->counters = decltype(dto->counters)::createShared();
         dto->statistics = decltype(dto->statistics)::createShared();
+        dto->stringLists = decltype(dto->stringLists)::createShared();
         return dto;
     }
 

--- a/SilKit/source/dashboard/Dto/BulkUpdateDto.hpp
+++ b/SilKit/source/dashboard/Dto/BulkUpdateDto.hpp
@@ -140,7 +140,7 @@ class MetricDataDto : public oatpp::DTO
 
     DTO_FIELD(Int64, ts);
     DTO_FIELD(String, pn);
-    DTO_FIELD(String, mn);
+    DTO_FIELD(Vector<String>, mn);
     DTO_FIELD(Enum<MetricKind>::AsString, mk);
     DTO_FIELD(String, mv);
 };

--- a/SilKit/source/dashboard/Dto/BulkUpdateDto.hpp
+++ b/SilKit/source/dashboard/Dto/BulkUpdateDto.hpp
@@ -38,7 +38,7 @@ class BulkDataServiceDto : public oatpp::DTO
     DTO_FIELD(UInt64, id);
     DTO_FIELD(String, name);
     DTO_FIELD(String, networkName);
-    DTO_FIELD(Object<DataSpecDto>, spec);
+    DTO_FIELD(Object<DataSpecDto>, spec) = Object<DataSpecDto>::createShared();
 };
 
 class BulkRpcServiceDto : public oatpp::DTO
@@ -48,7 +48,7 @@ class BulkRpcServiceDto : public oatpp::DTO
     DTO_FIELD(UInt64, id);
     DTO_FIELD(String, name);
     DTO_FIELD(String, networkName);
-    DTO_FIELD(Object<RpcSpecDto>, spec);
+    DTO_FIELD(Object<RpcSpecDto>, spec) = Object<RpcSpecDto>::createShared();
 };
 
 class BulkServiceInternalDto : public oatpp::DTO
@@ -93,7 +93,7 @@ class BulkSimulationDto : public oatpp::DTO
     DTO_INIT(BulkSimulationDto, DTO)
 
     DTO_FIELD(Int64, stopped);
-    DTO_FIELD(Object<BulkSystemDto>, system);
+    DTO_FIELD(Object<BulkSystemDto>, system) = Object<BulkSystemDto>::createShared();
     DTO_FIELD(Vector<Object<BulkParticipantDto>>, participants) = Vector<Object<BulkParticipantDto>>::createShared();
 };
 

--- a/SilKit/source/dashboard/IntegrationTests/DashboardSystemApiController.hpp
+++ b/SilKit/source/dashboard/IntegrationTests/DashboardSystemApiController.hpp
@@ -43,6 +43,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE. */
 #include "SimulationCreationResponseDto.hpp"
 #include "SimulationEndDto.hpp"
 #include "SystemStatusDto.hpp"
+#include "BulkUpdateDto.hpp"
 
 #include "TestResult.hpp"
 
@@ -377,6 +378,24 @@ public:
         {
             _allSimulationsFinishedPromise.set_value();
         }
+        return createResponse(Status::CODE_204, "");
+    }
+    ENDPOINT("POST", "system-service/v1.1/simulations/{simulationId}", updateSimulation, PATH(UInt64, simulationId),
+             BODY_DTO(Object<BulkSimulationDto>, simulation))
+    {
+        std::this_thread::sleep_for(_updateTimeout);
+        OATPP_ASSERT_HTTP(simulationId <= _simulationId, Status::CODE_404, "simulationId not found");
+        OATPP_ASSERT_HTTP(simulation, Status::CODE_400, "simulation not set");
+        return createResponse(Status::CODE_204, "");
+    }
+
+    ENDPOINT("POST", "system-service/v1.1/simulations/{simulationId}/metrics", updateSimulationMetrics,
+             PATH(UInt64, simulationId), BODY_DTO(oatpp::Vector<Object<MetricDataDto>>, metrics))
+    {
+        std::this_thread::sleep_for(_updateTimeout);
+        OATPP_ASSERT_HTTP(simulationId <= _simulationId, Status::CODE_404, "simulationId not found");
+        OATPP_ASSERT_HTTP(metrics, Status::CODE_400, "simulation not set");
+        _data[simulationId].metricCount++;
         return createResponse(Status::CODE_204, "");
     }
 

--- a/SilKit/source/dashboard/Service/ISilKitEventHandler.hpp
+++ b/SilKit/source/dashboard/Service/ISilKitEventHandler.hpp
@@ -22,6 +22,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE. */
 #pragma once
 
 #include "DashboardBulkUpdate.hpp"
+#include "MetricsDatatypes.hpp"
 
 #include <string>
 
@@ -45,6 +46,9 @@ public:
                                          const Core::ServiceDescriptor& serviceDescriptor) = 0;
 
     virtual void OnBulkUpdate(uint64_t simulationId, const DashboardBulkUpdate& bulkUpdate) = 0;
+
+    virtual void OnMetricsUpdate(uint64_t simulationId, const std::string &origin,
+                                 const VSilKit::MetricsUpdate& metricsUpdate) = 0;
 };
 
 } // namespace Dashboard

--- a/SilKit/source/dashboard/Service/ISilKitToOatppMapper.hpp
+++ b/SilKit/source/dashboard/Service/ISilKitToOatppMapper.hpp
@@ -74,7 +74,7 @@ public:
     virtual auto CreateBulkServiceInternalDto(const ServiceDescriptor& serviceDescriptor)
         -> Object<BulkServiceInternalDto> = 0;
     virtual auto CreateBulkSimulationDto(const DashboardBulkUpdate& bulkUpdate) -> Object<BulkSimulationDto> = 0;
-    virtual auto CreateMetricsUpdateDto(const std::string origin,
+    virtual auto CreateMetricsUpdateDto(const std::string& origin,
                                         const VSilKit::MetricsUpdate& metricsUpdate) -> Object<MetricsUpdateDto> = 0;
 };
 } // namespace Dashboard

--- a/SilKit/source/dashboard/Service/ISilKitToOatppMapper.hpp
+++ b/SilKit/source/dashboard/Service/ISilKitToOatppMapper.hpp
@@ -40,6 +40,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE. */
 #include "BulkUpdateDto.hpp"
 
 #include "DashboardBulkUpdate.hpp"
+#include "MetricsDatatypes.hpp"
 
 
 namespace SilKit {
@@ -73,6 +74,8 @@ public:
     virtual auto CreateBulkServiceInternalDto(const ServiceDescriptor& serviceDescriptor)
         -> Object<BulkServiceInternalDto> = 0;
     virtual auto CreateBulkSimulationDto(const DashboardBulkUpdate& bulkUpdate) -> Object<BulkSimulationDto> = 0;
+    virtual auto CreateMetricsUpdateDto(const std::string origin,
+                                        const VSilKit::MetricsUpdate& metricsUpdate) -> Object<MetricsUpdateDto> = 0;
 };
 } // namespace Dashboard
 } // namespace SilKit

--- a/SilKit/source/dashboard/Service/Mocks/MockSilKitEventHandler.hpp
+++ b/SilKit/source/dashboard/Service/Mocks/MockSilKitEventHandler.hpp
@@ -40,6 +40,7 @@ public:
     MOCK_METHOD(void, OnServiceDiscoveryEvent,
                 (uint64_t, Core::Discovery::ServiceDiscoveryEvent::Type, const Core::ServiceDescriptor&), (override));
     MOCK_METHOD(void, OnBulkUpdate, (uint64_t, const DashboardBulkUpdate&), (override));
+    MOCK_METHOD(void, OnMetricsUpdate, (uint64_t, const std::string&, const VSilKit::MetricsUpdate&), (override));
 };
 
 } // namespace Dashboard

--- a/SilKit/source/dashboard/Service/Mocks/MockSilKitToOatppMapper.hpp
+++ b/SilKit/source/dashboard/Service/Mocks/MockSilKitToOatppMapper.hpp
@@ -57,7 +57,7 @@ public:
     MOCK_METHOD(Object<BulkRpcServiceDto>, CreateBulkRpcServiceDto, (const ServiceDescriptor&), (override));
     MOCK_METHOD(Object<BulkServiceInternalDto>, CreateBulkServiceInternalDto, (const ServiceDescriptor&), (override));
     MOCK_METHOD(Object<BulkSimulationDto>, CreateBulkSimulationDto, (const DashboardBulkUpdate&), (override));
-    MOCK_METHOD(Object<MetricsUpdateDto>, CreateMetricsUpdateDto, (const std::string, const VSilKit::MetricsUpdate&),
+    MOCK_METHOD(Object<MetricsUpdateDto>, CreateMetricsUpdateDto, (const std::string&, const VSilKit::MetricsUpdate&),
                 (override));
 };
 } // namespace Dashboard

--- a/SilKit/source/dashboard/Service/Mocks/MockSilKitToOatppMapper.hpp
+++ b/SilKit/source/dashboard/Service/Mocks/MockSilKitToOatppMapper.hpp
@@ -57,6 +57,8 @@ public:
     MOCK_METHOD(Object<BulkRpcServiceDto>, CreateBulkRpcServiceDto, (const ServiceDescriptor&), (override));
     MOCK_METHOD(Object<BulkServiceInternalDto>, CreateBulkServiceInternalDto, (const ServiceDescriptor&), (override));
     MOCK_METHOD(Object<BulkSimulationDto>, CreateBulkSimulationDto, (const DashboardBulkUpdate&), (override));
+    MOCK_METHOD(Object<MetricsUpdateDto>, CreateMetricsUpdateDto, (const std::string, const VSilKit::MetricsUpdate&),
+                (override));
 };
 } // namespace Dashboard
 } // namespace SilKit

--- a/SilKit/source/dashboard/Service/SilKitEvent.hpp
+++ b/SilKit/source/dashboard/Service/SilKitEvent.hpp
@@ -23,6 +23,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE. */
 
 #include "silkit/services/orchestration/OrchestrationDatatypes.hpp"
 #include "ServiceDatatypes.hpp"
+#include "MetricsDatatypes.hpp"
 
 namespace SilKit {
 namespace Dashboard {
@@ -51,7 +52,8 @@ enum class SilKitEventType
     OnSystemStateChanged,
     OnParticipantStatusChanged,
     OnServiceDiscoveryEvent,
-    OnSimulationEnd
+    OnSimulationEnd,
+    OnMetricUpdate,
 };
 
 template <SilKitEventType id>
@@ -69,12 +71,15 @@ struct SilKitEventTrait;
     { \
     };
 
+using MetricsUpdatePair = std::pair<std::string, VSilKit::MetricsUpdate>;
+
 SILKIT_EVENT(SimulationStart, OnSimulationStart)
 SILKIT_EVENT(Services::Orchestration::ParticipantConnectionInformation, OnParticipantConnected)
 SILKIT_EVENT(Services::Orchestration::SystemState, OnSystemStateChanged)
 SILKIT_EVENT(Services::Orchestration::ParticipantStatus, OnParticipantStatusChanged)
 SILKIT_EVENT(ServiceData, OnServiceDiscoveryEvent)
 SILKIT_EVENT(SimulationEnd, OnSimulationEnd)
+SILKIT_EVENT(MetricsUpdatePair, OnMetricUpdate)
 
 #undef SILKIT_EVENT
 
@@ -181,6 +186,11 @@ public:
     auto GetSimulationEnd() const -> const SimulationEnd&
     {
         return Get<SimulationEnd>();
+    }
+
+    auto GetMetricsUpdate() const -> const std::pair<std::string, VSilKit::MetricsUpdate>&
+    {
+        return Get<std::pair<std::string, VSilKit::MetricsUpdate>>();
     }
 
 private:

--- a/SilKit/source/dashboard/Service/SilKitEventHandler.cpp
+++ b/SilKit/source/dashboard/Service/SilKitEventHandler.cpp
@@ -111,6 +111,14 @@ void SilKitEventHandler::OnBulkUpdate(uint64_t simulationId, const DashboardBulk
                                                     _silKitToOatppMapper->CreateBulkSimulationDto(bulkUpdate));
 }
 
+void SilKitEventHandler::OnMetricsUpdate(uint64_t simulationId, const std::string& origin,
+                                         const VSilKit::MetricsUpdate& metricsUpdate)
+{
+    _dashboardSystemServiceClient->UpdateSimulationMetrics(
+        simulationId, _silKitToOatppMapper->CreateMetricsUpdateDto(origin, metricsUpdate));
+}
+
+
 void SilKitEventHandler::OnControllerCreated(uint64_t simulationId, const Core::ServiceDescriptor& serviceDescriptor)
 {
     Services::Logging::Debug(_logger, "Dashboard: adding service for simulation {} {}", simulationId,

--- a/SilKit/source/dashboard/Service/SilKitEventHandler.hpp
+++ b/SilKit/source/dashboard/Service/SilKitEventHandler.hpp
@@ -54,6 +54,9 @@ public: //methods
                                  const Core::ServiceDescriptor& serviceDescriptor) override;
     void OnBulkUpdate(uint64_t simulationId, const DashboardBulkUpdate& bulkUpdate) override;
 
+    void OnMetricsUpdate(uint64_t simulationId, const std::string& origin,
+                         const VSilKit::MetricsUpdate& metricsUpdate) override;
+
 private: //methods
     void OnControllerCreated(uint64_t simulationId, const Core::ServiceDescriptor& serviceDescriptor);
     void OnLinkCreated(uint64_t simulationId, const Core::ServiceDescriptor& serviceDescriptor);

--- a/SilKit/source/dashboard/Service/SilKitToOatppMapper.cpp
+++ b/SilKit/source/dashboard/Service/SilKitToOatppMapper.cpp
@@ -474,16 +474,16 @@ auto SilKitToOatppMapper::CreateMetricsUpdateDto(const std::string origin, const
         switch (metricData.kind)
         {
         case VSilKit::MetricKind::COUNTER:
-            dataDto->mk = "COUNTER";
+            dataDto->mk = MetricKind::Counter;
             break;
         case VSilKit::MetricKind::STATISTIC:
-            dataDto->mk = "STATISTIC";
+            dataDto->mk = MetricKind::Statistic;
             break;
         case VSilKit::MetricKind::STRING_LIST:
-            dataDto->mk = "STRING_LIST";
+            dataDto->mk = MetricKind::StringList;
             break;
         default:
-            dataDto->mk = "UNKNOWN";
+            dataDto->mk = MetricKind::Unknown;
             break;
         }
         dataDto->mv = metricData.value;

--- a/SilKit/source/dashboard/Service/SilKitToOatppMapper.cpp
+++ b/SilKit/source/dashboard/Service/SilKitToOatppMapper.cpp
@@ -471,9 +471,17 @@ auto SilKitToOatppMapper::CreateMetricsUpdateDto(const std::string origin, const
     {
         auto dataDto = MetricDataDto::createShared();
         dataDto->ts = metricData.timestamp;
-        auto&& metricNameFragments = SilKit::Util::SplitString(metricData.name, "/");
+        if(metricData.nameList.empty())
+        {
+            //backwards compatible single string for name
+            auto&& metricNameFragments = SilKit::Util::SplitString(metricData.name, "/");
+            std::copy(metricNameFragments.begin(),metricNameFragments.end(), std::back_inserter(*dataDto->mn));
+        }
+        else
+        {
+            std::copy(metricData.nameList.begin(),metricData.nameList.end(), std::back_inserter(*dataDto->mn));
+        }
 
-        std::copy(metricNameFragments.begin(),metricNameFragments.end(), std::back_inserter(*dataDto->mn));
         switch (metricData.kind)
         {
         case VSilKit::MetricKind::COUNTER:

--- a/SilKit/source/dashboard/Service/SilKitToOatppMapper.cpp
+++ b/SilKit/source/dashboard/Service/SilKitToOatppMapper.cpp
@@ -388,7 +388,7 @@ auto SilKitToOatppMapper::CreateBulkServiceInternalDto(const ServiceDescriptor& 
 
 auto SilKitToOatppMapper::CreateBulkSimulationDto(const DashboardBulkUpdate& bulkUpdate) -> Object<BulkSimulationDto>
 {
-    auto bulkSimulationDto = BulkSimulationDto::CreateEmpty();
+    auto bulkSimulationDto = BulkSimulationDto::createShared();
 
     if (bulkUpdate.stopped)
     {

--- a/SilKit/source/dashboard/Service/SilKitToOatppMapper.cpp
+++ b/SilKit/source/dashboard/Service/SilKitToOatppMapper.cpp
@@ -482,6 +482,9 @@ auto SilKitToOatppMapper::CreateMetricsUpdateDto(const std::string origin, const
         case VSilKit::MetricKind::STRING_LIST:
             dataDto->mk = MetricKind::StringList;
             break;
+        case VSilKit::MetricKind::ATTRIBUTE:
+            dataDto->mk = MetricKind::Attribute;
+            break;
         default:
             dataDto->mk = MetricKind::Unknown;
             break;

--- a/SilKit/source/dashboard/Service/SilKitToOatppMapper.cpp
+++ b/SilKit/source/dashboard/Service/SilKitToOatppMapper.cpp
@@ -406,7 +406,7 @@ auto SilKitToOatppMapper::CreateBulkSimulationDto(const DashboardBulkUpdate& bul
         auto it = nameToBulkParticipantDto.find(name);
         if (it == nameToBulkParticipantDto.end())
         {
-            auto dto = BulkParticipantDto::CreateEmpty();
+            auto dto = BulkParticipantDto::createShared();
             dto->name = name;
 
             it = nameToBulkParticipantDto.emplace(name, std::move(dto)).first;

--- a/SilKit/source/dashboard/Service/SilKitToOatppMapper.cpp
+++ b/SilKit/source/dashboard/Service/SilKitToOatppMapper.cpp
@@ -1,23 +1,6 @@
-/* Copyright (c) 2022 Vector Informatik GmbH
- 
-Permission is hereby granted, free of charge, to any person obtaining
-a copy of this software and associated documentation files (the
-"Software"), to deal in the Software without restriction, including
-without limitation the rights to use, copy, modify, merge, publish,
-distribute, sublicense, and/or sell copies of the Software, and to
-permit persons to whom the Software is furnished to do so, subject to
-the following conditions:
-
-The above copyright notice and this permission notice shall be
-included in all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
-EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
-MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
-NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
-LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
-OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
-WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE. */
+// SPDX-FileCopyrightText: 2022-2025 Vector Informatik GmbH
+//
+// SPDX-License-Identifier: MIT
 
 #include "SilKitToOatppMapper.hpp"
 
@@ -469,10 +452,11 @@ auto SilKitToOatppMapper::CreateMetricsUpdateDto(const std::string& participantN
     auto dto = MetricsUpdateDto::CreateEmpty();
     for (const auto& metricData : metricsUpdate.metrics)
     {
-        auto setValues = [&](auto&& dataDto) {
+        auto setValues = [&](auto&& dataDto, auto&& metricData) {
             dataDto->pn = participantName;
             dataDto->ts = metricData.timestamp;
-            std::copy(metricData.nameList.begin(), metricData.nameList.end(), std::back_inserter(*dataDto->mn));
+            auto&& nameList = SilKit::Util::SplitString(metricData.name, "/");
+            std::copy(nameList.begin(), nameList.end(), std::back_inserter(*dataDto->mn));
 
         };
 
@@ -481,33 +465,33 @@ auto SilKitToOatppMapper::CreateMetricsUpdateDto(const std::string& participantN
         case VSilKit::MetricKind::COUNTER:
         {
             auto dataDto = CounterDataDto::createShared();
-            setValues(dataDto);
+            setValues(dataDto, metricData);
             dto->counters->emplace_back(std::move(dataDto));
             break;
         }
         case VSilKit::MetricKind::STATISTIC:
         {
             auto dataDto = StatisticDataDto::createShared();
-            setValues(dataDto);
+            setValues(dataDto, metricData);
             dto->statistics->emplace_back(std::move(dataDto));
             break;
         }
         case VSilKit::MetricKind::ATTRIBUTE:
         {
             auto dataDto = AttributeDataDto::createShared();
-            setValues(dataDto);
+            setValues(dataDto, metricData);
             dto->attributes->emplace_back(std::move(dataDto));
             break;
         }
         case VSilKit::MetricKind::STRING_LIST:
         {
             auto dataDto = StringListDataDto::createShared();
-            setValues(dataDto);
+            setValues(dataDto, metricData);
             dto->stringLists->emplace_back(std::move(dataDto));
             break;
         }
         default:
-            assert(false);//DEBUG break
+            throw SilKit::SilKitError{"MetricsUpdate unknown MetricKind"};
             break;
         }
     }

--- a/SilKit/source/dashboard/Service/SilKitToOatppMapper.cpp
+++ b/SilKit/source/dashboard/Service/SilKitToOatppMapper.cpp
@@ -499,6 +499,13 @@ auto SilKitToOatppMapper::CreateMetricsUpdateDto(const std::string& participantN
             dto->attributes->emplace_back(std::move(dataDto));
             break;
         }
+        case VSilKit::MetricKind::STRING_LIST:
+        {
+            auto dataDto = StringListDataDto::createShared();
+            setValues(dataDto);
+            dto->stringLists->emplace_back(std::move(dataDto));
+            break;
+        }
         default:
             assert(false);//DEBUG break
             break;

--- a/SilKit/source/dashboard/Service/SilKitToOatppMapper.cpp
+++ b/SilKit/source/dashboard/Service/SilKitToOatppMapper.cpp
@@ -467,7 +467,7 @@ auto SilKitToOatppMapper::CreateMetricsUpdateDto(const std::string& participantN
         {
             auto dataDto = CounterDataDto::createShared();
             setValues(dataDto, metricData);
-            dataDto->mv = std::stoi(metricData.value);
+            dataDto->mv = objectMapper->readFromString<oatpp::Int64>(metricData.value);
             dto->counters->emplace_back(std::move(dataDto));
             break;
         }
@@ -480,19 +480,12 @@ auto SilKitToOatppMapper::CreateMetricsUpdateDto(const std::string& participantN
             break;
         }
         case VSilKit::MetricKind::ATTRIBUTE:
+        case VSilKit::MetricKind::STRING_LIST:
         {
             auto dataDto = AttributeDataDto::createShared();
             setValues(dataDto, metricData);
             dataDto->mv = metricData.value;
             dto->attributes->emplace_back(std::move(dataDto));
-            break;
-        }
-        case VSilKit::MetricKind::STRING_LIST:
-        {
-            auto dataDto = StringListDataDto::createShared();
-            setValues(dataDto, metricData);
-            dataDto->mv = objectMapper->readFromString<oatpp::Vector<oatpp::String>>(metricData.value);
-            dto->stringLists->emplace_back(std::move(dataDto));
             break;
         }
         default:

--- a/SilKit/source/dashboard/Service/SilKitToOatppMapper.cpp
+++ b/SilKit/source/dashboard/Service/SilKitToOatppMapper.cpp
@@ -22,6 +22,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE. */
 #include "SilKitToOatppMapper.hpp"
 
 #include "YamlParser.hpp"
+#include "StringHelpers.hpp"
 
 #include <string>
 #include <type_traits>
@@ -470,7 +471,9 @@ auto SilKitToOatppMapper::CreateMetricsUpdateDto(const std::string origin, const
     {
         auto dataDto = MetricDataDto::createShared();
         dataDto->ts = metricData.timestamp;
-        dataDto->mn = metricData.name;
+        auto&& metricNameFragments = SilKit::Util::SplitString(metricData.name, "/");
+
+        std::copy(metricNameFragments.begin(),metricNameFragments.end(), std::back_inserter(*dataDto->mn));
         switch (metricData.kind)
         {
         case VSilKit::MetricKind::COUNTER:

--- a/SilKit/source/dashboard/Service/SilKitToOatppMapper.cpp
+++ b/SilKit/source/dashboard/Service/SilKitToOatppMapper.cpp
@@ -462,6 +462,39 @@ auto SilKitToOatppMapper::CreateBulkSimulationDto(const DashboardBulkUpdate& bul
     return bulkSimulationDto;
 }
 
+auto SilKitToOatppMapper::CreateMetricsUpdateDto(const std::string origin, const VSilKit::MetricsUpdate& metricsUpdate)
+    -> Object<MetricsUpdateDto>
+{
+    auto dto = MetricsUpdateDto::CreateEmpty();
+    for (const auto& metricData : metricsUpdate.metrics)
+    {
+        auto dataDto = MetricDataDto::createShared();
+        dataDto->ts = metricData.timestamp;
+        dataDto->mn = metricData.name;
+        switch (metricData.kind)
+        {
+        case VSilKit::MetricKind::COUNTER:
+            dataDto->mk = "COUNTER";
+            break;
+        case VSilKit::MetricKind::STATISTIC:
+            dataDto->mk = "STATISTIC";
+            break;
+        case VSilKit::MetricKind::STRING_LIST:
+            dataDto->mk = "STRING_LIST";
+            break;
+        default:
+            dataDto->mk = "UNKNOWN";
+            break;
+        }
+        dataDto->mv = metricData.value;
+        dataDto->pn = origin;
+
+        dto->metrics->emplace_back(std::move(dataDto));
+    }
+    return dto;
+}
+
+
 // SilKitToOatppMapper Private Methods
 
 void SilKitToOatppMapper::ProcessServiceDiscovery(BulkParticipantDto& dto, const ServiceDescriptor& serviceDescriptor)

--- a/SilKit/source/dashboard/Service/SilKitToOatppMapper.cpp
+++ b/SilKit/source/dashboard/Service/SilKitToOatppMapper.cpp
@@ -449,7 +449,8 @@ auto SilKitToOatppMapper::CreateBulkSimulationDto(const DashboardBulkUpdate& bul
 auto SilKitToOatppMapper::CreateMetricsUpdateDto(const std::string& participantName, const VSilKit::MetricsUpdate& metricsUpdate)
     -> Object<MetricsUpdateDto>
 {
-    auto dto = MetricsUpdateDto::CreateEmpty();
+    auto objectMapper = oatpp::parser::json::mapping::ObjectMapper::createShared();       
+    auto dto = MetricsUpdateDto::createShared();
     for (const auto& metricData : metricsUpdate.metrics)
     {
         auto setValues = [&](auto&& dataDto, auto&& metricData) {
@@ -466,6 +467,7 @@ auto SilKitToOatppMapper::CreateMetricsUpdateDto(const std::string& participantN
         {
             auto dataDto = CounterDataDto::createShared();
             setValues(dataDto, metricData);
+            dataDto->mv = std::stoi(metricData.value);
             dto->counters->emplace_back(std::move(dataDto));
             break;
         }
@@ -473,6 +475,7 @@ auto SilKitToOatppMapper::CreateMetricsUpdateDto(const std::string& participantN
         {
             auto dataDto = StatisticDataDto::createShared();
             setValues(dataDto, metricData);
+            dataDto->mv = objectMapper->readFromString<oatpp::Vector<oatpp::Float64>>(metricData.value);
             dto->statistics->emplace_back(std::move(dataDto));
             break;
         }
@@ -480,6 +483,7 @@ auto SilKitToOatppMapper::CreateMetricsUpdateDto(const std::string& participantN
         {
             auto dataDto = AttributeDataDto::createShared();
             setValues(dataDto, metricData);
+            dataDto->mv = metricData.value;
             dto->attributes->emplace_back(std::move(dataDto));
             break;
         }
@@ -487,6 +491,7 @@ auto SilKitToOatppMapper::CreateMetricsUpdateDto(const std::string& participantN
         {
             auto dataDto = StringListDataDto::createShared();
             setValues(dataDto, metricData);
+            dataDto->mv = objectMapper->readFromString<oatpp::Vector<oatpp::String>>(metricData.value);
             dto->stringLists->emplace_back(std::move(dataDto));
             break;
         }

--- a/SilKit/source/dashboard/Service/SilKitToOatppMapper.hpp
+++ b/SilKit/source/dashboard/Service/SilKitToOatppMapper.hpp
@@ -52,7 +52,7 @@ public:
     auto CreateBulkServiceInternalDto(const ServiceDescriptor& serviceDescriptor)
         -> Object<BulkServiceInternalDto> override;
     auto CreateBulkSimulationDto(const DashboardBulkUpdate& bulkUpdate) -> Object<BulkSimulationDto> override;
-    auto CreateMetricsUpdateDto(const std::string origin,
+    auto CreateMetricsUpdateDto(const std::string& origin,
                                 const VSilKit::MetricsUpdate& metricsUpdate) -> Object<MetricsUpdateDto> override;
 
 private:

--- a/SilKit/source/dashboard/Service/SilKitToOatppMapper.hpp
+++ b/SilKit/source/dashboard/Service/SilKitToOatppMapper.hpp
@@ -52,6 +52,8 @@ public:
     auto CreateBulkServiceInternalDto(const ServiceDescriptor& serviceDescriptor)
         -> Object<BulkServiceInternalDto> override;
     auto CreateBulkSimulationDto(const DashboardBulkUpdate& bulkUpdate) -> Object<BulkSimulationDto> override;
+    auto CreateMetricsUpdateDto(const std::string origin,
+                                const VSilKit::MetricsUpdate& metricsUpdate) -> Object<MetricsUpdateDto> override;
 
 private:
     void ProcessServiceDiscovery(BulkParticipantDto& dto, const ServiceDescriptor& serviceDescriptor);

--- a/SilKit/source/dashboard/Service/Test_DashboardSilKitEventHandler.cpp
+++ b/SilKit/source/dashboard/Service/Test_DashboardSilKitEventHandler.cpp
@@ -694,7 +694,7 @@ TEST_F(Test_DashboardSilKitEventHandler, OnServiceDiscoveryEvent_Invalid_Ignore)
 TEST_F(Test_DashboardSilKitEventHandler, OnBulkUpdate)
 {
     constexpr uint64_t expectedSimulationId{123};
-    const auto expectedBulkSimulationDto = SilKit::Dashboard::BulkSimulationDto::CreateEmpty();
+    const auto expectedBulkSimulationDto = SilKit::Dashboard::BulkSimulationDto::createShared();
 
     // Arrange
     const auto service = CreateService();

--- a/SilKit/source/dashboard/TestResult.hpp
+++ b/SilKit/source/dashboard/TestResult.hpp
@@ -65,6 +65,7 @@ struct SimulationData
     std::map<std::string, std::map<uint64_t, Service>> servicesByParticipant;
     std::map<std::string, std::set<Link>> linksByParticipant;
     std::set<std::string> systemStates;
+    size_t metricCount{};
     bool stopped{false};
 };
 

--- a/SilKit/source/services/metrics/CMakeLists.txt
+++ b/SilKit/source/services/metrics/CMakeLists.txt
@@ -30,6 +30,7 @@ add_library(O_SilKit_Services_Metrics OBJECT
     MetricsTimerThread.cpp
 
     CreateMetricsSinksFromParticipantConfiguration.cpp
+
 )
 
 target_link_libraries(O_SilKit_Services_Metrics

--- a/SilKit/source/services/metrics/IAttributeMetric.hpp
+++ b/SilKit/source/services/metrics/IAttributeMetric.hpp
@@ -1,0 +1,18 @@
+// SPDX-FileCopyrightText: 2024 Vector Informatik GmbH
+//
+// SPDX-License-Identifier: MIT
+
+#pragma once
+
+#include <string>
+
+namespace VSilKit {
+
+struct IAttributeMetric
+{
+    virtual ~IAttributeMetric() = default;
+    virtual void Clear() = 0;
+    virtual void Add(const std::string& value) = 0;
+};
+
+} // namespace VSilKit

--- a/SilKit/source/services/metrics/IMetricsManager.hpp
+++ b/SilKit/source/services/metrics/IMetricsManager.hpp
@@ -4,10 +4,7 @@
 
 #pragma once
 
-#include <string>
-#include <sstream>
-#include <vector>
-#include <initializer_list>
+#include "MetricsDataTypes.hpp"
 
 namespace VSilKit {
 
@@ -16,22 +13,6 @@ struct IStatisticMetric;
 struct IStringListMetric;
 struct IAttributeMetric;
 
-using MetricName = std::initializer_list<std::string>;
-
-inline auto ToString(MetricName stringList) -> std::string
-{
-    std::stringstream ss;
-    if(stringList.size() == 1)
-    {
-        return *stringList.begin();
-    }
-
-    for (auto&& s : stringList)
-    {
-        ss << s << "/";
-    }
-    return ss.str();
-}
 
 struct IMetricsManager
 {

--- a/SilKit/source/services/metrics/IMetricsManager.hpp
+++ b/SilKit/source/services/metrics/IMetricsManager.hpp
@@ -21,6 +21,11 @@ using MetricName = std::initializer_list<std::string>;
 inline auto ToString(MetricName stringList) -> std::string
 {
     std::stringstream ss;
+    if(stringList.size() == 1)
+    {
+        return *stringList.begin();
+    }
+
     for (auto&& s : stringList)
     {
         ss << s << "/";

--- a/SilKit/source/services/metrics/IMetricsManager.hpp
+++ b/SilKit/source/services/metrics/IMetricsManager.hpp
@@ -5,6 +5,9 @@
 #pragma once
 
 #include <string>
+#include <sstream>
+#include <vector>
+#include <initializer_list>
 
 namespace VSilKit {
 
@@ -13,14 +16,28 @@ struct IStatisticMetric;
 struct IStringListMetric;
 struct IAttributeMetric;
 
+using MetricName = std::initializer_list<std::string>;
+
+inline auto ToString(MetricName stringList) -> std::string
+{
+    std::stringstream ss;
+    for (auto&& s : stringList)
+    {
+        ss << s << "/";
+    }
+    return ss.str();
+}
+
 struct IMetricsManager
 {
+
+
     virtual ~IMetricsManager() = default;
     virtual void SubmitUpdates() = 0;
-    virtual auto GetCounter(const std::string& name) -> ICounterMetric* = 0;
-    virtual auto GetStatistic(const std::string& name) -> IStatisticMetric* = 0;
-    virtual auto GetStringList(const std::string& name) -> IStringListMetric* = 0;
-    virtual auto GetAttribute(const std::string& name) -> IAttributeMetric* = 0;
+    virtual auto GetCounter(MetricName name) -> ICounterMetric* = 0;
+    virtual auto GetStatistic(MetricName name) -> IStatisticMetric* = 0;
+    virtual auto GetStringList(MetricName name) -> IStringListMetric* = 0;
+    virtual auto GetAttribute(MetricName name) -> IAttributeMetric* = 0;
 };
 
 } // namespace VSilKit

--- a/SilKit/source/services/metrics/IMetricsManager.hpp
+++ b/SilKit/source/services/metrics/IMetricsManager.hpp
@@ -35,8 +35,6 @@ inline auto ToString(MetricName stringList) -> std::string
 
 struct IMetricsManager
 {
-
-
     virtual ~IMetricsManager() = default;
     virtual void SubmitUpdates() = 0;
     virtual auto GetCounter(MetricName name) -> ICounterMetric* = 0;

--- a/SilKit/source/services/metrics/IMetricsManager.hpp
+++ b/SilKit/source/services/metrics/IMetricsManager.hpp
@@ -4,7 +4,7 @@
 
 #pragma once
 
-#include "MetricsDataTypes.hpp"
+#include "MetricsDatatypes.hpp"
 
 namespace VSilKit {
 

--- a/SilKit/source/services/metrics/IMetricsManager.hpp
+++ b/SilKit/source/services/metrics/IMetricsManager.hpp
@@ -11,6 +11,7 @@ namespace VSilKit {
 struct ICounterMetric;
 struct IStatisticMetric;
 struct IStringListMetric;
+struct IAttributeMetric;
 
 struct IMetricsManager
 {
@@ -19,6 +20,7 @@ struct IMetricsManager
     virtual auto GetCounter(const std::string& name) -> ICounterMetric* = 0;
     virtual auto GetStatistic(const std::string& name) -> IStatisticMetric* = 0;
     virtual auto GetStringList(const std::string& name) -> IStringListMetric* = 0;
+    virtual auto GetAttribute(const std::string& name) -> IAttributeMetric* = 0;
 };
 
 } // namespace VSilKit

--- a/SilKit/source/services/metrics/Metrics.hpp
+++ b/SilKit/source/services/metrics/Metrics.hpp
@@ -10,6 +10,7 @@
 #include "ICounterMetric.hpp"
 #include "IStatisticMetric.hpp"
 #include "IStringListMetric.hpp"
+#include "IAttributeMetric.hpp"
 #include "IMetricsManager.hpp"
 #include "IMetricsSender.hpp"
 #include "IMetricsProcessor.hpp"
@@ -20,6 +21,7 @@ namespace Core {
 using VSilKit::ICounterMetric;
 using VSilKit::IStatisticMetric;
 using VSilKit::IStringListMetric;
+using VSilKit::IAttributeMetric;
 using VSilKit::IMetricsManager;
 using VSilKit::IMetricsProcessor;
 using VSilKit::IMetricsSender;

--- a/SilKit/source/services/metrics/MetricsDatatypes.cpp
+++ b/SilKit/source/services/metrics/MetricsDatatypes.cpp
@@ -32,6 +32,8 @@ auto operator<<(std::ostream& os, const MetricKind& metricKind) -> std::ostream&
         return os << "MetricKind::STATISTIC";
     case MetricKind::STRING_LIST:
         return os << "MetricKind::STRING_LIST";
+    case MetricKind::ATTRIBUTE:
+        return os << "MetricKind::ATTRIBUTE";
     default:
         return os << "MetricKind(" << static_cast<std::underlying_type_t<MetricKind>>(metricKind) << ")";
     }

--- a/SilKit/source/services/metrics/MetricsDatatypes.cpp
+++ b/SilKit/source/services/metrics/MetricsDatatypes.cpp
@@ -6,10 +6,30 @@
 
 #include <ostream>
 #include <type_traits>
-
+#include <sstream>
 
 namespace VSilKit {
 
+
+auto ToString(MetricName stringList) -> std::string
+{
+    if(stringList.size() == 0)
+    {
+        return {};
+    }
+
+    auto it = stringList.begin();
+
+    std::stringstream ss;
+    ss << *it;
+
+    for (++it; it != stringList.end(); ++it)
+    {
+        ss << '/' << *it;
+    }
+
+    return ss.str();
+}
 
 auto operator==(const MetricData& lhs, const MetricData& rhs) -> bool
 {

--- a/SilKit/source/services/metrics/MetricsDatatypes.hpp
+++ b/SilKit/source/services/metrics/MetricsDatatypes.hpp
@@ -9,6 +9,8 @@
 #include <iosfwd>
 #include <string>
 #include <vector>
+#include <initializer_list>
+#include <string_view>
 
 
 namespace VSilKit {
@@ -40,6 +42,9 @@ struct MetricsUpdate
 {
     std::vector<MetricData> metrics;
 };
+
+using MetricName = std::initializer_list<std::string_view>;
+auto ToString(MetricName stringList) -> std::string;
 
 
 auto operator==(const MetricData& lhs, const MetricData& rhs) -> bool;

--- a/SilKit/source/services/metrics/MetricsDatatypes.hpp
+++ b/SilKit/source/services/metrics/MetricsDatatypes.hpp
@@ -33,7 +33,6 @@ struct MetricData
     std::string name;
     MetricKind kind;
     std::string value;
-    std::vector<std::string> nameList; // supersedes name
 };
 
 

--- a/SilKit/source/services/metrics/MetricsDatatypes.hpp
+++ b/SilKit/source/services/metrics/MetricsDatatypes.hpp
@@ -33,6 +33,7 @@ struct MetricData
     std::string name;
     MetricKind kind;
     std::string value;
+    std::vector<std::string> nameList; // supersedes name
 };
 
 

--- a/SilKit/source/services/metrics/MetricsDatatypes.hpp
+++ b/SilKit/source/services/metrics/MetricsDatatypes.hpp
@@ -23,6 +23,7 @@ enum struct MetricKind
     COUNTER,
     STATISTIC,
     STRING_LIST,
+    ATTRIBUTE,
 };
 
 

--- a/SilKit/source/services/metrics/MetricsManager.cpp
+++ b/SilKit/source/services/metrics/MetricsManager.cpp
@@ -195,22 +195,22 @@ void MetricsManager::SubmitUpdates()
 
 // IMetricsManager
 
-auto MetricsManager::GetCounter(const std::string &name) -> ICounterMetric *
+auto MetricsManager::GetCounter(MetricName name) -> ICounterMetric *
 {
     return &dynamic_cast<ICounterMetric &>(*GetOrCreateMetric(name, MetricKind::COUNTER));
 }
 
-auto MetricsManager::GetStatistic(const std::string &name) -> IStatisticMetric *
+auto MetricsManager::GetStatistic(MetricName name) -> IStatisticMetric *
 {
     return &dynamic_cast<IStatisticMetric &>(*GetOrCreateMetric(name, MetricKind::STATISTIC));
 }
 
-auto MetricsManager::GetStringList(const std::string &name) -> IStringListMetric *
+auto MetricsManager::GetStringList(MetricName name) -> IStringListMetric *
 {
     return &dynamic_cast<IStringListMetric &>(*GetOrCreateMetric(name, MetricKind::STRING_LIST));
 }
 
-auto MetricsManager::GetAttribute(const std::string& name) -> IAttributeMetric*
+auto MetricsManager::GetAttribute(MetricName name) -> IAttributeMetric*
 {
     return &dynamic_cast<IAttributeMetric&>(*GetOrCreateMetric(name, MetricKind::ATTRIBUTE));
 }
@@ -218,9 +218,10 @@ auto MetricsManager::GetAttribute(const std::string& name) -> IAttributeMetric*
 
 // MetricsManager
 
-auto MetricsManager::GetOrCreateMetric(std::string name, MetricKind kind) -> IMetric *
+auto MetricsManager::GetOrCreateMetric(MetricName nameList, MetricKind kind) -> IMetric *
 {
     std::lock_guard<decltype(_mutex)> lock{_mutex};
+    auto name = ToString(nameList);
 
     auto it = _metrics.find(name);
 

--- a/SilKit/source/services/metrics/MetricsManager.cpp
+++ b/SilKit/source/services/metrics/MetricsManager.cpp
@@ -163,11 +163,8 @@ void MetricsManager::SubmitUpdates()
             return std::chrono::duration_cast<std::chrono::nanoseconds>(timepoint.time_since_epoch()).count();
         };
 
-        for (const auto &pair : _metrics)
+        for (auto&& [name, metric] : _metrics)
         {
-            const auto &name = pair.first;
-            const auto *metric = pair.second.get();
-
             const auto timepoint = metric->GetUpdateTime();
             if (timepoint <= _lastSubmitUpdate)
             {

--- a/SilKit/source/services/metrics/MetricsManager.cpp
+++ b/SilKit/source/services/metrics/MetricsManager.cpp
@@ -117,6 +117,26 @@ private:
 };
 
 
+class MetricsManager::AttributeMetric
+    : public IAttributeMetric
+    , public IMetric
+{
+public:
+    AttributeMetric();
+
+    void Clear() override;
+    void Add(const std::string& value) override;
+
+    auto GetMetricKind() const -> MetricKind override;
+    auto GetUpdateTime() const -> MetricTimePoint override;
+    auto FormatValue() const -> std::string override;
+
+private:
+    MetricTimePoint _timestamp;
+    std::string _value;
+};
+
+
 MetricsManager::MetricsManager(std::string participantName, IMetricsProcessor &processor)
     : _participantName{std::move(participantName)}
     , _processor{&processor}
@@ -190,6 +210,11 @@ auto MetricsManager::GetStringList(const std::string &name) -> IStringListMetric
     return &dynamic_cast<IStringListMetric &>(*GetOrCreateMetric(name, MetricKind::STRING_LIST));
 }
 
+auto MetricsManager::GetAttribute(const std::string& name) -> IAttributeMetric*
+{
+    return &dynamic_cast<IAttributeMetric&>(*GetOrCreateMetric(name, MetricKind::ATTRIBUTE));
+}
+
 
 // MetricsManager
 
@@ -211,6 +236,9 @@ auto MetricsManager::GetOrCreateMetric(std::string name, MetricKind kind) -> IMe
             break;
         case MetricKind::STRING_LIST:
             it = _metrics.emplace(name, std::make_unique<StringListMetric>()).first;
+            break;
+        case MetricKind::ATTRIBUTE:
+            it = _metrics.emplace(name, std::make_unique<AttributeMetric>()).first;
             break;
         default:
             throw SilKit::SilKitError{fmt::format("Invalid MetricKind ({})", kind)};
@@ -357,6 +385,38 @@ auto MetricsManager::StringListMetric::FormatValue() const -> std::string
     }
     result.push_back(']');
     return result;
+}
+
+
+// AttributeMetric
+
+MetricsManager::AttributeMetric::AttributeMetric() = default;
+
+void MetricsManager::AttributeMetric::Clear()
+{
+    _timestamp = MetricClockNow();
+    _value.clear();
+}
+
+void MetricsManager::AttributeMetric::Add(const std::string& value)
+{
+    _timestamp = MetricClockNow();
+    _value = value;
+}
+
+auto MetricsManager::AttributeMetric::GetMetricKind() const -> MetricKind
+{
+    return MetricKind::ATTRIBUTE;
+}
+
+auto MetricsManager::AttributeMetric::GetUpdateTime() const -> MetricTimePoint
+{
+    return _timestamp;
+}
+
+auto MetricsManager::AttributeMetric::FormatValue() const -> std::string
+{
+    return _value;
 }
 
 

--- a/SilKit/source/services/metrics/MetricsManager.hpp
+++ b/SilKit/source/services/metrics/MetricsManager.hpp
@@ -56,13 +56,13 @@ public:
 
 public: // IMetricsManager
     void SubmitUpdates() override;
-    auto GetCounter(const std::string& name) -> ICounterMetric* override;
-    auto GetStatistic(const std::string& name) -> IStatisticMetric* override;
-    auto GetStringList(const std::string& name) -> IStringListMetric* override;
-    auto GetAttribute(const std::string& name) -> IAttributeMetric* override;
+    auto GetCounter(MetricName name) -> ICounterMetric* override;
+    auto GetStatistic(MetricName name) -> IStatisticMetric* override;
+    auto GetStringList(MetricName name) -> IStringListMetric* override;
+    auto GetAttribute(MetricName name) -> IAttributeMetric* override;
 
 private:
-    auto GetOrCreateMetric(std::string name, MetricKind kind) -> IMetric*;
+    auto GetOrCreateMetric(MetricName name, MetricKind kind) -> IMetric*;
 
 private:
     std::string _participantName;

--- a/SilKit/source/services/metrics/MetricsManager.hpp
+++ b/SilKit/source/services/metrics/MetricsManager.hpp
@@ -11,6 +11,7 @@
 #include "LoggerMessage.hpp"
 #include "IServiceEndpoint.hpp"
 #include "IParticipantInternal.hpp"
+#include "IAttributeMetric.hpp"
 
 #include <atomic>
 #include <chrono>
@@ -46,6 +47,7 @@ private:
     class CounterMetric;
     class StatisticMetric;
     class StringListMetric;
+    class AttributeMetric;
 
 public:
     MetricsManager(std::string participantName, IMetricsProcessor& processor);
@@ -57,6 +59,7 @@ public: // IMetricsManager
     auto GetCounter(const std::string& name) -> ICounterMetric* override;
     auto GetStatistic(const std::string& name) -> IStatisticMetric* override;
     auto GetStringList(const std::string& name) -> IStringListMetric* override;
+    auto GetAttribute(const std::string& name) -> IAttributeMetric* override;
 
 private:
     auto GetOrCreateMetric(std::string name, MetricKind kind) -> IMetric*;

--- a/SilKit/source/services/metrics/MetricsProcessor.cpp
+++ b/SilKit/source/services/metrics/MetricsProcessor.cpp
@@ -35,10 +35,8 @@ void MetricsProcessor::SetSinks(std::vector<std::unique_ptr<IMetricsSink>> sinks
 
     for (const auto &sink : _sinks)
     {
-        for (const auto &pair : _updateCache)
+        for (const auto &[origin, update] : _updateCache)
         {
-            const auto &origin = pair.first;
-            const auto &update = pair.second;
             sink->Process(origin, update);
         }
     }

--- a/SilKit/source/services/metrics/MetricsProcessor.cpp
+++ b/SilKit/source/services/metrics/MetricsProcessor.cpp
@@ -71,7 +71,8 @@ void MetricsProcessor::Process(const std::string &origin, const VSilKit::Metrics
     }
 }
 
-void MetricsProcessor::OnMetricsUpdate(const std::string &participantName, const MetricsUpdate &metricsUpdate)
+void MetricsProcessor::OnMetricsUpdate(const std::string &simulationName, const std::string &participantName,
+                                       const MetricsUpdate &metricsUpdate)
 {
     if (participantName == _participantName)
     {

--- a/SilKit/source/services/metrics/MetricsProcessor.cpp
+++ b/SilKit/source/services/metrics/MetricsProcessor.cpp
@@ -48,7 +48,7 @@ void MetricsProcessor::SetSinks(std::vector<std::unique_ptr<IMetricsSink>> sinks
     _sinksSetUp = true;
 }
 
-void MetricsProcessor::Process(const std::string &origin, const VSilKit::MetricsUpdate &metricsUpdate)
+void MetricsProcessor::Process(const std::string& origin, const VSilKit::MetricsUpdate& metricsUpdate)
 {
     if (!_sinksSetUp)
     {
@@ -71,8 +71,8 @@ void MetricsProcessor::Process(const std::string &origin, const VSilKit::Metrics
     }
 }
 
-void MetricsProcessor::OnMetricsUpdate(const std::string &simulationName, const std::string &participantName,
-                                       const MetricsUpdate &metricsUpdate)
+void MetricsProcessor::OnMetricsUpdate(const std::string& /*simulationName*/, const std::string& participantName,
+                                       const MetricsUpdate& metricsUpdate)
 {
     if (participantName == _participantName)
     {

--- a/SilKit/source/services/metrics/MetricsProcessor.hpp
+++ b/SilKit/source/services/metrics/MetricsProcessor.hpp
@@ -41,7 +41,8 @@ public: // IMetricsProcessor
     void Process(const std::string& origin, const MetricsUpdate& metricsUpdate) override;
 
 public: // IMetricsReceiverListener
-    void OnMetricsUpdate(std::string const& participantName, const MetricsUpdate& metricsUpdate) override;
+    void OnMetricsUpdate(const std::string& simulationName, const std::string& participantName,
+                         const MetricsUpdate& metricsUpdate) override;
 };
 
 } // namespace VSilKit

--- a/SilKit/source/services/metrics/MetricsReceiver.cpp
+++ b/SilKit/source/services/metrics/MetricsReceiver.cpp
@@ -29,7 +29,9 @@ void MetricsReceiver::ReceiveMsg(const SilKit::Core::IServiceEndpoint *from, con
         return;
     }
 
-    _listener->OnMetricsUpdate(from->GetServiceDescriptor().GetParticipantName(), msg);
+    const auto &serviceDescriptor = from->GetServiceDescriptor();
+
+    _listener->OnMetricsUpdate(serviceDescriptor.GetSimulationName(), serviceDescriptor.GetParticipantName(), msg);
 }
 
 

--- a/SilKit/source/services/metrics/MetricsReceiver.hpp
+++ b/SilKit/source/services/metrics/MetricsReceiver.hpp
@@ -17,7 +17,8 @@ namespace VSilKit {
 struct IMetricsReceiverListener
 {
     virtual ~IMetricsReceiverListener() = default;
-    virtual void OnMetricsUpdate(const std::string& participantName, const MetricsUpdate& metricsUpdate) = 0;
+    virtual void OnMetricsUpdate(const std::string& simulationName, const std::string& participantName,
+                                 const MetricsUpdate& metricsUpdate) = 0;
 };
 
 

--- a/SilKit/source/services/metrics/MetricsSerdes.cpp
+++ b/SilKit/source/services/metrics/MetricsSerdes.cpp
@@ -10,12 +10,17 @@ namespace VSilKit {
 
 inline auto operator<<(SilKit::Core::MessageBuffer& buffer, const MetricData& msg) -> SilKit::Core::MessageBuffer&
 {
-    return buffer << msg.timestamp << msg.name << msg.kind << msg.value;
+    return buffer << msg.timestamp << msg.name << msg.kind << msg.value << msg.nameList;
 }
 
 inline auto operator>>(SilKit::Core::MessageBuffer& buffer, MetricData& out) -> SilKit::Core::MessageBuffer&
 {
-    return buffer >> out.timestamp >> out.name >> out.kind >> out.value;
+    buffer >> out.timestamp >> out.name >> out.kind >> out.value;
+    if (buffer.RemainingBytesLeft() > 0)
+    {
+        buffer >> out.nameList;
+    }
+    return buffer;
 }
 
 

--- a/SilKit/source/services/metrics/MetricsSerdes.cpp
+++ b/SilKit/source/services/metrics/MetricsSerdes.cpp
@@ -10,16 +10,12 @@ namespace VSilKit {
 
 inline auto operator<<(SilKit::Core::MessageBuffer& buffer, const MetricData& msg) -> SilKit::Core::MessageBuffer&
 {
-    return buffer << msg.timestamp << msg.name << msg.kind << msg.value << msg.nameList;
+    return buffer << msg.timestamp << msg.name << msg.kind << msg.value;
 }
 
 inline auto operator>>(SilKit::Core::MessageBuffer& buffer, MetricData& out) -> SilKit::Core::MessageBuffer&
 {
     buffer >> out.timestamp >> out.name >> out.kind >> out.value;
-    if (buffer.RemainingBytesLeft() > 0)
-    {
-        buffer >> out.nameList;
-    }
     return buffer;
 }
 

--- a/SilKit/source/services/metrics/MetricsTimerThread.cpp
+++ b/SilKit/source/services/metrics/MetricsTimerThread.cpp
@@ -10,7 +10,6 @@ namespace VSilKit {
 
 MetricsTimerThread::MetricsTimerThread(std::chrono::seconds interval, std::function<void()> callback)
     : _callback{std::move(callback)}
-    , _interval{interval}
     , _thread{MakeThread(interval)}
 {
 }

--- a/SilKit/source/services/metrics/MetricsTimerThread.cpp
+++ b/SilKit/source/services/metrics/MetricsTimerThread.cpp
@@ -10,8 +10,8 @@ namespace VSilKit {
 
 MetricsTimerThread::MetricsTimerThread(std::chrono::seconds interval, std::function<void()> callback)
     : _callback{std::move(callback)}
-    , _thread{MakeThread()}
     , _interval{interval}
+    , _thread{MakeThread(interval)}
 {
 }
 
@@ -56,11 +56,11 @@ void MetricsTimerThread::Start()
     }
 }
 
-auto MetricsTimerThread::MakeThread() -> std::thread
+auto MetricsTimerThread::MakeThread(std::chrono::seconds interval) -> std::thread
 {
     auto go = _go.get_future();
     auto done = _done.get_future();
-    return std::thread{[go = std::move(go), done = std::move(done), callback = &_callback, timeout = _interval]() mutable {
+    return std::thread{[go = std::move(go), done = std::move(done), callback = &_callback, interval]() mutable {
         try
         {
             SilKit::Util::SetThreadName("SK Metrics");
@@ -69,7 +69,7 @@ auto MetricsTimerThread::MakeThread() -> std::thread
 
             while (true)
             {
-                if (done.wait_for(timeout) != std::future_status::timeout)
+                if (done.wait_for(interval) != std::future_status::timeout)
                 {
                     break;
                 }

--- a/SilKit/source/services/metrics/MetricsTimerThread.hpp
+++ b/SilKit/source/services/metrics/MetricsTimerThread.hpp
@@ -20,8 +20,8 @@ class MetricsTimerThread : public IMetricsTimerThread
     std::promise<void> _done;
     std::function<void()> _callback;
 
-    std::thread _thread;
     std::chrono::seconds _interval;
+    std::thread _thread;
 public:
     explicit MetricsTimerThread(std::chrono::seconds interval, std::function<void()> callback);
 
@@ -30,7 +30,7 @@ public:
     void Start() override;
 
 private:
-    auto MakeThread() -> std::thread;
+    auto MakeThread(std::chrono::seconds interval) -> std::thread;
 };
 
 } // namespace VSilKit

--- a/SilKit/source/services/metrics/MetricsTimerThread.hpp
+++ b/SilKit/source/services/metrics/MetricsTimerThread.hpp
@@ -21,9 +21,9 @@ class MetricsTimerThread : public IMetricsTimerThread
     std::function<void()> _callback;
 
     std::thread _thread;
-
+    std::chrono::seconds _interval;
 public:
-    explicit MetricsTimerThread(std::function<void()> callback);
+    explicit MetricsTimerThread(std::chrono::seconds interval, std::function<void()> callback);
 
     ~MetricsTimerThread() override;
 

--- a/SilKit/source/services/metrics/MetricsTimerThread.hpp
+++ b/SilKit/source/services/metrics/MetricsTimerThread.hpp
@@ -20,7 +20,6 @@ class MetricsTimerThread : public IMetricsTimerThread
     std::promise<void> _done;
     std::function<void()> _callback;
 
-    std::chrono::seconds _interval;
     std::thread _thread;
 public:
     explicit MetricsTimerThread(std::chrono::seconds interval, std::function<void()> callback);

--- a/SilKit/source/services/metrics/Test_MetricsJsonSink.cpp
+++ b/SilKit/source/services/metrics/Test_MetricsJsonSink.cpp
@@ -83,9 +83,9 @@ TEST(Test_MetricsJsonSink, test_json_escaping_and_structure)
     const std::string mv3{fmt::format(R"(["{}","{}"])", EscapeString(mv3a), EscapeString(mv3b))};
 
     MetricsUpdate update;
-    update.metrics.emplace_back(MetricData{ts1, mn1, mk1, mv1});
-    update.metrics.emplace_back(MetricData{ts2, mn2, mk2, mv2});
-    update.metrics.emplace_back(MetricData{ts3, mn3, mk3, mv3});
+    update.metrics.emplace_back(MetricData{ts1, mn1, mk1, mv1, {}});
+    update.metrics.emplace_back(MetricData{ts2, mn2, mk2, mv2, {}});
+    update.metrics.emplace_back(MetricData{ts3, mn3, mk3, mv3, {}});
 
     auto ownedOstream = std::make_unique<std::ostringstream>();
     auto& ostream = *ownedOstream;

--- a/SilKit/source/services/metrics/Test_MetricsJsonSink.cpp
+++ b/SilKit/source/services/metrics/Test_MetricsJsonSink.cpp
@@ -83,9 +83,9 @@ TEST(Test_MetricsJsonSink, test_json_escaping_and_structure)
     const std::string mv3{fmt::format(R"(["{}","{}"])", EscapeString(mv3a), EscapeString(mv3b))};
 
     MetricsUpdate update;
-    update.metrics.emplace_back(MetricData{ts1, mn1, mk1, mv1, {}});
-    update.metrics.emplace_back(MetricData{ts2, mn2, mk2, mv2, {}});
-    update.metrics.emplace_back(MetricData{ts3, mn3, mk3, mv3, {}});
+    update.metrics.emplace_back(MetricData{ts1, mn1, mk1, mv1, });
+    update.metrics.emplace_back(MetricData{ts2, mn2, mk2, mv2, });
+    update.metrics.emplace_back(MetricData{ts3, mn3, mk3, mv3, });
 
     auto ownedOstream = std::make_unique<std::ostringstream>();
     auto& ostream = *ownedOstream;

--- a/SilKit/source/services/metrics/Test_MetricsManager.cpp
+++ b/SilKit/source/services/metrics/Test_MetricsManager.cpp
@@ -119,4 +119,31 @@ TEST(Test_MetricsManager, string_list_metric_create_and_update_only_submits_afte
 }
 
 
+TEST(Test_MetricsManager, attribute_metric_create_and_update_only_submits_after_change)
+{
+    const std::string participantName{"Participant Name"};
+    const std::string metricName{"Attribute Metric"};
+
+    MetricsUpdate metricsUpdate;
+    metricsUpdate.metrics.emplace_back(MetricData{});
+
+    MockMetricsProcessor mockMetricsProcessor;
+    EXPECT_CALL(mockMetricsProcessor, Process(participantName, MetricsUpdateWithSingleMetricWithNameAndKind(
+                                                                   metricName, MetricKind::ATTRIBUTE)))
+        .Times(1);
+
+    MetricsManager metricsManager{participantName, mockMetricsProcessor};
+    // no metrics to report, no Process call should be made
+    metricsManager.SubmitUpdates();
+
+    auto metric = metricsManager.GetAttribute(metricName);
+    // no metric value to report, no Process call should be made
+    metricsManager.SubmitUpdates();
+
+    metric->Add("AttributeValue");
+    // metric value to report, single Process call
+    metricsManager.SubmitUpdates();
+}
+
+
 } // anonymous namespace

--- a/SilKit/source/services/metrics/Test_MetricsManager.cpp
+++ b/SilKit/source/services/metrics/Test_MetricsManager.cpp
@@ -16,6 +16,8 @@ namespace {
 using VSilKit::MetricData;
 using VSilKit::MetricKind;
 using VSilKit::MetricsManager;
+using VSilKit::MetricName;
+using VSilKit::ToString;
 using VSilKit::MetricsUpdate;
 using VSilKit::IMetricsProcessor;
 
@@ -29,7 +31,7 @@ struct MockMetricsProcessor : IMetricsProcessor
 
 MATCHER_P2(MetricDataWithNameAndKind, metricName, metricKind, "")
 {
-    return arg.name == metricName && arg.kind == metricKind;
+    return arg.name == ToString(metricName) && arg.kind == metricKind;
 }
 
 MATCHER_P2(MetricsUpdateWithSingleMetricWithNameAndKind, metricName, metricKind, "")
@@ -41,7 +43,7 @@ MATCHER_P2(MetricsUpdateWithSingleMetricWithNameAndKind, metricName, metricKind,
 TEST(Test_MetricsManager, counter_metric_create_and_update_only_submits_after_change)
 {
     const std::string participantName{"Participant Name"};
-    const std::string metricName{"Counter Metric"};
+    const MetricName metricName{"Counter Metric"};
 
     MetricsUpdate metricsUpdate;
     metricsUpdate.metrics.emplace_back(MetricData{});
@@ -68,7 +70,7 @@ TEST(Test_MetricsManager, counter_metric_create_and_update_only_submits_after_ch
 TEST(Test_MetricsManager, statistic_metric_create_and_update_only_submits_after_change)
 {
     const std::string participantName{"Participant Name"};
-    const std::string metricName{"Statistic Metric"};
+    const MetricName metricName{"Statistic Metric"};
 
     MetricsUpdate metricsUpdate;
     metricsUpdate.metrics.emplace_back(MetricData{});
@@ -95,7 +97,7 @@ TEST(Test_MetricsManager, statistic_metric_create_and_update_only_submits_after_
 TEST(Test_MetricsManager, string_list_metric_create_and_update_only_submits_after_change)
 {
     const std::string participantName{"Participant Name"};
-    const std::string metricName{"String-List Metric"};
+    const MetricName metricName{"String-List Metric"};
 
     MetricsUpdate metricsUpdate;
     metricsUpdate.metrics.emplace_back(MetricData{});
@@ -122,7 +124,7 @@ TEST(Test_MetricsManager, string_list_metric_create_and_update_only_submits_afte
 TEST(Test_MetricsManager, attribute_metric_create_and_update_only_submits_after_change)
 {
     const std::string participantName{"Participant Name"};
-    const std::string metricName{"Attribute Metric"};
+    const MetricName metricName{"Attribute Metric"};
 
     MetricsUpdate metricsUpdate;
     metricsUpdate.metrics.emplace_back(MetricData{});

--- a/SilKit/source/services/metrics/Test_MetricsProcessor.cpp
+++ b/SilKit/source/services/metrics/Test_MetricsProcessor.cpp
@@ -40,10 +40,10 @@ TEST(Test_MetricsProcessor, metrics_are_cached_until_sinks_are_set)
     const std::string participantName{"Participant Name"};
 
     MetricsUpdate updateOne;
-    updateOne.metrics.emplace_back(MetricData{1, "1", MetricKind::COUNTER, "1"});
+    updateOne.metrics.emplace_back(MetricData{1, "1", MetricKind::COUNTER, "1", {}});
 
     MetricsUpdate updateTwo;
-    updateTwo.metrics.emplace_back(MetricData{2, "2", MetricKind::COUNTER, "2"});
+    updateTwo.metrics.emplace_back(MetricData{2, "2", MetricKind::COUNTER, "2", {}});
 
     std::vector<MetricData> metrics;
     std::copy(updateOne.metrics.begin(), updateOne.metrics.end(), std::back_inserter(metrics));
@@ -70,16 +70,16 @@ TEST(Test_MetricsProcessor, metrics_are_cached_until_sinks_are_set_per_origin)
     const std::string updateTwoOrigin{"Two"};
 
     MetricsUpdate updateOneA;
-    updateOneA.metrics.emplace_back(MetricData{1, "1A", MetricKind::COUNTER, "1"});
+    updateOneA.metrics.emplace_back(MetricData{1, "1A", MetricKind::COUNTER, "1", {"1"}});
 
     MetricsUpdate updateOneB;
-    updateOneB.metrics.emplace_back(MetricData{2, "1B", MetricKind::COUNTER, "1"});
+    updateOneB.metrics.emplace_back(MetricData{2, "1B", MetricKind::COUNTER, "1", {"1"}});
 
     MetricsUpdate updateTwoA;
-    updateTwoA.metrics.emplace_back(MetricData{2, "2", MetricKind::COUNTER, "2"});
+    updateTwoA.metrics.emplace_back(MetricData{2, "2", MetricKind::COUNTER, "2", {"1"}});
 
     MetricsUpdate updateTwoB;
-    updateTwoB.metrics.emplace_back(MetricData{2, "2", MetricKind::COUNTER, "2"});
+    updateTwoB.metrics.emplace_back(MetricData{2, "2", MetricKind::COUNTER, "2", {"1"}});
 
     std::vector<MetricData> metricsOne;
     std::copy(updateOneA.metrics.begin(), updateOneA.metrics.end(), std::back_inserter(metricsOne));
@@ -111,10 +111,10 @@ TEST(Test_MetricsProcessor, metrics_are_processed_directly_after_sinks_are_set)
     const std::string participantName{"Participant Name"};
 
     MetricsUpdate updateOne;
-    updateOne.metrics.emplace_back(MetricData{1, "1", MetricKind::COUNTER, "1"});
+    updateOne.metrics.emplace_back(MetricData{1, "1", MetricKind::COUNTER, "1", {"1", "1.1"}});
 
     MetricsUpdate updateTwo;
-    updateTwo.metrics.emplace_back(MetricData{2, "2", MetricKind::COUNTER, "2"});
+    updateTwo.metrics.emplace_back(MetricData{2, "2", MetricKind::COUNTER, "2", {"2", "2.1"}});
 
     std::vector<std::unique_ptr<IMetricsSink>> sinks;
     sinks.emplace_back(std::make_unique<MockMetricsSink>());
@@ -137,10 +137,10 @@ TEST(Test_MetricsProcessor, receive_handler_ignores_metrics_from_own_participant
     const std::string participantName{"Participant Name"};
 
     MetricsUpdate updateOne;
-    updateOne.metrics.emplace_back(MetricData{1, "1", MetricKind::COUNTER, "1"});
+    updateOne.metrics.emplace_back(MetricData{1, "1", MetricKind::COUNTER, "1", {"1","1.1"}});
 
     MetricsUpdate updateTwo;
-    updateTwo.metrics.emplace_back(MetricData{2, "2", MetricKind::COUNTER, "2"});
+    updateTwo.metrics.emplace_back(MetricData{2, "2", MetricKind::COUNTER, "2", {"2", "2.1"}});
 
     std::vector<std::unique_ptr<IMetricsSink>> sinks;
     sinks.emplace_back(std::make_unique<MockMetricsSink>());

--- a/SilKit/source/services/metrics/Test_MetricsProcessor.cpp
+++ b/SilKit/source/services/metrics/Test_MetricsProcessor.cpp
@@ -133,6 +133,7 @@ TEST(Test_MetricsProcessor, metrics_are_processed_directly_after_sinks_are_set)
 
 TEST(Test_MetricsProcessor, receive_handler_ignores_metrics_from_own_participant)
 {
+    const std::string simulationName{"Simulation Name"};
     const std::string participantName{"Participant Name"};
 
     MetricsUpdate updateOne;
@@ -152,7 +153,7 @@ TEST(Test_MetricsProcessor, receive_handler_ignores_metrics_from_own_participant
     MetricsProcessor processor{participantName};
     processor.SetSinks(std::move(sinks));
     processor.Process(participantName, updateOne);
-    processor.OnMetricsUpdate(participantName, updateTwo);
+    processor.OnMetricsUpdate(simulationName, participantName, updateTwo);
 }
 
 

--- a/SilKit/source/services/metrics/Test_MetricsProcessor.cpp
+++ b/SilKit/source/services/metrics/Test_MetricsProcessor.cpp
@@ -40,10 +40,10 @@ TEST(Test_MetricsProcessor, metrics_are_cached_until_sinks_are_set)
     const std::string participantName{"Participant Name"};
 
     MetricsUpdate updateOne;
-    updateOne.metrics.emplace_back(MetricData{1, "1", MetricKind::COUNTER, "1", {}});
+    updateOne.metrics.emplace_back(MetricData{1, "1", MetricKind::COUNTER, "1"});
 
     MetricsUpdate updateTwo;
-    updateTwo.metrics.emplace_back(MetricData{2, "2", MetricKind::COUNTER, "2", {}});
+    updateTwo.metrics.emplace_back(MetricData{2, "2", MetricKind::COUNTER, "2"});
 
     std::vector<MetricData> metrics;
     std::copy(updateOne.metrics.begin(), updateOne.metrics.end(), std::back_inserter(metrics));
@@ -70,16 +70,16 @@ TEST(Test_MetricsProcessor, metrics_are_cached_until_sinks_are_set_per_origin)
     const std::string updateTwoOrigin{"Two"};
 
     MetricsUpdate updateOneA;
-    updateOneA.metrics.emplace_back(MetricData{1, "1A", MetricKind::COUNTER, "1", {"1"}});
+    updateOneA.metrics.emplace_back(MetricData{1, "1A", MetricKind::COUNTER, "1"});
 
     MetricsUpdate updateOneB;
-    updateOneB.metrics.emplace_back(MetricData{2, "1B", MetricKind::COUNTER, "1", {"1"}});
+    updateOneB.metrics.emplace_back(MetricData{2, "1B", MetricKind::COUNTER, "1"});
 
     MetricsUpdate updateTwoA;
-    updateTwoA.metrics.emplace_back(MetricData{2, "2", MetricKind::COUNTER, "2", {"1"}});
+    updateTwoA.metrics.emplace_back(MetricData{2, "2", MetricKind::COUNTER, "2"});
 
     MetricsUpdate updateTwoB;
-    updateTwoB.metrics.emplace_back(MetricData{2, "2", MetricKind::COUNTER, "2", {"1"}});
+    updateTwoB.metrics.emplace_back(MetricData{2, "2", MetricKind::COUNTER, "2"});
 
     std::vector<MetricData> metricsOne;
     std::copy(updateOneA.metrics.begin(), updateOneA.metrics.end(), std::back_inserter(metricsOne));
@@ -111,10 +111,10 @@ TEST(Test_MetricsProcessor, metrics_are_processed_directly_after_sinks_are_set)
     const std::string participantName{"Participant Name"};
 
     MetricsUpdate updateOne;
-    updateOne.metrics.emplace_back(MetricData{1, "1", MetricKind::COUNTER, "1", {"1", "1.1"}});
+    updateOne.metrics.emplace_back(MetricData{1, "1", MetricKind::COUNTER, "1"});
 
     MetricsUpdate updateTwo;
-    updateTwo.metrics.emplace_back(MetricData{2, "2", MetricKind::COUNTER, "2", {"2", "2.1"}});
+    updateTwo.metrics.emplace_back(MetricData{2, "2", MetricKind::COUNTER, "2"});
 
     std::vector<std::unique_ptr<IMetricsSink>> sinks;
     sinks.emplace_back(std::make_unique<MockMetricsSink>());
@@ -137,10 +137,10 @@ TEST(Test_MetricsProcessor, receive_handler_ignores_metrics_from_own_participant
     const std::string participantName{"Participant Name"};
 
     MetricsUpdate updateOne;
-    updateOne.metrics.emplace_back(MetricData{1, "1", MetricKind::COUNTER, "1", {"1","1.1"}});
+    updateOne.metrics.emplace_back(MetricData{1, "1", MetricKind::COUNTER, "1"});
 
     MetricsUpdate updateTwo;
-    updateTwo.metrics.emplace_back(MetricData{2, "2", MetricKind::COUNTER, "2", {"2", "2.1"}});
+    updateTwo.metrics.emplace_back(MetricData{2, "2", MetricKind::COUNTER, "2"});
 
     std::vector<std::unique_ptr<IMetricsSink>> sinks;
     sinks.emplace_back(std::make_unique<MockMetricsSink>());

--- a/SilKit/source/services/metrics/Test_MetricsRemoteSink.cpp
+++ b/SilKit/source/services/metrics/Test_MetricsRemoteSink.cpp
@@ -32,10 +32,10 @@ TEST(Test_MetricsRemoteSink, test_forward_to_sender_only_if_local_origin)
     const std::string otherOrigin{"Another Participant Name"};
 
     MetricsUpdate updateOne;
-    updateOne.metrics.emplace_back(MetricData{1, "One", MetricKind::COUNTER, "1"});
+    updateOne.metrics.emplace_back(MetricData{1, "One", MetricKind::COUNTER, "1", {"1"}});
 
     MetricsUpdate updateTwo;
-    updateTwo.metrics.emplace_back(MetricData{2, "Two", MetricKind::COUNTER, "2"});
+    updateTwo.metrics.emplace_back(MetricData{2, "Two", MetricKind::COUNTER, "2", {"2"}});
 
     MockMetricsSender sender;
 

--- a/SilKit/source/services/metrics/Test_MetricsRemoteSink.cpp
+++ b/SilKit/source/services/metrics/Test_MetricsRemoteSink.cpp
@@ -32,10 +32,10 @@ TEST(Test_MetricsRemoteSink, test_forward_to_sender_only_if_local_origin)
     const std::string otherOrigin{"Another Participant Name"};
 
     MetricsUpdate updateOne;
-    updateOne.metrics.emplace_back(MetricData{1, "One", MetricKind::COUNTER, "1", {"1"}});
+    updateOne.metrics.emplace_back(MetricData{1, "One", MetricKind::COUNTER, "1"});
 
     MetricsUpdate updateTwo;
-    updateTwo.metrics.emplace_back(MetricData{2, "Two", MetricKind::COUNTER, "2", {"2"}});
+    updateTwo.metrics.emplace_back(MetricData{2, "Two", MetricKind::COUNTER, "2"});
 
     MockMetricsSender sender;
 

--- a/SilKit/source/services/metrics/Test_MetricsSerdes.cpp
+++ b/SilKit/source/services/metrics/Test_MetricsSerdes.cpp
@@ -21,9 +21,9 @@ using testing::ContainerEq;
 TEST(Test_MetricsSerdes, serialize_deserialize_roundtrip)
 {
     MetricsUpdate original;
-    original.metrics.emplace_back(MetricData{1, "1", MetricKind::COUNTER, "1"});
-    original.metrics.emplace_back(MetricData{2, "2", MetricKind::STATISTIC, "[1,2,3,4]"});
-    original.metrics.emplace_back(MetricData{3, "3", MetricKind::STRING_LIST, R"(["1","2","3","4"])"});
+    original.metrics.emplace_back(MetricData{1, "1", MetricKind::COUNTER, "1", {}});
+    original.metrics.emplace_back(MetricData{2, "2", MetricKind::STATISTIC, "[1,2,3,4]", {}});
+    original.metrics.emplace_back(MetricData{3, "3", MetricKind::STRING_LIST, R"(["1","2","3","4"])", {}});
 
     SilKit::Core::MessageBuffer buffer;
     VSilKit::Serialize(buffer, original);

--- a/SilKit/source/services/metrics/Test_MetricsSerdes.cpp
+++ b/SilKit/source/services/metrics/Test_MetricsSerdes.cpp
@@ -21,9 +21,9 @@ using testing::ContainerEq;
 TEST(Test_MetricsSerdes, serialize_deserialize_roundtrip)
 {
     MetricsUpdate original;
-    original.metrics.emplace_back(MetricData{1, "1", MetricKind::COUNTER, "1", {}});
-    original.metrics.emplace_back(MetricData{2, "2", MetricKind::STATISTIC, "[1,2,3,4]", {}});
-    original.metrics.emplace_back(MetricData{3, "3", MetricKind::STRING_LIST, R"(["1","2","3","4"])", {}});
+    original.metrics.emplace_back(MetricData{1, "1", MetricKind::COUNTER, "1"});
+    original.metrics.emplace_back(MetricData{2, "2", MetricKind::STATISTIC, "[1,2,3,4]"});
+    original.metrics.emplace_back(MetricData{3, "3", MetricKind::STRING_LIST, R"(["1","2","3","4"])"});
 
     SilKit::Core::MessageBuffer buffer;
     VSilKit::Serialize(buffer, original);

--- a/SilKit/source/services/orchestration/TimeSyncService.cpp
+++ b/SilKit/source/services/orchestration/TimeSyncService.cpp
@@ -310,11 +310,12 @@ TimeSyncService::TimeSyncService(Core::IParticipantInternal* participant, ITimeP
     , _logger{participant->GetLoggerInternal()}
     , _timeProvider{timeProvider}
     , _timeConfiguration{participant->GetLoggerInternal()}
-    , _simStepCounterMetric{participant->GetMetricsManager()->GetCounter("SimStepCount")}
+    , _simStepCounterMetric{participant->GetMetricsManager()->GetCounter({"SimStepCount"})}
     , _simStepHandlerExecutionTimeStatisticMetric{participant->GetMetricsManager()->GetStatistic(
-          "SimStepHandlerExecutionDuration")}
-    , _simStepCompletionTimeStatisticMetric{participant->GetMetricsManager()->GetStatistic("SimStepCompletionDuration")}
-    , _simStepWaitingTimeStatisticMetric{participant->GetMetricsManager()->GetStatistic("SimStepWaitingDuration")}
+          {"SimStepHandlerExecutionDuration"})}
+    , _simStepCompletionTimeStatisticMetric{participant->GetMetricsManager()->GetStatistic(
+          {"SimStepCompletionDuration"})}
+    , _simStepWaitingTimeStatisticMetric{participant->GetMetricsManager()->GetStatistic({"SimStepWaitingDuration"})}
     , _watchDog{healthCheckConfig}
     , _animationFactor{animationFactor}
 {

--- a/SilKit/source/util/StringHelpers.cpp
+++ b/SilKit/source/util/StringHelpers.cpp
@@ -141,5 +141,20 @@ auto PrintableString(const std::string& participantName) -> std::string
     return safeName;
 }
 
+auto SplitString(std::string input, const std::string& separator)  -> std::vector<std::string>
+{
+    std::vector<std::string> tokens;
+    for (auto i = input.find(separator); i != input.npos; i = input.find(separator))
+    {
+        tokens.emplace_back(input.substr(0, i));
+        input = input.substr(i + 1);
+    }
+    if (!input.empty())
+    {
+        tokens.emplace_back(std::move(input));
+    }
+    return tokens;
+}
+
 } // namespace Util
 } // namespace SilKit

--- a/SilKit/source/util/StringHelpers.cpp
+++ b/SilKit/source/util/StringHelpers.cpp
@@ -141,7 +141,7 @@ auto PrintableString(const std::string& participantName) -> std::string
     return safeName;
 }
 
-auto SplitString(std::string input, const std::string& separator)  -> std::vector<std::string>
+auto SplitString(std::string_view input, const std::string_view& separator)  -> std::vector<std::string>
 {
     std::vector<std::string> tokens;
     for (auto i = input.find(separator); i != input.npos; i = input.find(separator))

--- a/SilKit/source/util/StringHelpers.hpp
+++ b/SilKit/source/util/StringHelpers.hpp
@@ -1,27 +1,11 @@
-// Copyright (c) 2024 Vector Informatik GmbH
+// SPDX-FileCopyrightText: 2023-2024 Vector Informatik GmbH
 //
-// Permission is hereby granted, free of charge, to any person obtaining
-// a copy of this software and associated documentation files (the
-// "Software"), to deal in the Software without restriction, including
-// without limitation the rights to use, copy, modify, merge, publish,
-// distribute, sublicense, and/or sell copies of the Software, and to
-// permit persons to whom the Software is furnished to do so, subject to
-// the following conditions:
-//
-// The above copyright notice and this permission notice shall be
-// included in all copies or substantial portions of the Software.
-//
-// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
-// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
-// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
-// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
-// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
-// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
-// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// SPDX-License-Identifier: MIT
 
 #pragma once
 
 #include <string>
+#include <string_view>
 #include <vector>
 
 
@@ -44,7 +28,7 @@ auto LowerCase(std::string input) -> std::string;
 
 auto PrintableString(const std::string& input) -> std::string;
 
-auto SplitString(std::string input, const std::string& separator)  -> std::vector<std::string>;
+auto SplitString(std::string_view input, const std::string_view& separator)  -> std::vector<std::string>;
 
 } // namespace Util
 } // namespace SilKit

--- a/SilKit/source/util/StringHelpers.hpp
+++ b/SilKit/source/util/StringHelpers.hpp
@@ -22,6 +22,7 @@
 #pragma once
 
 #include <string>
+#include <vector>
 
 
 namespace SilKit {
@@ -43,6 +44,7 @@ auto LowerCase(std::string input) -> std::string;
 
 auto PrintableString(const std::string& input) -> std::string;
 
+auto SplitString(std::string input, const std::string& separator)  -> std::vector<std::string>;
 
 } // namespace Util
 } // namespace SilKit


### PR DESCRIPTION
This PR extends the work done in #92 and #199.
Outline:
- add "Attribute" metric, which is constant
- add metrics for bytes transferred, transmit queue size and messages transfered
- make the metric name a list of strings, or as fallback, split a single string using the `/` separator into a list

TODO: automated testing proved difficult, I'm still investigating.