### PR TITLE
SILKIT-1896: Fix start of registry for Windows system service

### DIFF
--- a/Utilities/SilKitRegistry/Registry.cpp
+++ b/Utilities/SilKitRegistry/Registry.cpp
@@ -476,17 +476,19 @@ int main(int argc, char** argv)
 
         const auto generatedConfigurationPathOpt = commandlineParser.Get<CliParser::Option>("generate-configuration");
 
+
+        auto callStartRegistry = [=]() {
+            return StartRegistry(configuration, configuredListenUri, dashboardUri, enableDashboard,
+                                 generatedConfigurationPathOpt);
+        };
+
         if (windowsService)
         {
-            SilKitRegistry::RunWindowsService([=] {
-                return StartRegistry(configuration, listenUri, dashboardUri, enableDashboard,
-                                     generatedConfigurationPathOpt);
-            });
+            SilKitRegistry::RunWindowsService(callStartRegistry);
         }
         else
         {
-            const auto registry = StartRegistry(configuration, configuredListenUri, dashboardUri, enableDashboard,
-                                                generatedConfigurationPathOpt);
+            const auto registry = callStartRegistry();
 
             std::cout << "Press Ctrl-C to terminate..." << std::endl;
 


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2023 Vector Informatik GmbH

SPDX-License-Identifier: MIT
-->

## Subject
<!--
    Bugfix the start of SIL Kit registry with the configured ListenURI
 -->


## Description
<!--
    - Fix the start of SIL Kit registry with the configured ListenURI
-->

## Developer checklist (address before review)

- [ ] Rebase &rarr; commit history clean
- [ ] Squash and merge &rarr; proper PR title
