### PR TITLE
Fix GCC 8 and QNX710 for std::filesystem

### DIFF
--- a/SilKit/cmake/SilKitBuildSettings.cmake
+++ b/SilKit/cmake/SilKitBuildSettings.cmake
@@ -174,6 +174,9 @@ function(silkit_enable_warnings isOn)
                 -Wno-dangling-reference
                 )
         endif()
+	if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS "9")
+		link_libraries(-lstdc++fs)
+	endif()
     endif()
 
     add_compile_options(${_flags})

--- a/SilKit/cmake/qnx-cross-base-toolchain.cmake
+++ b/SilKit/cmake/qnx-cross-base-toolchain.cmake
@@ -69,7 +69,7 @@ set(CMAKE_CXX_COMPILER_TARGET ${qcc_arch})
 
 # Use LLVM stdlib for now, since GNU is segfaulting with future.waits
 # -Y and -stdlib should be redundant
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Y_cxx -stdlib=libc++ -Wc,-std=c++17")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Y_cxx -stdlib=libc++")
 set(CMAKE_EXE_LINKER_FLAGS "-Wl,-z,origin")
 
 if($ENV{QNX_HOST} MATCHES ".*qnx710.*")

--- a/SilKit/cmake/qnx-cross-base-toolchain.cmake
+++ b/SilKit/cmake/qnx-cross-base-toolchain.cmake
@@ -72,7 +72,7 @@ set(CMAKE_CXX_COMPILER_TARGET ${qcc_arch})
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Y_cxx -stdlib=libc++ -Wc,-std=c++17")
 set(CMAKE_EXE_LINKER_FLAGS "-Wl,-z,origin")
 
-link_libraries(-lstdc++fs)
+link_libraries(-lc++fs)
 
 set(CMAKE_ASM_COMPILER "${QCC_EXE}" -V${qcc_arch})
 set(CMAKE_ASM_DEFINE_FLAG "-Wa,--defsym,")

--- a/SilKit/cmake/qnx-cross-base-toolchain.cmake
+++ b/SilKit/cmake/qnx-cross-base-toolchain.cmake
@@ -73,7 +73,7 @@ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Y_cxx -stdlib=libc++")
 set(CMAKE_EXE_LINKER_FLAGS "-Wl,-z,origin")
 
 if($ENV{QNX_HOST} MATCHES ".*qnx710.*")
-    message(STATUS "QNX700 detected: Linking against libc++fs")
+    message(STATUS "QNX710 detected: Linking against libc++fs")
     link_libraries(-lc++fs)
 endif()
 

--- a/SilKit/cmake/qnx-cross-base-toolchain.cmake
+++ b/SilKit/cmake/qnx-cross-base-toolchain.cmake
@@ -72,7 +72,10 @@ set(CMAKE_CXX_COMPILER_TARGET ${qcc_arch})
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Y_cxx -stdlib=libc++ -Wc,-std=c++17")
 set(CMAKE_EXE_LINKER_FLAGS "-Wl,-z,origin")
 
-link_libraries(-lc++fs)
+if($ENV{QNX_HOST} MATCHES ".*qnx710.*")
+    message(STATUS "QNX700 detected: Linking against libc++fs")
+    link_libraries(-lc++fs)
+endif()
 
 set(CMAKE_ASM_COMPILER "${QCC_EXE}" -V${qcc_arch})
 set(CMAKE_ASM_DEFINE_FLAG "-Wa,--defsym,")

--- a/SilKit/cmake/qnx-cross-base-toolchain.cmake
+++ b/SilKit/cmake/qnx-cross-base-toolchain.cmake
@@ -69,8 +69,10 @@ set(CMAKE_CXX_COMPILER_TARGET ${qcc_arch})
 
 # Use LLVM stdlib for now, since GNU is segfaulting with future.waits
 # -Y and -stdlib should be redundant
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Y_cxx -stdlib=libc++ -Wc,-std=c++14")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Y_cxx -stdlib=libc++ -Wc,-std=c++17")
 set(CMAKE_EXE_LINKER_FLAGS "-Wl,-z,origin")
+
+link_libraries(-lstdc++fs)
 
 set(CMAKE_ASM_COMPILER "${QCC_EXE}" -V${qcc_arch})
 set(CMAKE_ASM_DEFINE_FLAG "-Wa,--defsym,")


### PR DESCRIPTION
GCC 8 based compilers need to explicitly link against libstdc++fs or libc++fs to work

## Developer checklist (address before review)

- [ ] Changelog.md updated
- [ ] Prepared update for depending repositories
- [ ] Documentation updated (public API changes only)
- [ ] API docstrings updated (public API changes only)
- [ ] Rebase &rarr; commit history clean
- [ ] Squash and merge &rarr; proper PR title
