### PR TITLE
registry: do not crash when dashboard is disabled

### DIFF
--- a/Utilities/SilKitRegistry/Registry.cpp
+++ b/Utilities/SilKitRegistry/Registry.cpp
@@ -207,10 +207,12 @@ auto StartRegistry(std::shared_ptr<SilKit::Config::IParticipantConfiguration> co
         catch (const std::exception& exception)
         {
             std::cerr << "error during dashboard instance creation: " << exception.what() << std::endl;
+            enableDashboard = false;
         }
         catch (...)
         {
             std::cerr << "unknown error during dashboard instance creation" << std::endl;
+            enableDashboard = false;
         }
     }
 


### PR DESCRIPTION
When SIL Kit is built without Dashboard support, a nullpointer was dereferenced.