### PR TITLE
structured logs: add targeted trace messages to logs

### DIFF
--- a/SilKit/source/core/participant/Participant_impl.hpp
+++ b/SilKit/source/core/participant/Participant_impl.hpp
@@ -1633,7 +1633,7 @@ template <typename SilKitMessageT>
 void Participant<SilKitConnectionT>::SendMsgImpl(const IServiceEndpoint* from, const std::string& targetParticipantName,
                                                  SilKitMessageT&& msg)
 {
-    TraceTx(GetLoggerInternal(), from, msg);
+    TraceTx(GetLoggerInternal(), from, targetParticipantName, msg);
     _connection.SendMsg(from, targetParticipantName, std::forward<SilKitMessageT>(msg));
 }
 

--- a/SilKit/source/services/logging/MessageTracing.hpp
+++ b/SilKit/source/services/logging/MessageTracing.hpp
@@ -71,6 +71,26 @@ void TraceTx(Logging::ILoggerInternal* logger, const Core::IServiceEndpoint* add
     }
 }
 
+// targeted messages
+template <class SilKitMessageT>
+void TraceTx(Logging::ILoggerInternal* logger, const Core::IServiceEndpoint* addr, const std::string_view target, const SilKitMessageT& msg)
+{
+    if (logger->GetLogLevel() == Logging::Level::Trace)
+    {
+        Logging::LoggerMessage lm{logger, Logging::Level::Trace};
+        lm.SetMessage("Send message");
+        lm.SetKeyValue(addr->GetServiceDescriptor());
+        lm.FormatKeyValue(Logging::Keys::msg, "{}", msg);
+        lm.FormatKeyValue(Logging::Keys::to, "{}", target);
+
+        auto virtualTimeStamp = GetTimestamp(msg);
+        if (virtualTimeStamp != std::chrono::nanoseconds::duration::min())
+        {
+                lm.FormatKeyValue(Logging::Keys::virtualTimeNS, "{}", virtualTimeStamp.count());
+        }
+        lm.Dispatch();
+    }
+}
 // Don't trace LogMessages - this could cause cycles!
 inline void TraceRx(Logging::ILoggerInternal* /*logger*/, Core::IServiceEndpoint* /*addr*/, const Logging::LogMsg& /*msg*/) {}
 inline void TraceTx(Logging::ILoggerInternal* /*logger*/, Core::IServiceEndpoint* /*addr*/, const Logging::LogMsg& /*msg*/) {}

--- a/SilKit/source/services/logging/StructuredLoggingKeys.hpp
+++ b/SilKit/source/services/logging/StructuredLoggingKeys.hpp
@@ -6,6 +6,7 @@
 
 #include <atomic>
 #include <string>
+#include <string_view>
 
 namespace SilKit {
 namespace Services {
@@ -15,6 +16,7 @@ namespace Keys {
 const std::string virtualTimeNS{"VirtualTimeNS"};
 const std::string msg{"Msg"};
 const std::string from{"From"};
+constexpr std::string_view to{"To"};
 
 const std::string waitingTime{"WaitingTime"};
 const std::string executionTime{"ExecutionTime"};


### PR DESCRIPTION
add structured logging for targeted messages. this adds a `To` field to the `kv`