### PR TITLE
Add SetStepDuration and TimeAdvanceModes

### DIFF
--- a/Demos/api/Orchestration/CMakeLists.txt
+++ b/Demos/api/Orchestration/CMakeLists.txt
@@ -5,5 +5,6 @@
 make_silkit_demo(SilKitDemoAutonomous Autonomous.cpp OFF)
 make_silkit_demo(SilKitDemoCoordinated Coordinated.cpp OFF)
 make_silkit_demo(SilKitDemoSimStep SimStep.cpp OFF)
+make_silkit_demo(SilKitDemoDynSimStep DynSimStep.cpp OFF)
 make_silkit_demo(SilKitDemoSimStepAsync SimStepAsync.cpp OFF)
 

--- a/Demos/api/Orchestration/DynSimStep.cpp
+++ b/Demos/api/Orchestration/DynSimStep.cpp
@@ -4,6 +4,7 @@
 
 #include <iostream>
 #include <random>
+#include <thread>
 
 #include "silkit/SilKit.hpp"
 
@@ -17,12 +18,73 @@ std::ostream& operator<<(std::ostream& out, std::chrono::nanoseconds timestamp)
 
 int main(int argc, char** argv)
 {
-    if (argc != 2)
+    if (argc != 5 && argc != 6)
     {
-        std::cerr << "Wrong number of arguments! Start demo with: " << argv[0] << " <ParticipantName>" << std::endl;
+        std::cerr << "Wrong number of arguments! Start demo with: " << argv[0] << 
+            " <ParticipantName> "
+            "<StepSize> "
+            "[-A (Autonomous) | -C (Coordinated)] "
+            "[-M (ByMinimalDuration) | -D (ByOwnDuration)] "
+            "[-R (Optional; Randomize StepSize (1ms to 10ms) with 10% probability every step)]" << std::endl;
         return -1;
     }
+    // Arg 1: Participant Name
     std::string participantName(argv[1]);
+
+    // Arg 2: Step Size
+    auto stepSize = std::chrono::milliseconds(std::stoi(argv[2]));
+    std::cout << "Starting with stepSize=" << stepSize << std::endl;
+
+    // Arg 3: Operation Mode
+    auto operationMode = SilKit::Services::Orchestration::OperationMode::Coordinated;
+    if (std::string(argv[3]) == "-A")
+    {
+        std::cout << "Using OperationMode::Autonomous" << std::endl;
+        operationMode = SilKit::Services::Orchestration::OperationMode::Autonomous;
+    }
+    else if (std::string(argv[3]) == "-C")
+    {
+        std::cout << "Using OperationMode::Coordinated" << std::endl;
+    }
+    else
+    {
+        std::cerr << "Unknown third argument '" << argv[3] << "'. Did you mean '-A' for autonomous mode or '-C' for coordinated mode?" << std::endl;
+        return -1;
+    }
+
+    // Arg 4: Time Advance Mode
+    auto timeAdvanceMode = SilKit::Services::Orchestration::TimeAdvanceMode::ByMinimalDuration;
+    if (std::string(argv[4]) == "-M")
+    {
+        std::cout << "Using TimeAdvanceMode::ByMinimalDuration" << std::endl;
+    }
+    else if (std::string(argv[4]) == "-D")
+    {
+        timeAdvanceMode = SilKit::Services::Orchestration::TimeAdvanceMode::ByOwnDuration;
+        std::cout << "Using TimeAdvanceMode::ByOwnDuration" << std::endl;
+    }
+    else
+    {
+        std::cerr << "Unknown argument '" << argv[4]
+                  << "'. Did you mean '-M' for TimeAdvanceMode::ByMinimalDuration or '-D' for TimeAdvanceMode::ByOwnDuration?" << std::endl;
+        return -1;
+    }
+
+    // Arg 5: Optional Randomize Step Size
+    bool randomizeStepSize = false;
+    if (argc == 6)
+    {
+        if (std::string(argv[5]) == "-R")
+        {
+            randomizeStepSize = true;
+            std::cout << "Randomizing step size every 10 steps." << std::endl << std::endl;
+        }
+        else
+        {
+            std::cerr << "Unknown argument '" << argv[5] << "'. Did you mean '-R' to randomize the step size every 10 steps?" << std::endl;
+            return -1;
+        }
+    }
 
     try
     {
@@ -34,13 +96,10 @@ int main(int argc, char** argv)
         auto participant = SilKit::CreateParticipant(participantConfiguration, participantName, registryUri);
         auto logger = participant->GetLogger();
 
-        auto* lifecycleService =
-            participant->CreateLifecycleService({SilKit::Services::Orchestration::OperationMode::Coordinated});
+        auto* lifecycleService = participant->CreateLifecycleService({operationMode});
 
-        auto* timeSyncService = lifecycleService->CreateTimeSyncService(SilKit::Services::Orchestration::TimeAdvanceMode::ByMinimalDuration);
+        auto* timeSyncService = lifecycleService->CreateTimeSyncService(timeAdvanceMode);
 
-        const auto stepSize = 10ms;
-        static int stepCounter = 0;
         std::random_device rd;
         std::mt19937 rng(rd());
         auto bounded_rand = [&rng](unsigned range) {
@@ -48,9 +107,9 @@ int main(int argc, char** argv)
             return dist(rng);
         };
 
-
         timeSyncService->SetSimulationStepHandler(
-            [logger, timeSyncService, participantName, bounded_rand](std::chrono::nanoseconds now,
+            [randomizeStepSize, logger, timeSyncService, participantName, bounded_rand](
+                std::chrono::nanoseconds now,
                                                                      std::chrono::nanoseconds duration) {
             // The invocation of this handler marks the beginning of a simulation step.
             {
@@ -59,7 +118,7 @@ int main(int argc, char** argv)
                 logger->Info(ss.str());
             }
 
-            if (bounded_rand(10) == 1)// && participantName == "P1")
+            if (randomizeStepSize && bounded_rand(10) == 1)
             {
                 auto rndStepDuration = bounded_rand(10);
                 timeSyncService->SetStepDuration(std::chrono::milliseconds(rndStepDuration));
@@ -69,12 +128,7 @@ int main(int argc, char** argv)
             }
 
             std::this_thread::sleep_for(500ms);
-            // All messages sent here are guaranteed to arrive at other participants before their next simulation step is called.
-            // So here, we can rely on having received all messages from the past (< now).
-            // Note that this guarantee only holds for messages sent within a simulation step,
-            // not for messages send outside of this handler (e.g. directly in a reception handler).
 
-            // Returning from the handler marks the end of a simulation step.
         }, stepSize);
 
         auto finalStateFuture = lifecycleService->StartLifecycle();

--- a/Demos/api/Orchestration/SimStep.cpp
+++ b/Demos/api/Orchestration/SimStep.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: MIT
 
 #include <iostream>
+#include <thread>
 
 #include "silkit/SilKit.hpp"
 
@@ -38,7 +39,7 @@ int main(int argc, char** argv)
 
         auto* timeSyncService = lifecycleService->CreateTimeSyncService();
 
-        const auto stepSize = 2ms;
+        const auto stepSize = 5ms;
 
         timeSyncService->SetSimulationStepHandler(
             [logger](std::chrono::nanoseconds now, std::chrono::nanoseconds duration) {

--- a/SilKit/IntegrationTests/CMakeLists.txt
+++ b/SilKit/IntegrationTests/CMakeLists.txt
@@ -114,6 +114,11 @@ add_silkit_test_to_executable(SilKitIntegrationTests
     SOURCES ITest_SimTask.cpp
 )
 
+add_silkit_test_to_executable(SilKitIntegrationTests
+    SOURCES ITest_DynStepSizes.cpp
+)
+
+
 add_silkit_test_to_executable(SilKitFunctionalTests
     SOURCES FTest_WallClockCoupling.cpp
 )

--- a/SilKit/IntegrationTests/Hourglass/MockCapi.cpp
+++ b/SilKit/IntegrationTests/Hourglass/MockCapi.cpp
@@ -614,6 +614,12 @@ extern "C"
         return globalCapi->SilKit_TimeSyncService_Create(outTimeSyncService, lifecycleService);
     }
 
+    SilKit_ReturnCode SilKitCALL SilKit_TimeSyncService_Create_With_TimeAdvanceMode(SilKit_TimeSyncService** outTimeSyncService,
+                                                               SilKit_LifecycleService* lifecycleService, SilKit_TimeAdvanceMode timeAdvanceMode)
+    {
+        return globalCapi->SilKit_TimeSyncService_Create_With_TimeAdvanceMode(outTimeSyncService, lifecycleService, timeAdvanceMode);
+    }
+
     SilKit_ReturnCode SilKitCALL SilKit_TimeSyncService_SetSimulationStepHandler(
         SilKit_TimeSyncService* timeSyncService, void* context, SilKit_TimeSyncService_SimulationStepHandler_t handler,
         SilKit_NanosecondsTime initialStepSize)
@@ -639,6 +645,12 @@ extern "C"
                                                             SilKit_NanosecondsTime* outNanosecondsTime)
     {
         return globalCapi->SilKit_TimeSyncService_Now(timeSyncService, outNanosecondsTime);
+    }
+
+    SilKit_ReturnCode SilKitCALL SilKit_TimeSyncService_SetStepDuration(SilKit_TimeSyncService* timeSyncService,
+                                                            SilKit_NanosecondsTime stepDuration)
+    {
+        return globalCapi->SilKit_TimeSyncService_SetStepDuration(timeSyncService, stepDuration);
     }
 
     SilKit_ReturnCode SilKitCALL SilKit_Experimental_TimeSyncService_AddOtherSimulationStepsCompletedHandler(

--- a/SilKit/IntegrationTests/Hourglass/MockCapi.hpp
+++ b/SilKit/IntegrationTests/Hourglass/MockCapi.hpp
@@ -325,6 +325,9 @@ public:
     MOCK_METHOD(SilKit_ReturnCode, SilKit_TimeSyncService_Create,
                 (SilKit_TimeSyncService * *outTimeSyncService, SilKit_LifecycleService* lifecycleService));
 
+    MOCK_METHOD(SilKit_ReturnCode, SilKit_TimeSyncService_Create_With_TimeAdvanceMode,
+                (SilKit_TimeSyncService * *outTimeSyncService, SilKit_LifecycleService* lifecycleService, SilKit_TimeAdvanceMode timeAdvanceMode));
+
     MOCK_METHOD(SilKit_ReturnCode, SilKit_TimeSyncService_SetSimulationStepHandler,
                 (SilKit_TimeSyncService * timeSyncService, void* context,
                  SilKit_TimeSyncService_SimulationStepHandler_t handler, SilKit_NanosecondsTime initialStepSize));
@@ -338,6 +341,9 @@ public:
 
     MOCK_METHOD(SilKit_ReturnCode, SilKit_TimeSyncService_Now,
                 (SilKit_TimeSyncService * timeSyncService, SilKit_NanosecondsTime* outNanosecondsTime));
+
+    MOCK_METHOD(SilKit_ReturnCode, SilKit_TimeSyncService_SetStepDuration,
+                (SilKit_TimeSyncService * timeSyncService, SilKit_NanosecondsTime stepDuration));
 
     MOCK_METHOD(SilKit_ReturnCode, SilKit_Experimental_TimeSyncService_AddOtherSimulationStepsCompletedHandler,
                 (SilKit_TimeSyncService * timeSyncService, void* context,

--- a/SilKit/IntegrationTests/Hourglass/Test_HourglassOrchestration.cpp
+++ b/SilKit/IntegrationTests/Hourglass/Test_HourglassOrchestration.cpp
@@ -447,7 +447,6 @@ TEST_F(Test_HourglassOrchestration, SilKit_TimeSyncService_SetStepDuration)
     timeSyncService.SetStepDuration(stepDuration);
 }
 
-
 TEST_F(Test_HourglassOrchestration, SilKit_Experimental_TimeSyncService_AddOtherSimulationStepsCompletedHandler)
 {
     using testing::_;

--- a/SilKit/IntegrationTests/Hourglass/Test_HourglassOrchestration.cpp
+++ b/SilKit/IntegrationTests/Hourglass/Test_HourglassOrchestration.cpp
@@ -148,6 +148,8 @@ public:
             .WillByDefault(DoAll(SetArgPointee<0>(mockLifecycleService), Return(SilKit_ReturnCode_SUCCESS)));
         ON_CALL(capi, SilKit_TimeSyncService_Create(_, _))
             .WillByDefault(DoAll(SetArgPointee<0>(mockTimeSyncService), Return(SilKit_ReturnCode_SUCCESS)));
+        ON_CALL(capi, SilKit_TimeSyncService_Create_With_TimeAdvanceMode(_, _, _))
+            .WillByDefault(DoAll(SetArgPointee<0>(mockTimeSyncService), Return(SilKit_ReturnCode_SUCCESS)));
         ON_CALL(capi, SilKit_SystemMonitor_Create(_, _))
             .WillByDefault(DoAll(SetArgPointee<0>(mockSystemMonitor), Return(SilKit_ReturnCode_SUCCESS)));
         ON_CALL(capi, SilKit_Experimental_SystemController_Create(_, _))
@@ -362,6 +364,23 @@ TEST_F(Test_HourglassOrchestration, SilKit_TimeSyncService_Create)
         mockLifecycleService};
 }
 
+TEST_F(Test_HourglassOrchestration, SilKit_TimeSyncService_Create_With_TimeAdvanceMode)
+{
+    EXPECT_CALL(capi, SilKit_TimeSyncService_Create_With_TimeAdvanceMode(testing::_, mockLifecycleService,
+                                                                         SilKit_TimeAdvanceMode_ByMinimalDuration));
+
+    SilKit::DETAIL_SILKIT_DETAIL_NAMESPACE_NAME::Impl::Services::Orchestration::TimeSyncService
+        timeSyncService_ByMinimalDuration{
+        mockLifecycleService, SilKit::Services::Orchestration::TimeAdvanceMode::ByMinimalDuration};
+
+    EXPECT_CALL(capi, SilKit_TimeSyncService_Create_With_TimeAdvanceMode(testing::_, mockLifecycleService,
+                                                                         SilKit_TimeAdvanceMode_ByOwnDuration));
+
+    SilKit::DETAIL_SILKIT_DETAIL_NAMESPACE_NAME::Impl::Services::Orchestration::TimeSyncService
+        timeSyncService_ByOwnDuration{
+        mockLifecycleService, SilKit::Services::Orchestration::TimeAdvanceMode::ByOwnDuration};
+}
+
 TEST_F(Test_HourglassOrchestration, SilKit_TimeSyncService_SetSimulationStepHandler)
 {
     const std::chrono::nanoseconds initialStepSize{0x123456};
@@ -414,6 +433,20 @@ TEST_F(Test_HourglassOrchestration, SilKit_TimeSyncService_Now)
 
     EXPECT_EQ(timeSyncService.Now(), nanoseconds);
 }
+
+TEST_F(Test_HourglassOrchestration, SilKit_TimeSyncService_SetStepDuration)
+{
+    const std::chrono::nanoseconds stepDuration{0x123456};
+
+    SilKit::DETAIL_SILKIT_DETAIL_NAMESPACE_NAME::Impl::Services::Orchestration::TimeSyncService timeSyncService{
+        mockLifecycleService};
+
+    EXPECT_CALL(capi, SilKit_TimeSyncService_SetStepDuration(mockTimeSyncService, testing::_))
+            .WillOnce(Return(SilKit_ReturnCode_SUCCESS));
+
+    timeSyncService.SetStepDuration(stepDuration);
+}
+
 
 TEST_F(Test_HourglassOrchestration, SilKit_Experimental_TimeSyncService_AddOtherSimulationStepsCompletedHandler)
 {

--- a/SilKit/IntegrationTests/ITest_AsyncSimTask.cpp
+++ b/SilKit/IntegrationTests/ITest_AsyncSimTask.cpp
@@ -302,11 +302,12 @@ auto MakeCompletionThread(SimParticipant* p, ParticipantData* d) -> std::thread
 
 TEST(ITest_AsyncSimTask, test_async_simtask_other_simulation_steps_completed_handler)
 {
-    SimTestHarness testHarness({"A", "B", "C"}, "silkit://localhost:0");
+    SimTestHarness testHarness({"A", "B", "C", "D"}, "silkit://localhost:0");
 
     const auto a = testHarness.GetParticipant("A");
     const auto b = testHarness.GetParticipant("B");
     const auto c = testHarness.GetParticipant("C");
+    const auto d = testHarness.GetParticipant("D");
 
     ParticipantData ad, bd, cd;
 
@@ -315,6 +316,8 @@ TEST(ITest_AsyncSimTask, test_async_simtask_other_simulation_steps_completed_han
     a->GetOrCreateLifecycleService()->SetStopHandler([&ad] { ad.running = false; });
     b->GetOrCreateLifecycleService()->SetStopHandler([&bd] { bd.running = false; });
     c->GetOrCreateLifecycleService()->SetStopHandler([&cd] { cd.running = false; });
+
+    d->GetOrCreateTimeSyncService()->SetSimulationStepHandler([](auto, auto) {}, 1ms);
 
     const auto aLifecycleService = a->GetOrCreateLifecycleService();
 

--- a/SilKit/IntegrationTests/ITest_DynStepSizes.cpp
+++ b/SilKit/IntegrationTests/ITest_DynStepSizes.cpp
@@ -1,0 +1,359 @@
+// SPDX-FileCopyrightText: 2023 Vector Informatik GmbH
+//
+// SPDX-License-Identifier: MIT
+
+#include <memory>
+#include <thread>
+#include <string>
+#include <chrono>
+#include <iostream>
+#include <sstream>
+#include "ITestFixture.hpp"
+
+using namespace std::chrono_literals;
+
+namespace testing {
+namespace internal {
+template <typename Rep, typename Period>
+class UniversalPrinter<std::chrono::duration<Rep, Period>>
+{
+public:
+    static void Print(const std::chrono::duration<Rep, Period>& value, ::std::ostream* os)
+    {
+        *os << std::chrono::duration_cast<std::chrono::nanoseconds>(value).count() << "ns";
+    }
+};
+
+template <typename R1, typename P1, typename R2, typename P2>
+class UniversalPrinter<std::pair<std::chrono::duration<R1, P1>, std::chrono::duration<R2, P2>>>
+{
+public:
+    static void Print(const std::pair<std::chrono::duration<R1, P1>, std::chrono::duration<R2, P2>>& p,
+                      ::std::ostream* os)
+    {
+        *os << "(";
+        UniversalPrinter<std::chrono::nanoseconds>::Print(p.first, os);
+        *os << ", ";
+        UniversalPrinter<std::chrono::nanoseconds>::Print(p.second, os);
+        *os << ")";
+    }
+};
+
+} // namespace internal
+} // namespace testing
+
+inline std::string ToString(const std::chrono::nanoseconds& ns)
+{
+    std::ostringstream os;
+    testing::internal::UniversalPrinter<std::chrono::nanoseconds>::Print(ns, &os);
+    return os.str();
+}
+inline std::string ToString(const std::pair<std::chrono::nanoseconds, std::chrono::nanoseconds>& p)
+{
+    std::ostringstream os;
+    testing::internal::UniversalPrinter<std::pair<std::chrono::nanoseconds, std::chrono::nanoseconds>>::Print(p, &os);
+    return os.str();
+}
+
+namespace {
+
+using namespace SilKit::Tests;
+using namespace SilKit::Config;
+using namespace SilKit::Services;
+using namespace SilKit::Services::Orchestration;
+
+template <typename Rep, typename Period>
+struct Dummy
+{
+    std::chrono::duration<Rep, Period> value;
+
+    explicit Dummy(const std::chrono::duration<Rep, Period>& v)
+        : value{v}
+    {
+    }
+
+    bool operator==(const Dummy<Rep, Period>& other) const
+    {
+        return value == other.value;
+    }
+
+    friend void PrintTo(const Dummy<Rep, Period>& d, std::ostream* os)
+    {
+        *os << std::chrono::duration_cast<std::chrono::nanoseconds>(d.value).count() << "ns";
+    }
+};
+
+#define SILKIT_ASSERT_CHRONO_EQ(expected, actual) ASSERT_EQ(Dummy{(expected)}, Dummy{(actual)})
+#define SILKIT_EXPECT_CHRONO_EQ(expected, actual) EXPECT_EQ(Dummy{(expected)}, Dummy{(actual)})
+
+
+struct ParticipantParams
+{
+    std::string name{};
+    std::chrono::nanoseconds initialStepSize{1ms};
+    TimeAdvanceMode timeAdvanceMode{TimeAdvanceMode::ByOwnDuration};
+    
+    // Change step size at these time points
+    std::map<std::chrono::nanoseconds /*changeTimePoint*/, std::chrono::nanoseconds /*newStepSize*/> changeStepSizeAtTimePoints{};
+    
+    // Result: recorded time points and durations
+    std::vector<std::pair<std::chrono::nanoseconds, std::chrono::nanoseconds>> timePointsAndDurations{}; 
+};
+
+struct ITest_DynStepSizes : ITest_SimTestHarness
+{
+    using ITest_SimTestHarness::ITest_SimTestHarness;
+    void RunTestSetup(std::vector<ParticipantParams>& participantsParams);
+    void AssertAllStepsEqual(const std::vector<ParticipantParams>& participantsParams);
+    void AssertAscendingStepsWithReferenceDuration(const std::vector<ParticipantParams>& participantsParams,
+                                                   std::chrono::nanoseconds refDuration);
+    void AssertStepsEqual(const std::vector<std::chrono::nanoseconds>& s1,
+                          const std::vector<std::chrono::nanoseconds>& s2);
+};
+
+void ITest_DynStepSizes::RunTestSetup(std::vector<ParticipantParams>& participantsParams)
+{
+    std::vector<std::string> participantNames;
+    for (const auto& participantParams : participantsParams)
+    {
+        participantNames.push_back(participantParams.name);
+    }
+    SetupFromParticipantList(participantNames);
+
+    std::mutex mx;
+
+    for (auto& participantParams : participantsParams)
+    {
+        auto&& simParticipant = _simTestHarness->GetParticipant(participantParams.name);
+        auto&& lifecycleService = simParticipant->GetOrCreateLifecycleService();
+        auto* timeSyncService = lifecycleService->CreateTimeSyncService(participantParams.timeAdvanceMode);
+        timeSyncService->SetSimulationStepHandler([timeSyncService, &participantParams, &mx, lifecycleService](auto now, auto duration) {
+            if (now >= 100ms)
+            {
+                lifecycleService->Stop("stopping the test at 100ms");
+            }
+            else
+            {
+                std::lock_guard<std::mutex> lock(mx);
+                participantParams.timePointsAndDurations.emplace_back(now, duration);
+
+                // Check if we need to change the step size at this time point
+                auto it = participantParams.changeStepSizeAtTimePoints.find(now);
+                if (it != participantParams.changeStepSizeAtTimePoints.end())
+                {
+                    auto newStepSize = it->second;
+                    timeSyncService->SetStepDuration(newStepSize);
+                }
+            }
+        }, participantParams.initialStepSize);
+    }
+
+    auto ok = _simTestHarness->Run(5s);
+    ASSERT_TRUE(ok) << "SimTestHarness should terminate without timeout";
+}
+
+void ITest_DynStepSizes::AssertAllStepsEqual(const std::vector<ParticipantParams>& participantsParams)
+{
+    for (size_t i = 1; i < participantsParams.size(); ++i)
+    {
+        const auto& ref = participantsParams[0].timePointsAndDurations;
+        const auto& cmp = participantsParams[i].timePointsAndDurations;
+
+        ASSERT_EQ(ref.size(), cmp.size())
+            << "Different number of steps for " << participantsParams[0].name << " and " << participantsParams[i].name;
+
+        for (size_t j = 0; j < ref.size(); ++j)
+        {
+            EXPECT_EQ(ref[j], cmp[j]) << "Differenz at index " << j << ": " << participantsParams[0].name
+                                      << "(now=" << ToString(ref[j].first) << ", duration=" << ToString(ref[j].second) << ")"
+                                      << " vs " << participantsParams[i].name << "(now=" << ToString(cmp[j].first)
+                                      << ", duration=" << ToString(cmp[j].second) << ")";
+        }
+    }
+}
+
+void ITest_DynStepSizes::AssertAscendingStepsWithReferenceDuration(
+    const std::vector<ParticipantParams>& participantsParams, std::chrono::nanoseconds refDuration)
+{
+    for (const auto& participant : participantsParams)
+    {
+        const auto& steps = participant.timePointsAndDurations;
+        ASSERT_FALSE(steps.empty()) << "No simulation steps for participant " << participant.name;
+
+        for (size_t i = 0; i < steps.size(); ++i)
+        {
+            // Check if duration matches the reference duration
+            EXPECT_EQ(steps[i].second, refDuration) << "Duration mismatch for " << participant.name << " at index " << i
+                                                    << ": expected " << ToString(refDuration) << ", got " << ToString(steps[i].second);
+
+            // Check if time points are strictly increasing by refDuration
+            if (i > 0)
+            {
+                auto diff = steps[i].first - steps[i - 1].first;
+                EXPECT_EQ(diff, refDuration)
+                    << "Timestep difference for " << participant.name << " at index " << i << " is " << ToString(diff)
+                    << ", expected " << ToString(refDuration) << " (" << ToString(steps[i - 1].first) << " -> "
+                    << ToString(steps[i].first) << ")";
+            }
+        }
+    }
+}
+
+void ITest_DynStepSizes::AssertStepsEqual(const std::vector<std::chrono::nanoseconds>& s1,
+                                          const std::vector<std::chrono::nanoseconds>& s2)
+{
+    ASSERT_EQ(s1.size(), s2.size()) << "Different number of steps";
+
+    for (size_t j = 0; j < s1.size(); ++j)
+    {
+        SILKIT_EXPECT_CHRONO_EQ(s1[j], s2[j]) << "Differenz at index " << j << ": "
+                                << "s1 now=" << ToString(s1[j]) << " vs s2 now=" << ToString(s2[j]);
+    }
+}
+
+// Zero duration is invalid and should throw
+TEST_F(ITest_DynStepSizes, invalid_duration)
+{
+    auto invalidDuration = 0ns;
+    std::vector<ParticipantParams> participantsParams = {{"P1", invalidDuration, TimeAdvanceMode::ByMinimalDuration}};
+    EXPECT_THROW(RunTestSetup(participantsParams), SilKit::SilKitError);
+}
+
+// Single participant with both time advance modes
+TEST_F(ITest_DynStepSizes, one_participant_ByMinimalDuration)
+{
+    auto refDuration = 5ms;
+    std::vector<ParticipantParams> participantsParams = {{"P1", refDuration, TimeAdvanceMode::ByMinimalDuration}};
+    RunTestSetup(participantsParams);
+    AssertAscendingStepsWithReferenceDuration(participantsParams, refDuration);
+}
+TEST_F(ITest_DynStepSizes, one_participant_ByOwnDuration)
+{
+    auto refDuration = 5ms;
+    std::vector<ParticipantParams> participantsParams = {{"P1", refDuration, TimeAdvanceMode::ByOwnDuration}};
+    RunTestSetup(participantsParams);
+    AssertAscendingStepsWithReferenceDuration(participantsParams, refDuration);
+}
+
+// Two/Three participants with ByMinimalDuration mode; Expect steps aligned to the minimal duration
+TEST_F(ITest_DynStepSizes, two_participants_ByMinimalDuration)
+{
+    std::vector<ParticipantParams> participantsParams = {{"P1", 1ms, TimeAdvanceMode::ByMinimalDuration},
+                                                         {"P2", 5ms, TimeAdvanceMode::ByMinimalDuration}};
+    RunTestSetup(participantsParams);
+    AssertAscendingStepsWithReferenceDuration(participantsParams, 1ms);
+}
+TEST_F(ITest_DynStepSizes, three_participants_ByMinimalDuration)
+{
+    std::vector<ParticipantParams> participantsParams = {{"P1", 1ms, TimeAdvanceMode::ByMinimalDuration},
+                                                         {"P2", 2ms, TimeAdvanceMode::ByMinimalDuration},
+                                                         {"P3", 3ms, TimeAdvanceMode::ByMinimalDuration}};
+    RunTestSetup(participantsParams);
+    AssertAscendingStepsWithReferenceDuration(participantsParams, 1ms);
+}
+
+// Two participants with mixed modes; Expect steps aligned to the minimal/own duration
+TEST_F(ITest_DynStepSizes, two_participants_MixedTimeAdvanceModes)
+{
+    std::vector<ParticipantParams> participantsParams = {{"P1", 5ms, TimeAdvanceMode::ByMinimalDuration},
+                                                         {"P2", 1ms, TimeAdvanceMode::ByOwnDuration}};
+    RunTestSetup(participantsParams);
+    AssertAscendingStepsWithReferenceDuration(participantsParams, 1ms);
+}
+
+// Three participants with mixed modes; Expect steps of P3(ByMinimalDuration) are equal to the union of P1,P2(ByOwnDuration)
+TEST_F(ITest_DynStepSizes, three_participants_MixedTimeAdvanceModes)
+{
+    std::vector<ParticipantParams> participantsParams = {{"P1", 2ms, TimeAdvanceMode::ByOwnDuration},
+                                                         {"P2", 3ms, TimeAdvanceMode::ByOwnDuration},
+                                                         {"P3", 4ms, TimeAdvanceMode::ByMinimalDuration}};
+    RunTestSetup(participantsParams);
+
+    AssertAscendingStepsWithReferenceDuration({participantsParams[0]}, 2ms);
+    AssertAscendingStepsWithReferenceDuration({participantsParams[1]}, 3ms);
+
+    // Collect nows for P1 and P2
+    std::set<std::chrono::nanoseconds> unionNows;
+    for (size_t i = 0; i < 2; ++i)
+    {
+        for (const auto& step : participantsParams[i].timePointsAndDurations)
+        {
+            unionNows.insert(step.first);
+        }
+    }
+    // Convert unionNows to sorted vector
+    std::vector<std::chrono::nanoseconds> unionNowsVec(unionNows.begin(), unionNows.end());
+    // Collect nows for P3
+    std::vector<std::chrono::nanoseconds> p3Nows;
+    for (const auto& step : participantsParams[2].timePointsAndDurations)
+    {
+        p3Nows.push_back(step.first);
+    }
+    // Compare P3 nows with union of P1 and P2 nows
+    AssertStepsEqual(p3Nows, unionNowsVec);
+
+}
+
+// Change to a different step size during simulation
+TEST_F(ITest_DynStepSizes, one_participant_change_step_size)
+{
+    std::vector<ParticipantParams> participantsParams = {
+        {"P1", 1ms, TimeAdvanceMode::ByOwnDuration, {{9ms, 10ms}, {80ms, 2ms}}}};
+    RunTestSetup(participantsParams);
+
+    ParticipantParams refData;
+    refData.name = "Reference";
+    refData.timePointsAndDurations = {
+        {0ms, 1ms},   {1ms, 1ms},   {2ms, 1ms},   {3ms, 1ms},   {4ms, 1ms},   {5ms, 1ms},   {6ms, 1ms},   {7ms, 1ms},
+        {8ms, 1ms},   {9ms, 1ms},   {10ms, 10ms}, {20ms, 10ms}, {30ms, 10ms}, {40ms, 10ms}, {50ms, 10ms}, {60ms, 10ms},
+        {70ms, 10ms}, {80ms, 10ms}, {90ms, 2ms},  {92ms, 2ms},  {94ms, 2ms},  {96ms, 2ms},  {98ms, 2ms}};
+
+    AssertAllStepsEqual({participantsParams[0], refData});
+}
+
+// Change to different step sizes during simulation; mixed time advance modes
+TEST_F(ITest_DynStepSizes, two_participants_mixed_change_step_size)
+{
+    std::vector<ParticipantParams> participantsParams = {
+        {"P1", 1ms, TimeAdvanceMode::ByOwnDuration, {{9ms, 10ms}, {80ms, 2ms}}},
+        {"P2", 20ms, TimeAdvanceMode::ByMinimalDuration}
+    };
+
+    RunTestSetup(participantsParams);
+
+    ParticipantParams refData;
+    refData.name = "Reference";
+    refData.timePointsAndDurations = {
+        {0ms, 1ms},   {1ms, 1ms},   {2ms, 1ms},   {3ms, 1ms},   {4ms, 1ms},   {5ms, 1ms},   {6ms, 1ms},   {7ms, 1ms},
+        {8ms, 1ms},   {9ms, 1ms},   {10ms, 10ms}, {20ms, 10ms}, {30ms, 10ms}, {40ms, 10ms}, {50ms, 10ms}, {60ms, 10ms},
+        {70ms, 10ms}, {80ms, 10ms}, {90ms, 2ms},  {92ms, 2ms},  {94ms, 2ms},  {96ms, 2ms},  {98ms, 2ms}};
+
+
+    AssertAllStepsEqual({participantsParams[0], refData});
+    // P2 (ByMinimalDuration) follows P1 (ByOwnDuration)
+    AssertAllStepsEqual({participantsParams[0], participantsParams[1]}); 
+}
+
+// Change to different step sizes during simulation; both participants with ByMinimalDuration
+TEST_F(ITest_DynStepSizes, two_participants_ByMinimalDuration_change_step_size)
+{
+    std::vector<ParticipantParams> participantsParams = {
+        {"P1", 1ms, TimeAdvanceMode::ByMinimalDuration, {{9ms, 10ms}, {80ms, 2ms}}},
+        {"P2", 20ms, TimeAdvanceMode::ByMinimalDuration}};
+
+    RunTestSetup(participantsParams);
+
+    ParticipantParams refData;
+    refData.name = "Reference";
+    refData.timePointsAndDurations = {
+        {0ms, 1ms},   {1ms, 1ms},   {2ms, 1ms},   {3ms, 1ms},   {4ms, 1ms},   {5ms, 1ms},   {6ms, 1ms},   {7ms, 1ms},
+        {8ms, 1ms},   {9ms, 1ms},   {10ms, 10ms}, {20ms, 10ms}, {30ms, 10ms}, {40ms, 10ms}, {50ms, 10ms}, {60ms, 10ms},
+        {70ms, 10ms}, {80ms, 10ms}, {90ms, 2ms},  {92ms, 2ms},  {94ms, 2ms},  {96ms, 2ms},  {98ms, 2ms}};
+
+
+    AssertAllStepsEqual({participantsParams[0], refData});
+    AssertAllStepsEqual({participantsParams[0], participantsParams[1]});
+}
+
+
+} //end namespace

--- a/SilKit/IntegrationTests/SimTestHarness/SimTestHarness.cpp
+++ b/SilKit/IntegrationTests/SimTestHarness/SimTestHarness.cpp
@@ -304,11 +304,6 @@ void SimTestHarness::AddParticipant(const std::string& participantName, const st
     // mandatory sim task for time synced simulation
     // by default, we do no operation during simulation task, the user should override this
     auto* lifecycleService = participant->GetOrCreateLifecycleService(startConfiguration);
-    if (startConfiguration.operationMode == SilKit::Services::Orchestration::OperationMode::Coordinated)
-    {
-        auto* timeSyncService = participant->GetOrCreateTimeSyncService();
-        timeSyncService->SetSimulationStepHandler([](auto, auto) {}, 1ms);
-    }
 
     lifecycleService->SetCommunicationReadyHandler([]() {});
 

--- a/SilKit/include/silkit/capi/Orchestration.h
+++ b/SilKit/include/silkit/capi/Orchestration.h
@@ -94,6 +94,12 @@ typedef int8_t SilKit_OperationMode;
 #define SilKit_OperationMode_Autonomous ((SilKit_OperationMode)20)
 
 
+/*! The TimeAdvanceMode. */
+typedef int8_t SilKit_TimeAdvanceMode;
+
+#define SilKit_TimeAdvanceMode_ByOwnDuration ((SilKit_TimeAdvanceMode)0)
+#define SilKit_TimeAdvanceMode_ByMinimalDuration ((SilKit_TimeAdvanceMode)10)
+
 /*! Details about a status change of a participant. */
 typedef struct
 {
@@ -452,6 +458,20 @@ SilKitAPI SilKit_ReturnCode SilKitCALL SilKit_TimeSyncService_Create(SilKit_Time
 typedef SilKit_ReturnCode(SilKitFPTR* SilKit_TimeSyncService_Create_t)(SilKit_TimeSyncService** outTimeSyncService,
                                                                        SilKit_LifecycleService* lifecycleService);
 
+/*! \brief Create a time sync service at this SIL Kit simulation participant.
+ * \param outTimeSyncService Pointer that refers to the resulting time sync service (out parameter).
+ * \param lifecycleService The lifecyle service at which the time sync service should be created.
+ * \param timeAdvanceMode The time advance mode for this time sync service.
+ *
+ * The object returned must not be deallocated using free()!
+ */
+SilKitAPI SilKit_ReturnCode SilKitCALL SilKit_TimeSyncService_Create_With_TimeAdvanceMode(SilKit_TimeSyncService** outTimeSyncService,
+                                                                     SilKit_LifecycleService* lifecycleService, SilKit_TimeAdvanceMode timeAdvanceMode);
+
+typedef SilKit_ReturnCode(SilKitFPTR* SilKit_TimeSyncService_Create_With_TimeAdvanceMode_t)(SilKit_TimeSyncService** outTimeSyncService,
+                                                                       SilKit_LifecycleService* lifecycleService,
+                                                                       SilKit_TimeAdvanceMode timeAdvanceMode);
+
 /*! \brief The handler to be called if the simulation task is due
  *
  * \param context The user provided context passed in \ref SilKit_TimeSyncService_SetSimulationStepHandler
@@ -526,6 +546,18 @@ SilKitAPI SilKit_ReturnCode SilKitCALL SilKit_TimeSyncService_Now(SilKit_TimeSyn
 
 typedef SilKit_ReturnCode(SilKitFPTR* SilKit_TimeSyncService_Now_t)(SilKit_TimeSyncService* timeSyncService,
                                                                     SilKit_NanosecondsTime* outNanosecondsTime);
+
+
+/*! \brief Set the duration of the next simulation step
+ *
+ * \param timeSyncService The time sync service obtained via \ref SilKit_TimeSyncService_Create.
+ * \param stepDuration The step size in nanoseconds.
+ */
+SilKitAPI SilKit_ReturnCode SilKitCALL SilKit_TimeSyncService_SetStepDuration(SilKit_TimeSyncService* timeSyncService,
+                                                                        SilKit_NanosecondsTime stepDuration);
+
+typedef SilKit_ReturnCode(SilKitFPTR* SilKit_TimeSyncService_SetStepDuration_t)(SilKit_TimeSyncService* timeSyncService,
+                                                                                SilKit_NanosecondsTime stepDuration);
 
 
 /*

--- a/SilKit/include/silkit/detail/impl/services/orchestration/LifecycleService.hpp
+++ b/SilKit/include/silkit/detail/impl/services/orchestration/LifecycleService.hpp
@@ -66,6 +66,9 @@ public:
 
     inline auto CreateTimeSyncService() -> SilKit::Services::Orchestration::ITimeSyncService* override;
 
+    inline auto CreateTimeSyncService(SilKit::Services::Orchestration::TimeAdvanceMode timeAdvanceMode)
+        -> SilKit::Services::Orchestration::ITimeSyncService* override;
+
 private:
     SilKit_LifecycleService* _lifecycleService{nullptr};
 
@@ -315,10 +318,21 @@ auto LifecycleService::Status() const -> const SilKit::Services::Orchestration::
 
 auto LifecycleService::CreateTimeSyncService() -> SilKit::Services::Orchestration::ITimeSyncService*
 {
-    _timeSyncService = std::make_unique<TimeSyncService>(_lifecycleService);
+    _timeSyncService = std::make_unique<TimeSyncService>(
+        _lifecycleService, SilKit::Services::Orchestration::TimeAdvanceMode::ByOwnDuration);
 
     return _timeSyncService.get();
 }
+
+// TODO bkd: Needed  or can I use a default in the function above? 
+auto LifecycleService::CreateTimeSyncService(SilKit::Services::Orchestration::TimeAdvanceMode timeAdvanceMode)
+    -> SilKit::Services::Orchestration::ITimeSyncService*
+{
+    _timeSyncService = std::make_unique<TimeSyncService>(_lifecycleService, timeAdvanceMode);
+
+    return _timeSyncService.get();
+}
+
 
 } // namespace Orchestration
 } // namespace Services

--- a/SilKit/include/silkit/detail/impl/services/orchestration/LifecycleService.hpp
+++ b/SilKit/include/silkit/detail/impl/services/orchestration/LifecycleService.hpp
@@ -324,7 +324,7 @@ auto LifecycleService::CreateTimeSyncService() -> SilKit::Services::Orchestratio
     return _timeSyncService.get();
 }
 
-// TODO bkd: Needed  or can I use a default in the function above? 
+// TODO bkd: Needed or can I use a default in the function above? 
 auto LifecycleService::CreateTimeSyncService(SilKit::Services::Orchestration::TimeAdvanceMode timeAdvanceMode)
     -> SilKit::Services::Orchestration::ITimeSyncService*
 {

--- a/SilKit/include/silkit/detail/impl/services/orchestration/TimeSyncService.hpp
+++ b/SilKit/include/silkit/detail/impl/services/orchestration/TimeSyncService.hpp
@@ -22,7 +22,11 @@ namespace Orchestration {
 class TimeSyncService : public SilKit::Services::Orchestration::ITimeSyncService
 {
 public:
+
     inline explicit TimeSyncService(SilKit_LifecycleService* lifecycleService);
+
+    inline explicit TimeSyncService(SilKit_LifecycleService* lifecycleService,
+                                    SilKit::Services::Orchestration::TimeAdvanceMode timeAdvanceMode);
 
     inline ~TimeSyncService() override = default;
 
@@ -35,7 +39,9 @@ public:
 
     inline auto Now() const -> std::chrono::nanoseconds override;
 
-public:
+    inline void SetStepDuration(std::chrono::nanoseconds stepDuration) override;
+
+    public:
     inline auto ExperimentalAddOtherSimulationStepsCompletedHandler(
         SilKit::Experimental::Services::Orchestration::OtherSimulationStepsCompletedHandler) -> SilKit::Util::HandlerId;
 
@@ -82,6 +88,12 @@ namespace Orchestration {
 TimeSyncService::TimeSyncService(SilKit_LifecycleService* lifecycleService)
 {
     const auto returnCode = SilKit_TimeSyncService_Create(&_timeSyncService, lifecycleService);
+    ThrowOnError(returnCode);
+}
+
+TimeSyncService::TimeSyncService(SilKit_LifecycleService* lifecycleService, SilKit::Services::Orchestration::TimeAdvanceMode timeAdvanceMode)
+{
+    const auto returnCode = SilKit_TimeSyncService_Create_With_TimeAdvanceMode(&_timeSyncService, lifecycleService, static_cast<SilKit_TimeAdvanceMode>(timeAdvanceMode));
     ThrowOnError(returnCode);
 }
 
@@ -138,6 +150,12 @@ auto TimeSyncService::Now() const -> std::chrono::nanoseconds
     ThrowOnError(returnCode);
 
     return std::chrono::nanoseconds{nanosecondsTime};
+}
+
+void TimeSyncService::SetStepDuration(std::chrono::nanoseconds stepDuration)
+{
+    const auto returnCode = SilKit_TimeSyncService_SetStepDuration(_timeSyncService, stepDuration.count());
+    ThrowOnError(returnCode);
 }
 
 inline auto TimeSyncService::ExperimentalAddOtherSimulationStepsCompletedHandler(std::function<void()> handler)

--- a/SilKit/include/silkit/services/orchestration/ILifecycleService.hpp
+++ b/SilKit/include/silkit/services/orchestration/ILifecycleService.hpp
@@ -191,6 +191,8 @@ public:
     /*! \brief Return the  ITimeSyncService for the current ILifecycleService.
     */
     virtual auto CreateTimeSyncService() -> ITimeSyncService* = 0;
+
+    virtual auto CreateTimeSyncService(TimeAdvanceMode timeAdvanceMode) -> ITimeSyncService* = 0;
 };
 
 } // namespace Orchestration

--- a/SilKit/include/silkit/services/orchestration/ITimeSyncService.hpp
+++ b/SilKit/include/silkit/services/orchestration/ITimeSyncService.hpp
@@ -53,7 +53,6 @@ public:
 
     virtual void SetStepDuration(std::chrono::nanoseconds stepDuration) = 0;
 
-
 };
 
 } // namespace Orchestration

--- a/SilKit/include/silkit/services/orchestration/ITimeSyncService.hpp
+++ b/SilKit/include/silkit/services/orchestration/ITimeSyncService.hpp
@@ -50,6 +50,10 @@ public:
     /*! \brief Get the current simulation time
      */
     virtual auto Now() const -> std::chrono::nanoseconds = 0;
+
+    virtual void SetStepDuration(std::chrono::nanoseconds stepDuration) = 0;
+
+
 };
 
 } // namespace Orchestration

--- a/SilKit/include/silkit/services/orchestration/OrchestrationDatatypes.hpp
+++ b/SilKit/include/silkit/services/orchestration/OrchestrationDatatypes.hpp
@@ -119,6 +119,14 @@ struct ParticipantConnectionInformation
     std::string participantName;
 };
 
+enum class TimeAdvanceMode : SilKit_TimeAdvanceMode
+{
+    //! Advance time based on the participant's own step duration
+    ByOwnDuration = SilKit_TimeAdvanceMode_ByOwnDuration,
+    //! Advance time based on the minimal step duration among all participants
+    ByMinimalDuration = SilKit_TimeAdvanceMode_ByMinimalDuration,
+};
+
 } // namespace Orchestration
 } // namespace Services
 } // namespace SilKit

--- a/SilKit/source/capi/CapiOrchestration.cpp
+++ b/SilKit/source/capi/CapiOrchestration.cpp
@@ -90,6 +90,23 @@ try
 }
 CAPI_CATCH_EXCEPTIONS
 
+SilKit_ReturnCode SilKitCALL SilKit_TimeSyncService_Create_With_TimeAdvanceMode(
+    SilKit_TimeSyncService** outTimeSyncService, SilKit_LifecycleService* lifecycleService,
+    SilKit_TimeAdvanceMode timeAdvanceMode)
+try
+{
+    ASSERT_VALID_OUT_PARAMETER(outTimeSyncService);
+    ASSERT_VALID_POINTER_PARAMETER(lifecycleService);
+
+    auto cppLifecycleService = reinterpret_cast<SilKit::Services::Orchestration::ILifecycleService*>(lifecycleService);
+    auto cppTimeSyncService = cppLifecycleService->CreateTimeSyncService(SilKit::Services::Orchestration::TimeAdvanceMode(timeAdvanceMode));
+
+    *outTimeSyncService = reinterpret_cast<SilKit_TimeSyncService*>(cppTimeSyncService);
+
+    return SilKit_ReturnCode_SUCCESS;
+}
+CAPI_CATCH_EXCEPTIONS
+
 
 SilKit_ReturnCode SilKitCALL
 SilKit_LifecycleService_SetCommunicationReadyHandler(SilKit_LifecycleService* lifecycleService, void* context,
@@ -423,6 +440,26 @@ try
 
     auto* timeSyncService = reinterpret_cast<SilKit::Services::Orchestration::ITimeSyncService*>(cTimeSyncService);
     *outNanosecondsTime = timeSyncService->Now().count();
+    return SilKit_ReturnCode_SUCCESS;
+}
+CAPI_CATCH_EXCEPTIONS
+
+
+SilKit_ReturnCode SilKitCALL SilKit_TimeSyncService_SetStepDuration(SilKit_TimeSyncService* cTimeSyncService,
+                                                        SilKit_NanosecondsTime stepDuration)
+try
+{
+    ASSERT_VALID_POINTER_PARAMETER(cTimeSyncService);
+
+    auto* timeSyncService = reinterpret_cast<SilKit::Services::Orchestration::ITimeSyncService*>(cTimeSyncService);
+
+    if (stepDuration <= 0)
+    {
+        SilKit_error_string = "Step duration must be positive";
+        return SilKit_ReturnCode_BADPARAMETER;
+    }
+
+    timeSyncService->SetStepDuration(std::chrono::nanoseconds(stepDuration));
     return SilKit_ReturnCode_SUCCESS;
 }
 CAPI_CATCH_EXCEPTIONS

--- a/SilKit/source/capi/Test_CapiSymbols.cpp
+++ b/SilKit/source/capi/Test_CapiSymbols.cpp
@@ -87,6 +87,7 @@ TEST(Test_CapiSymbols, DISABLED_link_all_public_symbols)
     (void)SilKit_SystemMonitor_Create(nullptr, nullptr);
     (void)SilKit_LifecycleService_Create(nullptr, nullptr, nullptr);
     (void)SilKit_TimeSyncService_Create(nullptr, nullptr);
+    (void)SilKit_TimeSyncService_Create_With_TimeAdvanceMode(nullptr, nullptr, 0);
     (void)SilKit_LifecycleService_SetCommunicationReadyHandler(nullptr, nullptr, nullptr);
     (void)SilKit_LifecycleService_SetCommunicationReadyHandlerAsync(nullptr, nullptr, nullptr);
     (void)SilKit_LifecycleService_CompleteCommunicationReadyHandlerAsync(nullptr);

--- a/SilKit/source/core/mock/participant/MockParticipant.hpp
+++ b/SilKit/source/core/mock/participant/MockParticipant.hpp
@@ -71,6 +71,8 @@ public:
     MOCK_METHOD(Services::Orchestration::ParticipantStatus&, Status, (), (override, const));
     MOCK_METHOD(Services::Orchestration::ITimeSyncService*, GetTimeSyncService, (), ());
     MOCK_METHOD(Services::Orchestration::ITimeSyncService*, CreateTimeSyncService, (), (override));
+    MOCK_METHOD(Services::Orchestration::ITimeSyncService*, CreateTimeSyncService,
+                (SilKit::Services::Orchestration::TimeAdvanceMode), (override));
     MOCK_METHOD(void, AddAsyncSubscriptionsCompletionHandler, (std::function<void()> /*handler*/));
     MOCK_METHOD(Services::Orchestration::OperationMode, GetOperationMode, (), (const));
 };
@@ -84,6 +86,7 @@ public:
                 (SimulationStepHandler task, std::chrono::nanoseconds initialStepSize), (override));
     MOCK_METHOD(void, CompleteSimulationStep, (), (override));
     MOCK_METHOD(std::chrono::nanoseconds, Now, (), (override, const));
+    MOCK_METHOD(void, SetStepDuration, (std::chrono::nanoseconds));
 };
 
 class MockSystemMonitor : public Services::Orchestration::ISystemMonitor
@@ -248,7 +251,8 @@ public:
     DummyParticipant()
     {
         ON_CALL(mockLifecycleService, GetTimeSyncService).WillByDefault(testing::Return(&mockTimeSyncService));
-        ON_CALL(mockLifecycleService, CreateTimeSyncService).WillByDefault(testing::Return(&mockTimeSyncService));
+        ON_CALL(mockLifecycleService, CreateTimeSyncService()).WillByDefault(testing::Return(&mockTimeSyncService));
+        ON_CALL(mockLifecycleService, CreateTimeSyncService(testing::_)).WillByDefault(testing::Return(&mockTimeSyncService));
         ON_CALL(logger, GetLogLevel()).WillByDefault(testing::Return(Services::Logging::Level::Debug));
     }
 

--- a/SilKit/source/services/orchestration/LifecycleService.cpp
+++ b/SilKit/source/services/orchestration/LifecycleService.cpp
@@ -407,6 +407,22 @@ auto LifecycleService::CreateTimeSyncService() -> ITimeSyncService*
     {
         _participant->RegisterTimeSyncService(_timeSyncService);
         _timeSyncActive = true;
+        _timeSyncService->SetTimeAdvanceMode(TimeAdvanceMode::ByOwnDuration);
+        return _timeSyncService;
+    }
+    else
+    {
+        throw ConfigurationError("You may not create the time synchronization service more than once.");
+    }
+}
+
+auto LifecycleService::CreateTimeSyncService(TimeAdvanceMode timeAdvanceMode) -> ITimeSyncService*
+{
+    if (!_timeSyncActive)
+    {
+        _participant->RegisterTimeSyncService(_timeSyncService);
+        _timeSyncActive = true;
+        _timeSyncService->SetTimeAdvanceMode(timeAdvanceMode);
         return _timeSyncService;
     }
     else

--- a/SilKit/source/services/orchestration/LifecycleService.hpp
+++ b/SilKit/source/services/orchestration/LifecycleService.hpp
@@ -54,6 +54,7 @@ public:
     void SetAbortHandler(AbortHandler handler) override;
 
     auto CreateTimeSyncService() -> ITimeSyncService* override;
+    auto CreateTimeSyncService(TimeAdvanceMode timeAdvanceMode) -> ITimeSyncService* override;
     auto GetTimeSyncService() -> ITimeSyncService*;
 
     auto StartLifecycle() -> std::future<ParticipantState> override;

--- a/SilKit/source/services/orchestration/Test_LifecycleService.cpp
+++ b/SilKit/source/services/orchestration/Test_LifecycleService.cpp
@@ -44,8 +44,8 @@ public:
     MOCK_METHOD(void, SetSimulationStepHandlerAsync,
                 (SimulationStepHandler task, std::chrono::nanoseconds initialStepSize), (override));
     MOCK_METHOD(void, CompleteSimulationStep, (), (override));
-    MOCK_METHOD(void, SetPeriod, (std::chrono::nanoseconds));
     MOCK_METHOD(std::chrono::nanoseconds, Now, (), (override, const));
+    MOCK_METHOD(void, SetStepDuration, (std::chrono::nanoseconds), (override));
 };
 
 class MockParticipant : public DummyParticipant
@@ -1155,6 +1155,9 @@ TEST_F(Test_LifecycleService, error_on_create_time_sync_service_twice)
     // Goal: make sure that CreateTimeSync cannot be called more than once (must throw exception)
     LifecycleService lifecycleService(&participant);
     lifecycleService.SetLifecycleConfiguration(StartCoordinated());
+
+    MockTimeSync mockTimeSync(&participant, &participant.mockTimeProvider, healthCheckConfig, &lifecycleService);
+    lifecycleService.SetTimeSyncService(&mockTimeSync);
 
     EXPECT_NO_THROW({
         try

--- a/SilKit/source/services/orchestration/TimeConfiguration.hpp
+++ b/SilKit/source/services/orchestration/TimeConfiguration.hpp
@@ -40,7 +40,7 @@ public: //Methods
     bool HoppedOn();
 
     void SetStepDuration(std::chrono::nanoseconds duration);
-    auto GetMinimalOtherDuration() const -> std::chrono::nanoseconds;
+    auto GetMinimalAlignedDuration() const -> std::chrono::nanoseconds;
 
     auto GetTimeAdvanceMode() const -> TimeAdvanceMode;
     void SetTimeAdvanceMode(TimeAdvanceMode timeAdvanceMode);
@@ -57,7 +57,6 @@ private: //Members
     Logging::ILoggerInternal* _logger;
 
     TimeAdvanceMode _timeAdvanceMode{TimeAdvanceMode::ByOwnDuration};
-
 };
 
 } // namespace Orchestration

--- a/SilKit/source/services/orchestration/TimeConfiguration.hpp
+++ b/SilKit/source/services/orchestration/TimeConfiguration.hpp
@@ -26,8 +26,6 @@ public: //Methods
     bool RemoveSynchronizedParticipant(const std::string& otherParticipantName);
     auto GetSynchronizedParticipantNames() -> std::vector<std::string>;
     void OnReceiveNextSimStep(const std::string& participantName, NextSimTask nextStep);
-    void SynchronizedParticipantRemoved(const std::string& otherParticipantName);
-    void SetStepDuration(std::chrono::nanoseconds duration);
     void AdvanceTimeStep();
     auto CurrentSimStep() const -> NextSimTask;
     auto NextSimStep() const -> NextSimTask;
@@ -41,6 +39,12 @@ public: //Methods
     bool IsHopOn();
     bool HoppedOn();
 
+    void SetStepDuration(std::chrono::nanoseconds duration);
+    auto GetMinimalOtherDuration() const -> std::chrono::nanoseconds;
+
+    auto GetTimeAdvanceMode() const -> TimeAdvanceMode;
+    void SetTimeAdvanceMode(TimeAdvanceMode timeAdvanceMode);
+
 private: //Members
     mutable std::mutex _mx;
     using Lock = std::unique_lock<decltype(_mx)>;
@@ -51,6 +55,9 @@ private: //Members
 
     bool _hoppedOn = false;
     Logging::ILoggerInternal* _logger;
+
+    TimeAdvanceMode _timeAdvanceMode{TimeAdvanceMode::ByOwnDuration};
+
 };
 
 } // namespace Orchestration

--- a/SilKit/source/services/orchestration/TimeSyncService.cpp
+++ b/SilKit/source/services/orchestration/TimeSyncService.cpp
@@ -192,6 +192,7 @@ private:
             return false;
         }
 
+        // No other participant has a lower time point
         if (_configuration->OtherParticipantHasLowerTimepoint())
         {
             return false;
@@ -453,9 +454,9 @@ void TimeSyncService::SetSimulationStepHandlerAsync(SimulationStepHandler task,
     _timeConfiguration.SetStepDuration(initialStepSize);
 }
 
-void TimeSyncService::SetPeriod(std::chrono::nanoseconds period)
+void TimeSyncService::SetStepDuration(std::chrono::nanoseconds stepDuration)
 {
-    _timeConfiguration.SetStepDuration(period);
+    _timeConfiguration.SetStepDuration(stepDuration);
 }
 
 bool TimeSyncService::SetupTimeSyncPolicy(bool isSynchronizingVirtualTime)
@@ -829,6 +830,12 @@ bool TimeSyncService::IsBlocking() const
 {
     return _timeConfiguration.IsBlocking();
 }
+
+void TimeSyncService::SetTimeAdvanceMode(TimeAdvanceMode timeAdvanceMode)
+{
+    _timeConfiguration.SetTimeAdvanceMode(timeAdvanceMode);
+}
+
 
 } // namespace Orchestration
 } // namespace Services

--- a/SilKit/source/services/orchestration/TimeSyncService.hpp
+++ b/SilKit/source/services/orchestration/TimeSyncService.hpp
@@ -56,8 +56,7 @@ public:
     void SetSimulationStepHandler(SimulationStepHandler task, std::chrono::nanoseconds initialStepSize) override;
     void SetSimulationStepHandlerAsync(SimulationStepHandler task, std::chrono::nanoseconds initialStepSize) override;
     void CompleteSimulationStep() override;
-    void SetStepDuration(std::chrono::nanoseconds stepDuration);
-
+    void SetStepDuration(std::chrono::nanoseconds stepDuration) override;
 
     void ReceiveMsg(const IServiceEndpoint* from, const NextSimTask& task) override;
     auto Now() const -> std::chrono::nanoseconds override;

--- a/SilKit/source/services/orchestration/TimeSyncService.hpp
+++ b/SilKit/source/services/orchestration/TimeSyncService.hpp
@@ -56,7 +56,9 @@ public:
     void SetSimulationStepHandler(SimulationStepHandler task, std::chrono::nanoseconds initialStepSize) override;
     void SetSimulationStepHandlerAsync(SimulationStepHandler task, std::chrono::nanoseconds initialStepSize) override;
     void CompleteSimulationStep() override;
-    void SetPeriod(std::chrono::nanoseconds period);
+    void SetStepDuration(std::chrono::nanoseconds stepDuration);
+
+
     void ReceiveMsg(const IServiceEndpoint* from, const NextSimTask& task) override;
     auto Now() const -> std::chrono::nanoseconds override;
 
@@ -98,6 +100,8 @@ public:
     auto AddOtherSimulationStepsCompletedHandler(std::function<void()> handler) -> HandlerId;
     void RemoveOtherSimulationStepsCompletedHandler(HandlerId handlerId);
     void InvokeOtherSimulationStepsCompletedHandlers();
+
+    void SetTimeAdvanceMode(TimeAdvanceMode timeAdvanceMode);
 
 private:
     // ----------------------------------------
@@ -154,6 +158,7 @@ private:
     std::atomic<bool> _wallClockReachedBeforeCompletion{false};
 
     Util::SynchronizedHandlers<std::function<void()>> _otherSimulationStepsCompletedHandlers;
+
 };
 
 // ================================================================================

--- a/docs/api/capi/capi-orchestration.rst
+++ b/docs/api/capi/capi-orchestration.rst
@@ -18,6 +18,7 @@ Orchestration C API
 .. doxygenfunction:: SilKit_LifecycleService_Continue
 
 .. doxygenfunction:: SilKit_TimeSyncService_Create
+.. doxygenfunction:: SilKit_TimeSyncService_Create_With_TimeAdvanceMode
 .. doxygenfunction:: SilKit_TimeSyncService_SetSimulationStepHandler
 .. doxygenfunction:: SilKit_TimeSyncService_SetSimulationStepHandlerAsync
 .. doxygenfunction:: SilKit_TimeSyncService_CompleteSimulationStep


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2023 Vector Informatik GmbH

SPDX-License-Identifier: MIT
-->

This PR adds support for dynamic time step management in the SIL Kit orchestration layer by introducing `SetStepDuration `and `TimeAdvanceMode `features. The changes enable participants to either advance time based on their own step duration or synchronize with the time points among all participants.

**Key Changes:**
- Introduced a new `TimeAdvanceMode` enum with two modes: `ByOwnDuration` and `ByMinimalDuration`
- Renamed the internal `SetPeriod` method to `SetStepDuration` and exposed it in the public API
- Added a new overload of `CreateTimeSyncService` that accepts a `TimeAdvanceMode` parameter

With these changes, a participant can reduce the step duration in a critical phase where a more fine grained synchronization is needed. 
