### PR TITLE
docs: add missing history field for data publisher

### DIFF
--- a/docs/changelog/versions/latest.md
+++ b/docs/changelog/versions/latest.md
@@ -12,6 +12,7 @@
 
 - Improved the behavior of the `sil-kit-system-controller`, allowing single participants to drop out and rejoin before
   all required participants are connected without having to restart other required participants or the system controller.
+- `docs`: document the ability to override the history length of ``DataPublisher`` controllers in the participant configuration
 
 ## Added
 

--- a/docs/configuration/services-configuration.rst
+++ b/docs/configuration/services-configuration.rst
@@ -135,6 +135,7 @@ DataPublishers
   DataPublishers: 
   - Name: DataPublisher1
     Topic: SomeTopic1
+    History: 1
     Labels:
       - Key: SomeKey
         Value: SomeValue
@@ -154,9 +155,15 @@ DataPublishers
      - The name of the data publisher.
    * - Topic
      - The topic on which the data publisher publishes its information. (optional)
+   * - History
+     - The history length determines if the last message published by this data publisher is cached
+       and automatically sent to any new subscribers.
+       Note that the value will replace the programmatically provided history length.
+       The default for the programmatically provided history length is ``0``.
+       If set, the value must be either ``0`` or ``1``. (optional)
    * - Labels
-     - The labels determining matching subscribers with the same topic and media type. (optional)
-        Note that these labels will replace all programmatically provided labels.
+     - The labels determining matching subscribers with the same topic and media type.
+       Note that these labels will replace all programmatically provided labels. (optional)
 
 
 .. _sec:cfg-participant-data-subscribers:


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2023 Vector Informatik GmbH

SPDX-License-Identifier: MIT
-->

## Subject
<!--
    - What kind of changes does this pull request comprise?
    - Add a label like "Bugfix", "docs", etc. to this PR to give context.
 -->

Adds the field to the documentation as well. That was missed during the initial implementation.

## Developer checklist (address before review)

- [ ] Changelog.md updated
- [ ] Prepared update for depending repositories
- [ ] Documentation updated (public API changes only)
- [ ] API docstrings updated (public API changes only)
- [ ] Rebase &rarr; commit history clean
- [x] Squash and merge &rarr; proper PR title
