### PR TITLE
Fix CMake configuration for QNX targets

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -119,11 +119,11 @@
         {
             "name": "x-cross-qnx-x86_64",
             "generator": "Unix Makefiles",
+            "inherits": [ "mixin-dirs" ],
             "environment": {
                 "SILKIT_CMAKE_PRESET_BUILD_PLATFORM": "qnx"
             },
             "toolchainFile": "${sourceDir}/SilKit/cmake/toolchain-qnx-x86_64.cmake",
-            "binaryDir": "${sourceDir}/_build/${presetName}",
             "cacheVariables": {
                 "SILKIT_BUILD_DASHBOARD": "OFF"
             },

--- a/SilKit/cmake/toolchain-qnx-aarch64.cmake
+++ b/SilKit/cmake/toolchain-qnx-aarch64.cmake
@@ -3,6 +3,6 @@
 # SPDX-License-Identifier: MIT
 
 #NB: Call <<QNX_INSTALLATION_DIR>>/qnxsdp-env.sh before building
-set(SILKIT_TARGET_TOOLSET "gcc_ntoaarch64le_gpp")
+set(SILKIT_TARGET_TOOLSET "gcc_ntoaarch64le")
 set(SILKIT_TARGET_ARCHITECTURE "aarch64")
 include(${CMAKE_CURRENT_LIST_DIR}/qnx-cross-base-toolchain.cmake)


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2023 Vector Informatik GmbH

SPDX-License-Identifier: MIT
-->

## Subject
<!--
    - What kind of changes does this pull request comprise?
    - Add a label like "Bugfix", "docs", etc. to this PR to give context
 -->
 1. Fixes the wrong toolset selection for QNX aarch64
 2. Sets the correct default installation path for the QNX CMake presets


## Description
<!--
    - Give a short summary of the intention of the changes.
    - Don't replicate the commit messages here.
    - Which Jira tickets are addressed with this pull request (list all if multiple tickets are affected)?
-->
1. The QNX build for aarch64 was failing due to a wrong target toolset selection. When the "_cxx" suffix is appended to the originally selected "gcc_ntoaarch64le_gpp", it results in an unknown toolset target "gcc_ntoaarch64le_gpp_cxx". By removing the "_gpp" suffix, it results in a correct toolset target "gcc_ntoaarch64le_cxx".
2. The QNX presets did not have an `installDir` set, so the installation path was defaulting to `/usr/local`. Now the QNX presets inherit the `mixin-dirs` and have the same `installDir` as the other presets.

## Instructions for review / testing
<!--
    - Hilight some of the important changes, which reviewers should focus on
    - Which parts should be reviewed in detail? For example: content of console output, correct semantics of changes
    - Test steps and test setup description. For example: which programs or configs to use
-->
Are there any other files I missed with my fixes?

## Developer checklist (address before review)

- [ ] Changelog.md updated
- [ ] Prepared update for depending repositories
- [ ] Documentation updated (public API changes only)
- [ ] API docstrings updated (public API changes only)
- [ ] Rebase &rarr; commit history clean
- [ ] Squash and merge &rarr; proper PR title
