### PR TITLE
capi: `Vendor.h` requires `Logger.h` for the `SilKit_Logger` typedef

### DIFF
--- a/SilKit/include/silkit/capi/Vendor.h
+++ b/SilKit/include/silkit/capi/Vendor.h
@@ -7,6 +7,7 @@
 #include "silkit/capi/SilKitMacros.h"
 #include "silkit/capi/Types.h"
 #include "silkit/capi/InterfaceIdentifiers.h"
+#include "silkit/capi/Logger.h"
 
 SILKIT_BEGIN_DECLS
 


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2023 Vector Informatik GmbH

SPDX-License-Identifier: MIT
-->

## Subject
<!--
    - What kind of changes does this pull request comprise?
    - Add a label like "Bugfix", "docs", etc. to this PR to give context.
 -->

The public C-API header `Vendor.h` is currently not able top be included on its own. The declarations require the typedef `SilKit_Logger` from the header `Logger.h`.

## Developer checklist (address before review)

- [ ] Changelog.md updated
- [ ] Prepared update for depending repositories
- [ ] Documentation updated (public API changes only)
- [ ] API docstrings updated (public API changes only)
- [ ] Rebase &rarr; commit history clean
- [x] Squash and merge &rarr; proper PR title
