### PR TITLE
qnx: remove c++14 from compile flags

### DIFF
--- a/SilKit/cmake/qnx-cross-base-toolchain.cmake
+++ b/SilKit/cmake/qnx-cross-base-toolchain.cmake
@@ -69,7 +69,7 @@ set(CMAKE_CXX_COMPILER_TARGET ${qcc_arch})
 
 # Use LLVM stdlib for now, since GNU is segfaulting with future.waits
 # -Y and -stdlib should be redundant
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Y_cxx -stdlib=libc++ -Wc,-std=c++14")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Y_cxx -stdlib=libc++")
 set(CMAKE_EXE_LINKER_FLAGS "-Wl,-z,origin")
 
 set(CMAKE_ASM_COMPILER "${QCC_EXE}" -V${qcc_arch})


### PR DESCRIPTION
## Description
We are now using the C++17 standard so we can remove the c++14 flag

## Instructions for review / testing
<!--
    - Hilight some of the important changes, which reviewers should focus on
    - Which parts should be reviewed in detail? For example: content of console output, correct semantics of changes
    - Test steps and test setup description. For example: which programs or configs to use
-->

## Developer checklist (address before review)

- [ ] Changelog.md updated
- [ ] Prepared update for depending repositories
- [ ] Documentation updated (public API changes only)
- [ ] API docstrings updated (public API changes only)
- [ ] Rebase &rarr; commit history clean
- [ ] Squash and merge &rarr; proper PR title
