### PR TITLE
third-party: update oatpp to 1.3.1

### DIFF
--- a/docs/changelog/versions/latest.md
+++ b/docs/changelog/versions/latest.md
@@ -3,3 +3,4 @@
 ## Changed
 
 - `cmake`: merged almost all internal CMake `INTERFACE` libraries into `I_SilKit`
+- `third-party`: update `oatpp` to version 1.3.1


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2023 Vector Informatik GmbH

SPDX-License-Identifier: MIT
-->

## Subject
<!--
    - What kind of changes does this pull request comprise?
    - Add a label like "Bugfix", "docs", etc. to this PR to give context.
 -->

Update `oatpp` to version 1.3.1 which fixes a warning emitted on new-ish GCC versions.

```
[...]/oatpp/src/oatpp/network/monitor/ConnectionMonitor.cpp: In static member function ‘static void oatpp::network::monitor::ConnectionMonitor::Monitor::monitorTask(std::shared_ptr<oatpp::network::monitor::ConnectionMonitor::Monitor>)’:
[...]/oatpp/src/oatpp/network/monitor/ConnectionMonitor.cpp:146:52: warning:
ignoring return value of ‘std::lock_guard<_Mutex>::lock_guard(mutex_type&) [with _Mutex = std::mutex; mutex_type = std::mutex]’, declared with attribute ‘nodiscard’ [-Wunused-result]
```

## Developer checklist (address before review)

- [ ] Changelog.md updated
- [ ] Prepared update for depending repositories
- [ ] Documentation updated (public API changes only)
- [ ] API docstrings updated (public API changes only)
- [ ] Rebase &rarr; commit history clean
- [ ] Squash and merge &rarr; proper PR title
