### PR TITLE
cmake: add explicit build options to QNX presets

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -120,11 +120,13 @@
             "name": "x-cross-qnx-x86_64",
             "generator": "Unix Makefiles",
             "inherits": [ "mixin-dirs" ],
-            "environment": {
-                "SILKIT_CMAKE_PRESET_BUILD_PLATFORM": "qnx"
-            },
             "toolchainFile": "${sourceDir}/SilKit/cmake/toolchain-qnx-x86_64.cmake",
             "cacheVariables": {
+                "CMAKE_BUILD_TYPE": "RelWithDebInfo",
+                "SILKIT_BUILD_TESTS": "ON",
+                "SILKIT_BUILD_UTILITIES": "ON",
+                "SILKIT_WARNINGS_AS_ERRORS": "OFF",
+                "SILKIT_PACKAGE_SYMBOLS": "ON",
                 "SILKIT_BUILD_DASHBOARD": "OFF"
             },
             "vendor": {
@@ -135,13 +137,13 @@
             }
         },
         {
-            "inherits": "x-cross-qnx-x86_64",
             "name": "x-cross-qnx-armv7",
+            "inherits": "x-cross-qnx-x86_64",
             "toolchainFile": "${sourceDir}/SilKit/cmake/toolchain-qnx-armv7.cmake"
         },
         {
-            "inherits": "x-cross-qnx-x86_64",
             "name": "x-cross-qnx-aarch64",
+            "inherits": "x-cross-qnx-x86_64",
             "toolchainFile": "${sourceDir}/SilKit/cmake/toolchain-qnx-aarch64.cmake"
         }
     ],


### PR DESCRIPTION
## Description
QNX needs specific CMAKE Options since not all options work with the SDK and toolchains for QNX

## Developer checklist (address before review)

- [ ] ~~Changelog.md updated~~ No user visible change
- [ ] ~~Prepared update for depending repositories~~
- [ ] ~~Documentation updated (public API changes only)~~
- [ ] ~~API docstrings updated (public API changes only)~~
- [x] Rebase &rarr; commit history clean
- [x] Squash and merge &rarr; proper PR title
