### PR TITLE
registry: add hidden experimental status file argument

### DIFF
--- a/Utilities/SilKitRegistry/Registry.cpp
+++ b/Utilities/SilKitRegistry/Registry.cpp
@@ -9,6 +9,7 @@
 #include <locale>
 #include <iostream>
 #include <iomanip>
+#include <optional>
 
 #include "silkit/config/IParticipantConfiguration.hpp"
 #include "silkit/services/logging/string_utils.hpp"
@@ -307,6 +308,69 @@ auto StartRegistry(std::shared_ptr<SilKit::Config::IParticipantConfiguration> co
     return result;
 }
 
+class StatusFile
+{
+    std::optional<std::filesystem::path> path;
+
+public:
+    StatusFile() = default;
+
+    explicit StatusFile(const std::filesystem::path& path) : path{Resolve(path)}
+    {
+        Write("starting");
+    }
+
+    ~StatusFile()
+    {
+        Write("stopped");
+
+        if (path.has_value())
+        {
+            try
+            {
+                std::filesystem::remove(path.value());
+            }
+            catch (const std::exception& exception)
+            {
+                std::cerr << "Error: Failed to remove status file " << path.value() << ": " << exception.what() << std::endl;
+            }
+        }
+    }
+
+    void Write(const std::string_view content)
+    {
+        if (!path.has_value())
+        {
+            return;
+        }
+
+        try
+        {
+            std::ofstream file{path.value(), std::ios::out | std::ios::trunc | std::ios::binary};
+            file << content;
+            file.flush();
+            file.close();
+        }
+        catch (const std::exception & exception)
+        {
+            std::cerr << "Error: Failed to write status file " << path.value() << ": " << exception.what() << std::endl;
+        }
+    }
+
+    static auto Resolve(const std::filesystem::path& path) -> std::optional<std::filesystem::path>
+    {
+        try
+        {
+            return std::filesystem::absolute(path);
+        }
+        catch (const std::exception& exception)
+        {
+            std::cerr << "Error: Failed to resolve status file path " << path << ": " << exception.what() << std::endl;
+            return std::nullopt;
+        }
+    }
+};
+
 } // namespace
 
 int main(int argc, char** argv)
@@ -344,6 +408,12 @@ int main(int argc, char** argv)
                                            "-s, --use-signal-handler: Exit this process when a signal is received. If "
                                            "not set, the process runs infinitely.",
                                            CliParser::Hidden);
+
+    commandlineParser.Add<CliParser::Option>(
+        "x-status-file", "", "", "[--x-status-file <path>]",
+        "--x-status-file <path>: The registry process will write the current status ('starting' or 'running') as the "
+        "entire content of the file. This option is ignored if the registry is run as a Windows service.",
+        CliParser::Hidden);
 
     if (SilKitRegistry::HasWindowsServiceSupport())
     {
@@ -413,6 +483,9 @@ int main(int argc, char** argv)
     auto dashboardUri{commandlineParser.Get<CliParser::Option>("dashboard-uri").Value()};
     const auto useSignalHandler{commandlineParser.Get<CliParser::Flag>("use-signal-handler").Value()};
     auto enableDashboard{commandlineParser.Get<CliParser::Option>("dashboard-uri").HasValue()};
+
+    const auto argStatusFile{commandlineParser.Get<CliParser::Option>("x-status-file").Value()};
+    auto statusFile = argStatusFile.empty() ? StatusFile{} : StatusFile{argStatusFile};
 
     if (commandlineParser.Get<CliParser::Flag>("enable-dashboard").Value())
     {
@@ -489,6 +562,8 @@ int main(int argc, char** argv)
         else
         {
             const auto registry = callStartRegistry();
+
+            statusFile.Write("running");
 
             std::cout << "Press Ctrl-C to terminate..." << std::endl;
 

--- a/Utilities/SilKitRegistry/Registry.cpp
+++ b/Utilities/SilKitRegistry/Registry.cpp
@@ -483,9 +483,7 @@ int main(int argc, char** argv)
     auto dashboardUri{commandlineParser.Get<CliParser::Option>("dashboard-uri").Value()};
     const auto useSignalHandler{commandlineParser.Get<CliParser::Flag>("use-signal-handler").Value()};
     auto enableDashboard{commandlineParser.Get<CliParser::Option>("dashboard-uri").HasValue()};
-
     const auto argStatusFile{commandlineParser.Get<CliParser::Option>("x-status-file").Value()};
-    auto statusFile = argStatusFile.empty() ? StatusFile{} : StatusFile{argStatusFile};
 
     if (commandlineParser.Get<CliParser::Flag>("enable-dashboard").Value())
     {
@@ -503,6 +501,9 @@ int main(int argc, char** argv)
 
     bool windowsService{SilKitRegistry::HasWindowsServiceSupport()
                         && commandlineParser.Get<CliParser::Flag>("windows-service").Value()};
+
+    // Use the status file only if the path isn't empty and the registry is not running as a Windows service.
+    auto statusFile = argStatusFile.empty() || windowsService ? StatusFile{} : StatusFile{argStatusFile};
 
     if (!isValidLogLevel(logLevel))
     {

--- a/Utilities/SilKitRegistry/Registry.cpp
+++ b/Utilities/SilKitRegistry/Registry.cpp
@@ -411,8 +411,9 @@ int main(int argc, char** argv)
 
     commandlineParser.Add<CliParser::Option>(
         "x-status-file", "", "", "[--x-status-file <path>]",
-        "--x-status-file <path>: The registry process will write the current status ('starting' or 'running') as the "
-        "entire content of the file. This option is ignored if the registry is run as a Windows service.",
+        "--x-status-file <path>: The registry process will write the current status ('starting', 'running', or "
+        "'stopped') as the entire content of the file. This option is ignored if the registry is run as a Windows "
+        "service.",
         CliParser::Hidden);
 
     if (SilKitRegistry::HasWindowsServiceSupport())


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2023 Vector Informatik GmbH

SPDX-License-Identifier: MIT
-->

## Subject
<!--
    - What kind of changes does this pull request comprise?
    - Add a label like "Bugfix", "docs", etc. to this PR to give context.
 -->

This change adds a hidden command line argument `--x-status-file` to the `sil-kit-registry` executable. It expects a path that can be opened for file creation, truncation, and writing.

The registry will rewrite this files content to `starting` at an early point in the startup procedure.

After the registry has started listening for incoming connection, the files content will be rewritten to `running`.

When the registry is shutting down 'normally' (e.g., CTRL-C, handled signals, or a handled exception) the files content will be rewritten to `stopped`. The file is also deleted afterwards. The rewrite ensures that even if the file cannot be deleted for some reason, it will not contain `running` anymore.

Such a status file is very useful for implementing a health check for orchestrated container setups, e.g., using `docker-compose`. It allows the user to ensure that participant containers are only started after the registry is up.

## Why Hidden & Experimental

The argument is useful in this state (for the example given above), but it may not be enough. We might think about either adding a separate PID-file argument, or integrate that functionality with this argument.

Personally I believe that this needs to be used in our own workflows until it's clear that it can be 'released'.

## Developer checklist (address before review)

- [ ] Changelog.md updated
- [ ] Prepared update for depending repositories
- [ ] Documentation updated (public API changes only)
- [ ] API docstrings updated (public API changes only)
- [ ] Rebase &rarr; commit history clean
- [x] Squash and merge &rarr; proper PR title
