### PR TITLE
core: emit warning when connected via registry-proxy

### DIFF
--- a/SilKit/source/core/vasio/VAsioConnection.cpp
+++ b/SilKit/source/core/vasio/VAsioConnection.cpp
@@ -1454,6 +1454,7 @@ void VAsioConnection::ReceiveProxyMessage(IVAsioPeer* from, SerializedMessage&& 
         // the disconnected peer, to inform the destination that the source peer has disconnected.
         auto [it, inserted] =
             _proxySourceToDestinations[fromSimulationName][proxyMessage.source].insert(proxyMessage.destination);
+        SILKIT_UNUSED_ARG(it);
 
         if (inserted)
         {


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2023 Vector Informatik GmbH

SPDX-License-Identifier: MIT
-->

## Subject
<!--
    - What kind of changes does this pull request comprise?
    - Add a label like "Bugfix", "docs", etc. to this PR to give context.
 -->

Emit warnings when the registry-proxy is used. Warnings should be emitted on all 'involved' participants and the registry.

### Registry

The registry emits the warnings when the first message is proxied. The warning is emitted for both directions.

```
[2025-07-15 11:08:46.742] [SilKitRegistry] [warning] Acting as proxy between "V" ("simname") and "U" ("simname")
[2025-07-15 11:08:46.742] [SilKitRegistry] [warning] Acting as proxy between "U" ("simname") and "V" ("simname")
```

### Participant

The participants emit the warning when the (successful) `ParticipantAnnouncementReply` is sent or received.

```
[2025-07-15 11:08:46.742] [U] [warning] Connected to "V" ("simname") using "SilKitRegistry" as a proxy
```

```
[2025-07-15 11:08:46.742] [V] [warning] Connected to "U" ("simname") using "SilKitRegistry" as a proxy
```

## Developer checklist (address before review)

- [ ] Changelog.md updated
- [ ] Prepared update for depending repositories
- [ ] Documentation updated (public API changes only)
- [ ] API docstrings updated (public API changes only)
- [ ] Rebase &rarr; commit history clean
- [ ] Squash and merge &rarr; proper PR title
