### PR TITLE
config: add export final participant configuration as string

### DIFF
--- a/Demos/communication/include/ApplicationBase.hpp
+++ b/Demos/communication/include/ApplicationBase.hpp
@@ -517,6 +517,7 @@ private:
         _participant =
             SilKit::CreateParticipant(_participantConfiguration, _arguments.participantName, _arguments.registryUri);
         _systemMonitor = _participant->CreateSystemMonitor();
+        (void)SilKit::Config::ParticipantConfigurationToString(_participantConfiguration);
     }
 
     void SetupLifecycle()

--- a/SilKit/include/silkit/capi/SilKit.h
+++ b/SilKit/include/silkit/capi/SilKit.h
@@ -104,4 +104,14 @@ typedef SilKit_ReturnCode(SilKitFPTR* SilKit_ParticipantConfiguration_Destroy_t)
     SilKit_ParticipantConfiguration* participantConfiguration);
 
 
+/*! \brief Return a JSON-string of the complete parsed participant configuration.
+*  \param outputJsonString the JSON string of the configuration. When this is NULL outputSize will contain the required size for the JSON string.
+*  \param outputSize the size of the outputJsonString is stored here. Can be called with outputJsonString set to NULL to get the required size.
+*/
+SilKitAPI SilKit_ReturnCode SilKitCALL SilKit_ParticipantConfiguration_ToString(
+    const SilKit_ParticipantConfiguration* outParticipantConfiguration, char** outputJsonString, size_t* outputSize);
+
+typedef SilKit_ReturnCode(SilKitFPTR* SilKit_ParticipantConfiguration_ToString_t)(
+    const SilKit_ParticipantConfiguration* outParticipantConfiguration, char** outputJsonString, size_t* outputSize);
+
 SILKIT_END_DECLS

--- a/SilKit/include/silkit/config/IParticipantConfiguration.hpp
+++ b/SilKit/include/silkit/config/IParticipantConfiguration.hpp
@@ -73,6 +73,9 @@ DETAIL_SILKIT_CPP_API auto ParticipantConfigurationFromString(const std::string&
 DETAIL_SILKIT_CPP_API auto ParticipantConfigurationFromFile(const std::string& filename)
     -> std::shared_ptr<SilKit::Config::IParticipantConfiguration>;
 
+DETAIL_SILKIT_CPP_API auto ParticipantConfigurationToString(
+    std::shared_ptr<SilKit::Config::IParticipantConfiguration> config) -> std::string;
+
 } // namespace Config
 DETAIL_SILKIT_DETAIL_VN_NAMESPACE_CLOSE
 } // namespace SilKit

--- a/SilKit/include/silkit/detail/impl/config/IParticipantConfiguration.ipp
+++ b/SilKit/include/silkit/detail/impl/config/IParticipantConfiguration.ipp
@@ -26,6 +26,9 @@
 #include "silkit/detail/impl/ThrowOnError.hpp"
 #include "silkit/detail/impl/config/ParticipantConfiguration.hpp"
 
+#include <string>
+#include <vector>
+
 namespace SilKit {
 DETAIL_SILKIT_DETAIL_VN_NAMESPACE_BEGIN
 namespace Config {
@@ -52,6 +55,25 @@ auto ParticipantConfigurationFromFile(const std::string& path)
     return std::make_shared<Impl::Config::ParticipantConfiguration>(participantConfiguration);
 }
 
+auto ParticipantConfigurationToString(std::shared_ptr<SilKit::Config::IParticipantConfiguration> config) -> std::string
+{
+    size_t size{};
+    auto&& concreteConfig = std::dynamic_pointer_cast<Impl::Config::ParticipantConfiguration>(config);
+    SilKit_ParticipantConfiguration_ToString(concreteConfig->Get(), nullptr, &size);
+
+    std::vector<char> buffer;
+    if( size > 0)
+    {
+        buffer.resize(size);
+        //C++17 std::string::data() -> char*;
+        auto&& data = buffer.data();
+        SilKit_ParticipantConfiguration_ToString(concreteConfig->Get(), &data, &size);
+
+    }
+    return {buffer.data(), buffer.size()};
+}
+
+
 } // namespace Config
 DETAIL_SILKIT_DETAIL_VN_NAMESPACE_CLOSE
 } // namespace SilKit
@@ -61,5 +83,6 @@ namespace SilKit {
 namespace Config {
 using SilKit::DETAIL_SILKIT_DETAIL_NAMESPACE_NAME::Config::ParticipantConfigurationFromString;
 using SilKit::DETAIL_SILKIT_DETAIL_NAMESPACE_NAME::Config::ParticipantConfigurationFromFile;
+using SilKit::DETAIL_SILKIT_DETAIL_NAMESPACE_NAME::Config::ParticipantConfigurationToString;
 } // namespace Config
 } // namespace SilKit

--- a/SilKit/source/capi/CapiParticipant.cpp
+++ b/SilKit/source/capi/CapiParticipant.cpp
@@ -174,7 +174,6 @@ try
     {
         std::copy(std::cbegin(jsonString), std::cend(jsonString), *outputString);
     }
-    // since it is not possible to release the "raw" pointer from a shared_ptr, we copy it into our own raw pointer
 
     return SilKit_ReturnCode_SUCCESS;
 }

--- a/SilKit/source/capi/CapiParticipant.cpp
+++ b/SilKit/source/capi/CapiParticipant.cpp
@@ -22,6 +22,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE. */
 #include "ParticipantConfiguration.hpp"
 #include "ParticipantConfigurationFromXImpl.hpp"
 #include "CreateParticipantImpl.hpp"
+#include "YamlParser.hpp"
 
 #include "silkit/capi/SilKit.h"
 #include "silkit/SilKit.hpp"
@@ -154,6 +155,30 @@ try
 }
 CAPI_CATCH_EXCEPTIONS
 
+
+SilKit_ReturnCode SilKitCALL SilKit_ParticipantConfiguration_ToString(
+    const SilKit_ParticipantConfiguration* participantConfiguration, char** outputString, size_t* requiredSize)
+try
+{
+    ASSERT_VALID_OUT_PARAMETER(participantConfiguration);
+    ASSERT_VALID_POINTER_PARAMETER(requiredSize);
+    //outputString may be NULL
+
+    auto* cppParticipantConfiguration =
+        reinterpret_cast<const SilKit::Config::ParticipantConfiguration*>(participantConfiguration);
+
+    auto&& jsonString = SilKit::Config::SerializeAsJson(*cppParticipantConfiguration);
+    *requiredSize = jsonString.size();
+
+    if(outputString != nullptr && jsonString.size() > 0)
+    {
+        std::copy(std::cbegin(jsonString), std::cend(jsonString), *outputString);
+    }
+    // since it is not possible to release the "raw" pointer from a shared_ptr, we copy it into our own raw pointer
+
+    return SilKit_ReturnCode_SUCCESS;
+}
+CAPI_CATCH_EXCEPTIONS
 
 SilKit_ReturnCode SilKitCALL
 SilKit_ParticipantConfiguration_Destroy(SilKit_ParticipantConfiguration* participantConfiguration)


### PR DESCRIPTION
When a participant configuration was processed, it may include fragments included by `includes:` statements.
This adds a new API to retrieve the finalized participant configuration as string.
Will be used e.g. in the network simulator and the dashboard.