### PR TITLE
tests: fix warning that breaks the nightly build

### DIFF
--- a/SilKit/IntegrationTests/ITest_Dashboard.cpp
+++ b/SilKit/IntegrationTests/ITest_Dashboard.cpp
@@ -245,7 +245,7 @@ void CheckSimulationData(SilKit::Dashboard::SimulationData actual, SilKit::Dashb
     ASSERT_EQ(actual.stopped, expected.stopped) << "Simulation " << simulationId << " should have been stopped!";
     if(expected.metricCount != 0)
     {
-        ASSERT_GT(actual.metricCount, 0)
+        ASSERT_GT(actual.metricCount, 0u)
             << "Simulation " << simulationId << " should have the metric count set to non-zero";
     }
 }


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2023 Vector Informatik GmbH

SPDX-License-Identifier: MIT
-->

## Subject

Nightly build broke again (32-bit MSVC)~~, not sure why it didn't trip the CI on `github.com`~~. The `github.com` runners use a more recent version of the 14.2 toolset, which explains the difference.

## Developer checklist (address before review)

- [ ] Changelog.md updated
- [ ] Prepared update for depending repositories
- [ ] Documentation updated (public API changes only)
- [ ] API docstrings updated (public API changes only)
- [ ] Rebase &rarr; commit history clean
- [ ] Squash and merge &rarr; proper PR title
