### PR TITLE
third-party: update fmt to 12.1.0

### DIFF
--- a/SilKit/cmake/SilKitBuildSettings.cmake
+++ b/SilKit/cmake/SilKitBuildSettings.cmake
@@ -88,6 +88,12 @@ function(silkit_enable_warnings isOn)
                 /wd4389 # too many bogus signed/unsigned warnings in VS2017 Win32
             )
         endif()
+
+        if ("${SILKIT_HOST_ARCHITECTURE}" STREQUAL "x86")
+            set(_flags ${_flags}
+                /wd4244 # possible loss of data after conversion (fmt 12.1.0 produces these on 32-bit MSVC builds)
+            )
+        endif()
     elseif(MINGW)
         set(_flags
             -pedantic

--- a/docs/changelog/versions/latest.md
+++ b/docs/changelog/versions/latest.md
@@ -4,3 +4,4 @@
 
 - `cmake`: merged almost all internal CMake `INTERFACE` libraries into `I_SilKit`
 - `third-party`: update `oatpp` to version 1.3.1
+- `third-party`: update `fmt` to version 12.1.0


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2023 Vector Informatik GmbH

SPDX-License-Identifier: MIT
-->

## Subject
<!--
    - What kind of changes does this pull request comprise?
    - Add a label like "Bugfix", "docs", etc. to this PR to give context.
 -->

Updates `fmt` to version 12.1.0 which fixes a warning emitted on modern GCC versions (which triggers an error due to our warning flags).

## Developer checklist (address before review)

- [x] Changelog.md updated
- [ ] Prepared update for depending repositories
- [ ] Documentation updated (public API changes only)
- [ ] API docstrings updated (public API changes only)
- [ ] Rebase &rarr; commit history clean
- [x] Squash and merge &rarr; proper PR title
