### PR TITLE
config: enable configuration override for publisher history length

### DIFF
--- a/SilKit/IntegrationTests/CMakeLists.txt
+++ b/SilKit/IntegrationTests/CMakeLists.txt
@@ -184,6 +184,12 @@ add_silkit_test_to_executable(SilKitIntegrationTests
     SOURCES ITest_LinDynamicResponse.cpp
 )
 
+# Pub/Sub
+
+add_silkit_test_to_executable(SilKitIntegrationTests
+    SOURCES ITest_PubHistory.cpp
+)
+
 # RPC
 
 add_silkit_test_to_executable(SilKitInternalIntegrationTests

--- a/SilKit/IntegrationTests/ITest_PubHistory.cpp
+++ b/SilKit/IntegrationTests/ITest_PubHistory.cpp
@@ -1,0 +1,231 @@
+// SPDX-FileCopyrightText: 2025 Vector Informatik GmbH
+// SPDX-License-Identifier: MIT
+
+#include "gtest/gtest.h"
+#include "gmock/gmock.h"
+
+#include "silkit/SilKit.hpp"
+#include "silkit/config/IParticipantConfiguration.hpp"
+#include "silkit/participant/IParticipant.hpp"
+#include "silkit/services/pubsub/IDataPublisher.hpp"
+#include "silkit/services/pubsub/IDataSubscriber.hpp"
+#include "silkit/vendor/CreateSilKitRegistry.hpp"
+
+#include <atomic>
+#include <chrono>
+#include <future>
+#include <thread>
+
+namespace {
+
+using namespace std::chrono_literals;
+
+constexpr const char* PUBLISHER_NAME = "P";
+
+constexpr const char* EMPTY_PART_CONF = R"(
+)";
+
+constexpr const char* HISTORY_ZERO_PART_CONF = R"(
+DataPublishers:
+  - Name: P
+    History: 0
+)";
+
+constexpr const char* HISTORY_ONE_PART_CONF = R"(
+DataPublishers:
+  - Name: P
+    History: 1
+)";
+
+struct Participant
+{
+    std::shared_ptr<SilKit::Config::IParticipantConfiguration> configuration;
+    std::unique_ptr<SilKit::IParticipant> participant;
+
+    void SetupParticipant(const char* configurationString, const std::string& participantName,
+                          const std::string& registryUri)
+    {
+        this->configuration = SilKit::Config::ParticipantConfigurationFromString(configurationString);
+        this->participant = SilKit::CreateParticipant(configuration, participantName, registryUri);
+    }
+};
+
+struct PublisherParticipant : Participant
+{
+    SilKit::Services::PubSub::IDataPublisher* publisher{nullptr};
+
+    void SetupPublisher(const std::string& name, const SilKit::Services::PubSub::PubSubSpec& spec, std::size_t history)
+    {
+        this->publisher = this->participant->CreateDataPublisher(name, spec, history);
+    }
+};
+
+struct SubscriberParticipant : Participant
+{
+    SilKit::Services::PubSub::IDataSubscriber* subscriber{nullptr};
+    std::atomic<std::uint64_t> counter{0};
+
+    void SetupSubscriber(const std::string& name, const SilKit::Services::PubSub::PubSubSpec& spec)
+    {
+        this->subscriber =
+            this->participant->CreateDataSubscriber(name, spec, [this](auto, const auto&) { this->counter += 1; });
+    }
+};
+
+void ExpectMessage(SubscriberParticipant& s, std::chrono::nanoseconds timeout)
+{
+    const auto deadline = std::chrono::steady_clock::now() + timeout;
+
+    while (std::chrono::steady_clock::now() < deadline)
+    {
+        if (s.counter > 0)
+        {
+            break;
+        }
+
+        std::this_thread::sleep_for(100ms);
+    }
+
+    ASSERT_GT(s.counter, 0);
+}
+
+void ExpectNoMessage(SubscriberParticipant& s, std::chrono::nanoseconds timeout)
+{
+    const auto deadline = std::chrono::steady_clock::now() + timeout;
+
+    while (std::chrono::steady_clock::now() < deadline)
+    {
+        ASSERT_EQ(s.counter, 0);
+        std::this_thread::sleep_for(100ms);
+    }
+}
+
+struct ITest_PubHistory : testing::Test
+{
+    void SetUp() override
+    {
+        this->registryConfiguration = SilKit::Config::ParticipantConfigurationFromString("");
+        this->spec = SilKit::Services::PubSub::PubSubSpec{"P", "application/octet-stream"};
+        this->data = std::vector<std::uint8_t>{0xCA, 0xFE, 0xAF, 0xFE};
+    }
+
+    std::shared_ptr<SilKit::Config::IParticipantConfiguration> registryConfiguration;
+    SilKit::Services::PubSub::PubSubSpec spec;
+    std::vector<std::uint8_t> data;
+};
+
+TEST_F(ITest_PubHistory, history_api_one_conf_empty)
+{
+    const auto registry = SilKit::Vendor::Vector::CreateSilKitRegistry(registryConfiguration);
+    const auto registryUri = registry->StartListening("silkit://127.0.0.1:0");
+
+    PublisherParticipant a;
+    a.SetupParticipant(EMPTY_PART_CONF, "A", registryUri);
+    a.SetupPublisher(PUBLISHER_NAME, spec, 1);
+
+    // publish a single message, which will be historized and picked up by the subscriber
+    a.publisher->Publish(SilKit::Util::ToSpan(data));
+
+    SubscriberParticipant b;
+    b.SetupParticipant(EMPTY_PART_CONF, "B", registryUri);
+    b.SetupSubscriber("S", spec);
+
+    ExpectMessage(b, 2s);
+}
+
+TEST_F(ITest_PubHistory, history_api_zero_conf_empty)
+{
+    const auto registry = SilKit::Vendor::Vector::CreateSilKitRegistry(registryConfiguration);
+    const auto registryUri = registry->StartListening("silkit://127.0.0.1:0");
+
+    PublisherParticipant a;
+    a.SetupParticipant(EMPTY_PART_CONF, "A", registryUri);
+    a.SetupPublisher(PUBLISHER_NAME, spec, 0);
+
+    // publish a single message, which will not be historized
+    a.publisher->Publish(SilKit::Util::ToSpan(data));
+
+    SubscriberParticipant b;
+    b.SetupParticipant(EMPTY_PART_CONF, "B", registryUri);
+    b.SetupSubscriber("S", spec);
+
+    ExpectNoMessage(b, 2s);
+}
+
+TEST_F(ITest_PubHistory, history_api_one_conf_one)
+{
+    const auto registry = SilKit::Vendor::Vector::CreateSilKitRegistry(registryConfiguration);
+    const auto registryUri = registry->StartListening("silkit://127.0.0.1:0");
+
+    PublisherParticipant a;
+    a.SetupParticipant(HISTORY_ONE_PART_CONF, "A", registryUri);
+    a.SetupPublisher(PUBLISHER_NAME, spec, 1);
+
+    // publish a single message, which will be historized and picked up by the subscriber
+    a.publisher->Publish(SilKit::Util::ToSpan(data));
+
+    SubscriberParticipant b;
+    b.SetupParticipant(EMPTY_PART_CONF, "B", registryUri);
+    b.SetupSubscriber("S", spec);
+
+    ExpectMessage(b, 2s);
+}
+
+TEST_F(ITest_PubHistory, history_api_zero_conf_one)
+{
+    const auto registry = SilKit::Vendor::Vector::CreateSilKitRegistry(registryConfiguration);
+    const auto registryUri = registry->StartListening("silkit://127.0.0.1:0");
+
+    PublisherParticipant a;
+    a.SetupParticipant(HISTORY_ONE_PART_CONF, "A", registryUri);
+    a.SetupPublisher(PUBLISHER_NAME, spec, 0);
+
+    // publish a single message, which will be historized and picked up by the subscriber
+    a.publisher->Publish(SilKit::Util::ToSpan(data));
+
+    SubscriberParticipant b;
+    b.SetupParticipant(EMPTY_PART_CONF, "B", registryUri);
+    b.SetupSubscriber("S", spec);
+
+    ExpectMessage(b, 2s);
+}
+
+TEST_F(ITest_PubHistory, history_api_one_conf_zero)
+{
+    const auto registry = SilKit::Vendor::Vector::CreateSilKitRegistry(registryConfiguration);
+    const auto registryUri = registry->StartListening("silkit://127.0.0.1:0");
+
+    PublisherParticipant a;
+    a.SetupParticipant(HISTORY_ZERO_PART_CONF, "A", registryUri);
+    a.SetupPublisher(PUBLISHER_NAME, spec, 1);
+
+    // publish a single message, which will be historized and picked up by the subscriber
+    a.publisher->Publish(SilKit::Util::ToSpan(data));
+
+    SubscriberParticipant b;
+    b.SetupParticipant(EMPTY_PART_CONF, "B", registryUri);
+    b.SetupSubscriber("S", spec);
+
+    ExpectNoMessage(b, 2s);
+}
+
+TEST_F(ITest_PubHistory, history_api_zero_conf_zero)
+{
+    const auto registry = SilKit::Vendor::Vector::CreateSilKitRegistry(registryConfiguration);
+    const auto registryUri = registry->StartListening("silkit://127.0.0.1:0");
+
+    PublisherParticipant a;
+    a.SetupParticipant(HISTORY_ZERO_PART_CONF, "A", registryUri);
+    a.SetupPublisher(PUBLISHER_NAME, spec, 0);
+
+    // publish a single message, which will be historized and picked up by the subscriber
+    a.publisher->Publish(SilKit::Util::ToSpan(data));
+
+    SubscriberParticipant b;
+    b.SetupParticipant(EMPTY_PART_CONF, "B", registryUri);
+    b.SetupSubscriber("S", spec);
+
+    ExpectNoMessage(b, 2s);
+}
+
+} //end namespace

--- a/SilKit/IntegrationTests/ITest_PubHistory.cpp
+++ b/SilKit/IntegrationTests/ITest_PubHistory.cpp
@@ -37,6 +37,12 @@ DataPublishers:
     History: 1
 )";
 
+constexpr const char* HISTORY_TWO_PART_CONF = R"(
+DataPublishers:
+  - Name: P
+    History: 2
+)";
+
 struct Participant
 {
     std::shared_ptr<SilKit::Config::IParticipantConfiguration> configuration;
@@ -226,6 +232,16 @@ TEST_F(ITest_PubHistory, history_api_zero_conf_zero)
     b.SetupSubscriber("S", spec);
 
     ExpectNoMessage(b, 2s);
+}
+
+TEST_F(ITest_PubHistory, history_api_zero_conf_two_error)
+{
+    const auto registry = SilKit::Vendor::Vector::CreateSilKitRegistry(registryConfiguration);
+    const auto registryUri = registry->StartListening("silkit://127.0.0.1:0");
+
+    PublisherParticipant a;
+    a.SetupParticipant(HISTORY_TWO_PART_CONF, "A", registryUri);
+    EXPECT_THROW(a.SetupPublisher(PUBLISHER_NAME, spec, 0), SilKit::ConfigurationError);
 }
 
 } //end namespace

--- a/SilKit/IntegrationTests/ITest_PubHistory.cpp
+++ b/SilKit/IntegrationTests/ITest_PubHistory.cpp
@@ -199,7 +199,7 @@ TEST_F(ITest_PubHistory, history_api_one_conf_zero)
     a.SetupParticipant(HISTORY_ZERO_PART_CONF, "A", registryUri);
     a.SetupPublisher(PUBLISHER_NAME, spec, 1);
 
-    // publish a single message, which will be historized and picked up by the subscriber
+    // publish a single message, which will not be historized
     a.publisher->Publish(SilKit::Util::ToSpan(data));
 
     SubscriberParticipant b;
@@ -218,7 +218,7 @@ TEST_F(ITest_PubHistory, history_api_zero_conf_zero)
     a.SetupParticipant(HISTORY_ZERO_PART_CONF, "A", registryUri);
     a.SetupPublisher(PUBLISHER_NAME, spec, 0);
 
-    // publish a single message, which will be historized and picked up by the subscriber
+    // publish a single message, which will not be historized
     a.publisher->Publish(SilKit::Util::ToSpan(data));
 
     SubscriberParticipant b;

--- a/SilKit/source/config/ParticipantConfiguration.hpp
+++ b/SilKit/source/config/ParticipantConfiguration.hpp
@@ -176,7 +176,7 @@ struct DataPublisher
     std::optional<std::vector<Label>> labels;
 
     //! \brief History length of a DataPublisher.
-    std::optional<size_t> history{0};
+    std::optional<size_t> history;
 
     std::vector<std::string> useTraceSinks;
     Replay replay;

--- a/SilKit/source/config/ParticipantConfiguration.schema.json
+++ b/SilKit/source/config/ParticipantConfiguration.schema.json
@@ -439,6 +439,12 @@
         "$ref": "#/definitions/MatchingLabel"
       }
     },
+    "History": {
+      "type": "integer",
+      "description": "Override the history length (must be `0` or `1`)",
+      "minimum": 0,
+      "maximum": 1
+    },
     "Logging": {
       "type": "object",
       "description": "Configures the properties of the SIL Kit Logging Service",
@@ -601,6 +607,9 @@
           },
           "Labels": {
             "$ref": "#/definitions/Labels"
+          },
+          "History": {
+            "$ref": "#/definitions/History"
           }
         },
         "additionalProperties": false,

--- a/SilKit/source/config/ParticipantConfiguration_Full.json
+++ b/SilKit/source/config/ParticipantConfiguration_Full.json
@@ -150,6 +150,7 @@
     {
       "Name": "Publisher1",
       "Topic": "Temperature",
+      "History": 1,
       "Labels": [
         {
           "Key": "A",

--- a/SilKit/source/config/ParticipantConfiguration_Full.yaml
+++ b/SilKit/source/config/ParticipantConfiguration_Full.yaml
@@ -117,6 +117,7 @@ FlexrayControllers:
 DataPublishers:
 - Name: Publisher1
   Topic: Temperature
+  History: 1
   Labels:
     - Key: A
       Value: B

--- a/SilKit/source/config/YamlReader.cpp
+++ b/SilKit/source/config/YamlReader.cpp
@@ -339,6 +339,7 @@ void YamlReader::Read(SilKit::Config::DataPublisher& obj)
     ReadKeyValue(obj.name, "Name");
     OptionalRead(obj.topic, "Topic");
     OptionalRead(obj.labels, "Labels");
+    OptionalRead(obj.history, "History");
     OptionalRead(obj.useTraceSinks, "UseTraceSinks");
     OptionalRead(obj.replay, "Replay");
 }

--- a/SilKit/source/config/YamlValidator.cpp
+++ b/SilKit/source/config/YamlValidator.cpp
@@ -121,6 +121,7 @@ const std::set<std::string> schemaPaths_v1 = {
     "/DataPublishers/Replay/MdfChannel/GroupSource",
     "/DataPublishers/Replay/UseTraceSource",
     "/DataPublishers/Topic",
+    "/DataPublishers/History",
     "/DataPublishers/UseTraceSinks",
     "/DataSubscribers",
     "/DataSubscribers/Labels",

--- a/SilKit/source/config/YamlWriter.cpp
+++ b/SilKit/source/config/YamlWriter.cpp
@@ -403,7 +403,7 @@ void YamlWriter::Write(const SilKit::Config::DataPublisher& obj)
     WriteKeyValue("Name", obj.name);
     OptionalWrite(obj.topic, "Topic");
     OptionalWrite(obj.labels, "Labels");
-    //OptionalWrite(obj.history, "History");
+    OptionalWrite(obj.history, "History");
     OptionalWrite(obj.useTraceSinks, "UseTraceSinks");
     OptionalWrite(obj.replay, "Replay");
 }

--- a/SilKit/source/core/participant/Participant_impl.hpp
+++ b/SilKit/source/core/participant/Participant_impl.hpp
@@ -511,8 +511,14 @@ auto Participant<SilKitConnectionT>::CreateDataPublisher(const std::string& cano
     SilKit::Config::DataPublisher controllerConfig =
         GetConfigByControllerName(_participantConfig.dataPublishers, canonicalName);
     UpdateOptionalConfigValue(canonicalName, controllerConfig.topic, dataSpec.Topic());
+    UpdateOptionalConfigValue(canonicalName, controllerConfig.history, history);
     UpdateOptionalConfigValue(canonicalName, controllerConfig.labels,
                               SilKit::Config::V1::Label::VectorFromPublicApi(dataSpec.Labels()));
+
+    if (controllerConfig.history.value() > 1)
+    {
+        throw SilKit::ConfigurationError("DataPublishers do not support history > 1.");
+    }
 
     auto sortedConfigLabels = controllerConfig.labels.value();
     std::sort(sortedConfigLabels.begin(), sortedConfigLabels.end(),
@@ -536,7 +542,7 @@ auto Participant<SilKitConnectionT>::CreateDataPublisher(const std::string& cano
         controllerConfig, network, std::move(supplementalData), true, true, &_timeProvider, configuredDataNodeSpec,
         network, controllerConfig);
 
-    _connection.SetHistoryLengthForLink(history, controller);
+    _connection.SetHistoryLengthForLink(controllerConfig.history.value(), controller);
 
     if (GetLogger()->GetLogLevel() <= Logging::Level::Trace)
     {

--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -10,6 +10,11 @@ The format is based on `Keep a Changelog (http://keepachangelog.com/en/1.0.0/) <
 [4.0.57] - UNRELEASED
 ---------------------
 
+Added
+~~~~~
+
+- The history length of a publisher can now be overridden in the participant configuration.
+
 
 [4.0.56] - 2025-05-19
 ---------------------


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2023 Vector Informatik GmbH

SPDX-License-Identifier: MIT
-->

## Subject
<!--
    - What kind of changes does this pull request comprise?
    - Add a label like "Bugfix", "docs", etc. to this PR to give context.
 -->

Makes it possible to override the publisher history length in the participant configuration. Analogous to the override of the topic, or the labels.

JIRA: SILKIT-1777

## Developer checklist (address before review)

- [x] Changelog.md updated
- [ ] Prepared update for depending repositories
- [ ] Documentation updated (public API changes only)
- [ ] API docstrings updated (public API changes only)
- [ ] Rebase &rarr; commit history clean
- [x Squash and merge &rarr; proper PR title
