### PR TITLE
style: use full paths for internal headers in `capi/...`

### DIFF
--- a/SilKit/source/capi/CapiCan.cpp
+++ b/SilKit/source/capi/CapiCan.cpp
@@ -2,14 +2,11 @@
 //
 // SPDX-License-Identifier: MIT
 
-#include <map>
-#include <mutex>
-#include <cstring>
-#include <sstream>
+#include "silkit/capi/Can.h"
 
-#include "silkit/capi/SilKit.h"
-#include "silkit/SilKit.hpp"
-#include "CapiImpl.hpp"
+#include "capi/CapiImpl.hpp"
+
+#include "silkit/participant/IParticipant.hpp"
 #include "silkit/services/can/all.hpp"
 
 

--- a/SilKit/source/capi/CapiDataPubSub.cpp
+++ b/SilKit/source/capi/CapiDataPubSub.cpp
@@ -2,18 +2,13 @@
 //
 // SPDX-License-Identifier: MIT
 
-#include "silkit/capi/SilKit.h"
-#include "silkit/SilKit.hpp"
-#include "silkit/services/logging/ILogger.hpp"
-#include "silkit/services/orchestration/all.hpp"
+#include "silkit/capi/DataPubSub.h"
+
+#include "capi/CapiImpl.hpp"
+#include "capi/TypeConversion.hpp"
+
+#include "silkit/participant/IParticipant.hpp"
 #include "silkit/services/pubsub/all.hpp"
-
-#include "CapiImpl.hpp"
-#include "TypeConversion.hpp"
-
-#include <map>
-#include <mutex>
-#include <cstring>
 
 
 SilKit_ReturnCode SilKitCALL SilKit_DataPublisher_Create(SilKit_DataPublisher** outPublisher,

--- a/SilKit/source/capi/CapiEthernet.cpp
+++ b/SilKit/source/capi/CapiEthernet.cpp
@@ -2,14 +2,12 @@
 //
 // SPDX-License-Identifier: MIT
 
-#include "silkit/capi/SilKit.h"
-#include "silkit/SilKit.hpp"
-#include "silkit/services/logging/ILogger.hpp"
-#include "silkit/services/orchestration/all.hpp"
-#include "silkit/services/ethernet/all.hpp"
+#include "silkit/capi/Ethernet.h"
 
-#include <cstring>
-#include "CapiImpl.hpp"
+#include "capi/CapiImpl.hpp"
+
+#include "silkit/participant/IParticipant.hpp"
+#include "silkit/services/ethernet/all.hpp"
 
 
 SilKit_ReturnCode SilKitCALL SilKit_EthernetController_Create(SilKit_EthernetController** outController,

--- a/SilKit/source/capi/CapiFlexray.cpp
+++ b/SilKit/source/capi/CapiFlexray.cpp
@@ -2,15 +2,12 @@
 //
 // SPDX-License-Identifier: MIT
 
-#include <string>
-#include <cstring>
+#include "silkit/capi/Flexray.h"
 
-#include "silkit/capi/SilKit.h"
-#include "silkit/SilKit.hpp"
+#include "capi/CapiImpl.hpp"
+
+#include "silkit/participant/IParticipant.hpp"
 #include "silkit/services/flexray/all.hpp"
-
-#include "IParticipantInternal.hpp"
-#include "CapiImpl.hpp"
 
 
 namespace {

--- a/SilKit/source/capi/CapiImpl.hpp
+++ b/SilKit/source/capi/CapiImpl.hpp
@@ -4,11 +4,12 @@
 
 #pragma once
 
-#include "silkit/capi/Types.h"
+#include "capi/CapiExceptions.hpp"
+
 #include "silkit/capi/InterfaceIdentifiers.h"
+#include "silkit/capi/Types.h"
 #include "silkit/participant/exception.hpp"
 
-#include "CapiExceptions.hpp"
 
 #define CAPI_CATCH_EXCEPTIONS \
     catch (const SilKit::CapiBadParameterError& e) \

--- a/SilKit/source/capi/CapiLin.cpp
+++ b/SilKit/source/capi/CapiLin.cpp
@@ -2,16 +2,16 @@
 //
 // SPDX-License-Identifier: MIT
 
+#include "silkit/capi/Lin.h"
+
+#include "capi/CapiImpl.hpp"
 #include "services/lin/LinControllerExtensionsImpl.hpp"
 
-#include "silkit/capi/SilKit.h"
-#include "silkit/SilKit.hpp"
-#include "silkit/services/lin/all.hpp"
 #include "silkit/experimental/services/lin/LinControllerExtensions.hpp"
+#include "silkit/participant/IParticipant.hpp"
+#include "silkit/services/lin/all.hpp"
 
-#include "CapiImpl.hpp"
-
-#include <cstring>
+#include <vector>
 
 
 namespace {

--- a/SilKit/source/capi/CapiLogger.cpp
+++ b/SilKit/source/capi/CapiLogger.cpp
@@ -2,11 +2,11 @@
 //
 // SPDX-License-Identifier: MIT
 
-#include "silkit/capi/SilKit.h"
-#include "silkit/SilKit.hpp"
-#include "silkit/services/logging/ILogger.hpp"
+#include "silkit/capi/Logger.h"
 
-#include "CapiImpl.hpp"
+#include "capi/CapiImpl.hpp"
+
+#include "silkit/services/logging/ILogger.hpp"
 
 #include <string>
 

--- a/SilKit/source/capi/CapiNetworkSimulator.cpp
+++ b/SilKit/source/capi/CapiNetworkSimulator.cpp
@@ -2,21 +2,20 @@
 //
 // SPDX-License-Identifier: MIT
 
-#include <iostream>
-#include <string>
-#include <algorithm>
-#include <map>
-#include <mutex>
-#include <cstring>
+#include "silkit/capi/NetworkSimulator.h"
+#include "silkit/capi/EventProducer.h"
 
-#include "silkit/capi/SilKit.h"
-#include "silkit/SilKit.hpp"
-#include "CapiImpl.hpp"
-
-#include "silkit/experimental/netsim/all.hpp"
+#include "capi/CapiImpl.hpp"
+#include "participant/ParticipantExtensionsImpl.hpp"
 
 #include "silkit/detail/impl/HourglassConversions.hpp"
-#include "participant/ParticipantExtensionsImpl.hpp"
+#include "silkit/experimental/netsim/all.hpp"
+#include "silkit/participant/IParticipant.hpp"
+
+#include <memory>
+#include <string>
+#include <vector>
+
 
 namespace SilKit {
 namespace Experimental {

--- a/SilKit/source/capi/CapiOrchestration.cpp
+++ b/SilKit/source/capi/CapiOrchestration.cpp
@@ -2,22 +2,21 @@
 //
 // SPDX-License-Identifier: MIT
 
-#include "silkit/capi/SilKit.h"
-#include "silkit/SilKit.hpp"
-#include "silkit/services/orchestration/all.hpp"
-#include "silkit/participant/exception.hpp"
+#include "silkit/capi/Orchestration.h"
 
+#include "capi/CapiImpl.hpp"
 #include "participant/ParticipantExtensionsImpl.hpp"
-
-#include "CapiImpl.hpp"
-#include "TypeConversion.hpp"
-
 #include "services/orchestration/TimeSyncServiceExtensionsImpl.hpp"
 
-#include <memory>
+#include "silkit/experimental/services/orchestration/ISystemController.hpp"
+#include "silkit/participant/IParticipant.hpp"
+#include "silkit/services/orchestration/all.hpp"
+
+#include <chrono>
+#include <future>
 #include <map>
-#include <mutex>
-#include <cstring>
+#include <memory>
+#include <string>
 
 
 namespace {

--- a/SilKit/source/capi/CapiParticipant.cpp
+++ b/SilKit/source/capi/CapiParticipant.cpp
@@ -2,23 +2,18 @@
 //
 // SPDX-License-Identifier: MIT
 
-#include "ParticipantConfiguration.hpp"
-#include "ParticipantConfigurationFromXImpl.hpp"
+#include "silkit/capi/Participant.h"
+
 #include "CreateParticipantImpl.hpp"
-#include "YamlParser.hpp"
+#include "capi/CapiImpl.hpp"
+#include "config/ParticipantConfiguration.hpp"
+#include "config/ParticipantConfigurationFromXImpl.hpp"
+#include "config/YamlParser.hpp"
 
-#include "silkit/capi/SilKit.h"
-#include "silkit/SilKit.hpp"
-#include "silkit/services/logging/ILogger.hpp"
-#include "silkit/services/orchestration/all.hpp"
+#include "silkit/participant/IParticipant.hpp"
 
-#include "CapiImpl.hpp"
-#include "TypeConversion.hpp"
-
+#include <algorithm>
 #include <memory>
-#include <map>
-#include <mutex>
-#include <fstream>
 
 
 SilKit_ReturnCode SilKitCALL SilKit_Participant_Create(SilKit_Participant** outParticipant,

--- a/SilKit/source/capi/CapiRpc.cpp
+++ b/SilKit/source/capi/CapiRpc.cpp
@@ -2,21 +2,15 @@
 //
 // SPDX-License-Identifier: MIT
 
-#include "silkit/capi/SilKit.h"
-#include "silkit/SilKit.hpp"
-#include "silkit/services/logging/ILogger.hpp"
-#include "silkit/services/orchestration/all.hpp"
-#include "silkit/services/orchestration/string_utils.hpp"
+#include "silkit/capi/Rpc.h"
+
+#include "capi/CapiImpl.hpp"
+#include "capi/TypeConversion.hpp"
+
+#include "silkit/participant/IParticipant.hpp"
 #include "silkit/services/rpc/all.hpp"
 
-#include "CapiImpl.hpp"
-#include "TypeConversion.hpp"
-
-#include <string>
-#include <algorithm>
-#include <map>
-#include <mutex>
-#include <cstring>
+#include <chrono>
 
 
 namespace {

--- a/SilKit/source/capi/CapiVendor.cpp
+++ b/SilKit/source/capi/CapiVendor.cpp
@@ -2,19 +2,16 @@
 //
 // SPDX-License-Identifier: MIT
 
-#include "ParticipantConfiguration.hpp"
-#include "CreateSilKitRegistryImpl.hpp"
+#include "silkit/capi/Vendor.h"
 
-#include "silkit/capi/SilKit.h"
+#include "CreateSilKitRegistryImpl.hpp"
+#include "capi/CapiImpl.hpp"
+#include "config/ParticipantConfiguration.hpp"
 
 #include "silkit/vendor/ISilKitRegistry.hpp"
 
-#include "CapiImpl.hpp"
-#include "TypeConversion.hpp"
-
 #include <memory>
-#include <map>
-#include <mutex>
+#include <string>
 
 
 SilKit_ReturnCode SilKitCALL SilKit_Vendor_Vector_SilKitRegistry_Create(

--- a/SilKit/source/capi/CapiVersion.cpp
+++ b/SilKit/source/capi/CapiVersion.cpp
@@ -2,9 +2,10 @@
 //
 // SPDX-License-Identifier: MIT
 
-#include "silkit/capi/SilKit.h"
+#include "silkit/capi/Version.h"
+
 #include "SilKitVersionImpl.hpp"
-#include "CapiImpl.hpp"
+#include "capi/CapiImpl.hpp"
 
 
 SilKit_ReturnCode SilKitCALL SilKit_Version_Major(uint32_t* outVersionMajor)

--- a/SilKit/source/capi/Test_CapiCan.cpp
+++ b/SilKit/source/capi/Test_CapiCan.cpp
@@ -2,11 +2,14 @@
 //
 // SPDX-License-Identifier: MIT
 
-#include "gtest/gtest.h"
-#include "gmock/gmock.h"
-#include "silkit/capi/SilKit.h"
+#include "core/mock/participant/MockParticipant.hpp"
+
+#include "silkit/capi/Can.h"
 #include "silkit/services/can/all.hpp"
-#include "MockParticipant.hpp"
+
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+
 
 namespace {
 using namespace SilKit::Services::Can;

--- a/SilKit/source/capi/Test_CapiData.cpp
+++ b/SilKit/source/capi/Test_CapiData.cpp
@@ -6,11 +6,14 @@
 #define _CRT_SECURE_NO_WARNINGS
 #endif
 
-#include "gtest/gtest.h"
-#include "gmock/gmock.h"
-#include "silkit/capi/SilKit.h"
+#include "core/mock/participant/MockParticipant.hpp"
+
+#include "silkit/capi/DataPubSub.h"
 #include "silkit/services/pubsub/all.hpp"
-#include "MockParticipant.hpp"
+
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+
 
 namespace {
 using namespace SilKit::Services::PubSub;

--- a/SilKit/source/capi/Test_CapiEthernet.cpp
+++ b/SilKit/source/capi/Test_CapiEthernet.cpp
@@ -2,14 +2,15 @@
 //
 // SPDX-License-Identifier: MIT
 
-#include "gtest/gtest.h"
-#include "gmock/gmock.h"
-#include "silkit/capi/SilKit.h"
-#include "silkit/services/ethernet/all.hpp"
-#include "EthDatatypeUtils.hpp"
-#include "MockParticipant.hpp"
+#include "core/mock/participant/MockParticipant.hpp"
+#include "services/ethernet/EthDatatypeUtils.hpp"
 
-#include "fmt/format.h"
+#include "silkit/capi/Ethernet.h"
+#include "silkit/services/ethernet/all.hpp"
+
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+
 
 namespace {
 using namespace SilKit::Services::Ethernet;

--- a/SilKit/source/capi/Test_CapiExceptions.cpp
+++ b/SilKit/source/capi/Test_CapiExceptions.cpp
@@ -2,11 +2,14 @@
 //
 // SPDX-License-Identifier: MIT
 
-#include "gtest/gtest.h"
-#include "gmock/gmock.h"
+#include "capi/CapiExceptions.hpp"
+#include "capi/CapiImpl.hpp"
 
-#include "CapiImpl.hpp"
 #include "silkit/detail/impl/ThrowOnError.hpp"
+
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+
 
 namespace {
 

--- a/SilKit/source/capi/Test_CapiFlexray.cpp
+++ b/SilKit/source/capi/Test_CapiFlexray.cpp
@@ -2,12 +2,14 @@
 //
 // SPDX-License-Identifier: MIT
 
+#include "core/mock/participant/MockParticipant.hpp"
+
 #include "silkit/capi/Flexray.h"
-#include "silkit/capi/SilKit.h"
 #include "silkit/services/flexray/all.hpp"
+
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
-#include "MockParticipant.hpp"
+
 
 namespace {
 using namespace SilKit::Core;

--- a/SilKit/source/capi/Test_CapiLin.cpp
+++ b/SilKit/source/capi/Test_CapiLin.cpp
@@ -2,14 +2,15 @@
 //
 // SPDX-License-Identifier: MIT
 
-#include "gtest/gtest.h"
-#include "gmock/gmock.h"
+#include "core/mock/participant/MockParticipant.hpp"
+#include "services/lin/ILinControllerExtensions.hpp"
 
-#include "silkit/capi/SilKit.h"
+#include "silkit/capi/Lin.h"
 #include "silkit/services/lin/all.hpp"
 
-#include "MockParticipant.hpp"
-#include "ILinControllerExtensions.hpp"
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+
 
 namespace {
 using namespace SilKit::Services::Lin;

--- a/SilKit/source/capi/Test_CapiNetSim.cpp
+++ b/SilKit/source/capi/Test_CapiNetSim.cpp
@@ -2,11 +2,14 @@
 //
 // SPDX-License-Identifier: MIT
 
-#include "gtest/gtest.h"
-#include "gmock/gmock.h"
-#include "silkit/capi/SilKit.h"
+#include "core/mock/participant/MockParticipant.hpp"
+
+#include "silkit/capi/NetworkSimulator.h"
 #include "silkit/experimental/netsim/all.hpp"
-#include "MockParticipant.hpp"
+
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+
 
 namespace {
 using namespace SilKit::Experimental::NetworkSimulation;

--- a/SilKit/source/capi/Test_CapiParticipantStateHandling.cpp
+++ b/SilKit/source/capi/Test_CapiParticipantStateHandling.cpp
@@ -6,12 +6,14 @@
 #define _CRT_SECURE_NO_WARNINGS
 #endif
 
-#include "gtest/gtest.h"
-#include "gmock/gmock.h"
-#include "silkit/capi/SilKit.h"
+#include "core/mock/participant/MockParticipant.hpp"
+
+#include "silkit/capi/Orchestration.h"
 #include "silkit/services/orchestration/all.hpp"
 
-#include "MockParticipant.hpp"
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+
 
 namespace {
 using testing::Return;

--- a/SilKit/source/capi/Test_CapiRpc.cpp
+++ b/SilKit/source/capi/Test_CapiRpc.cpp
@@ -6,12 +6,15 @@
 #define _CRT_SECURE_NO_WARNINGS
 #endif
 
-#include "gtest/gtest.h"
-#include "gmock/gmock.h"
-#include "silkit/capi/SilKit.h"
+#include "core/mock/participant/MockParticipant.hpp"
+#include "services/rpc/RpcCallHandle.hpp"
+
+#include "silkit/capi/Rpc.h"
 #include "silkit/services/rpc/all.hpp"
-#include "MockParticipant.hpp"
-#include "RpcCallHandle.hpp"
+
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+
 
 namespace {
 using namespace SilKit::Services::Rpc;

--- a/SilKit/source/capi/Test_CapiSilKit.cpp
+++ b/SilKit/source/capi/Test_CapiSilKit.cpp
@@ -2,11 +2,13 @@
 //
 // SPDX-License-Identifier: MIT
 
-#include "gtest/gtest.h"
-#include "gmock/gmock.h"
+#include "core/mock/participant/MockParticipant.hpp"
+
 #include "silkit/capi/SilKit.h"
 
-#include "MockParticipant.hpp"
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+
 
 namespace {
 

--- a/SilKit/source/capi/Test_CapiTimeSync.cpp
+++ b/SilKit/source/capi/Test_CapiTimeSync.cpp
@@ -2,12 +2,14 @@
 //
 // SPDX-License-Identifier: MIT
 
-#include "gtest/gtest.h"
-#include "gmock/gmock.h"
-#include "silkit/capi/SilKit.h"
+#include "core/mock/participant/MockParticipant.hpp"
+
+#include "silkit/capi/Orchestration.h"
 #include "silkit/services/orchestration/all.hpp"
 
-#include "MockParticipant.hpp"
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+
 
 namespace {
 using namespace SilKit::Services::Orchestration;

--- a/SilKit/source/capi/TypeConversion.hpp
+++ b/SilKit/source/capi/TypeConversion.hpp
@@ -4,13 +4,15 @@
 
 #pragma once
 
+#include "silkit/capi/DataPubSub.h"
+#include "silkit/capi/Rpc.h"
 #include "silkit/capi/Types.h"
-
 #include "silkit/services/pubsub/PubSubSpec.hpp"
 #include "silkit/services/rpc/RpcSpec.hpp"
 
-#include <vector>
 #include <string>
+#include <vector>
+
 
 namespace {
 


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2023 Vector Informatik GmbH

SPDX-License-Identifier: MIT
-->

## Subject
<!--
    - What kind of changes does this pull request comprise?
    - Add a label like "Bugfix", "docs", etc. to this PR to give context.
 -->

Use full paths for internal headers in all sources and headers in `SilKit/source/capi/`. Rearranges the includes to follow the guidelines in the [LLVM Styleguide for C++](https://llvm.org/docs/CodingStandards.html#include-style) ~~[Google Styleguide for C++](https://google.github.io/styleguide/cppguide.html#Names_and_Order_of_Includes)~~. Removes unneccessary includes.

## Developer checklist (address before review)

- [ ] Changelog.md updated
- [ ] Prepared update for depending repositories
- [ ] Documentation updated (public API changes only)
- [ ] API docstrings updated (public API changes only)
- [ ] Rebase &rarr; commit history clean
- [x] Squash and merge &rarr; proper PR title
