### PR TITLE
cmake: bump version to 5.0.0 🚀

### DIFF
--- a/SilKit/cmake/SilKitVersion.cmake
+++ b/SilKit/cmake/SilKitVersion.cmake
@@ -1,23 +1,6 @@
-# Copyright (c) 2022 Vector Informatik GmbH
-# 
-# Permission is hereby granted, free of charge, to any person obtaining
-# a copy of this software and associated documentation files (the
-# "Software"), to deal in the Software without restriction, including
-# without limitation the rights to use, copy, modify, merge, publish,
-# distribute, sublicense, and/or sell copies of the Software, and to
-# permit persons to whom the Software is furnished to do so, subject to
-# the following conditions:
-# 
-# The above copyright notice and this permission notice shall be
-# included in all copies or substantial portions of the Software.
-# 
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
-# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
-# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
-# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
-# LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
-# OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
-# WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+# SPDX-FileCopyrightText: 2024-025 Vector Informatik GmbH
+#
+# SPDX-License-Identifier: MIT
 
 # SIL Kit Versioning:
 # * Major and minor release number is configured here. The patch number should not be changed here; it will be set by 
@@ -25,9 +8,9 @@
 # * Major and minor release number, as well as the sprint number are encoded into Version.hpp and compiled into the library,
 #   they will be accessible from public headers.
 macro(configure_silkit_version project_name)
-    set(SILKIT_VERSION_MAJOR 4)
+    set(SILKIT_VERSION_MAJOR 5)
     set(SILKIT_VERSION_MINOR 0)
-    set(SILKIT_VERSION_PATCH 57)
+    set(SILKIT_VERSION_PATCH 0)
     set(SILKIT_BUILD_NUMBER 0 CACHE STRING "The build number")
     set(SILKIT_VERSION_SUFFIX "")
 


### PR DESCRIPTION
Finally implement the new semantic versioning. 
I'm fed up with users asking "is there anything new since version 4.0.33" 🤣

TODO for 5.0:
- build RelWithDebInfo as default for distributions
- Changelog in MD format, and move old Changelog entries into separate files?
- LTO on some platform/compilers? see #227 
