### PR TITLE
docs: update the platform support table

### DIFF
--- a/docs/changelog/versions/latest.md
+++ b/docs/changelog/versions/latest.md
@@ -4,3 +4,4 @@
 
 - `cmake`: merged almost all internal CMake `INTERFACE` libraries into `I_SilKit`
 - `third-party`: update `oatpp` to version 1.3.1
+- `docs`: update the supported platforms table

--- a/docs/for-developers/developers.rst
+++ b/docs/for-developers/developers.rst
@@ -212,6 +212,12 @@ Essential targets. Automatically tested and provided as official binary packages
    * - Ubuntu 20.04
      - amd64
      - Clang 10, `.deb`
+   * - Ubuntu 22.04
+     - ARM64
+     - Clang 14, `.deb`
+   * - Alma Linux 9
+     - amd64
+     - Clang 20, `.rpm`
 
 Tier 2: CI Support
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -242,6 +248,11 @@ Officially supported and automatically tested. NO binary packages provided
    * - macOS
      - ARM64
      - AppleClang 15
+   * - QNX 8\ [#label]_
+     - amd64
+     - QCC 12
+
+.. [#label] Nightly builds and tests of the main branch every six (6) hours
 
 Tier 3: Known to build
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -257,7 +268,7 @@ Since these are not part of the CI pipeline, compatibility with these platforms 
      - Notes
    * - QNX 7.1 RTOS
      - X86 64bit
-     - QNX GCC 8
+     -
    * - FreeBSD 14
      - X86 64bit
      - FreeBSD Clang 18


### PR DESCRIPTION
## Subject
Update the platform support list


## Description
Moved QNX 8 builds we have on Vector internal CI to Tier 2
Added all the Linux packages available on `github.com/vectorgrp/sil-kit-pkg` to Tier 1

## Instructions for review / testing
-

## Developer checklist (address before review)

- [x] Changelog.md updated
- [ ] Prepared update for depending repositories
- [x] Documentation updated (public API changes only)
- [ ] API docstrings updated (public API changes only)
- [x] Rebase &rarr; commit history clean
- [ ] Squash and merge &rarr; proper PR title
