### PR TITLE
SILKIT-1966 LIN service: put master to sleep only after sleep frame received in detailed simulation

### DIFF
--- a/SilKit/source/services/lin/LinController.cpp
+++ b/SilKit/source/services/lin/LinController.cpp
@@ -515,11 +515,9 @@ void LinController::GoToSleep()
         return;
     }
 
-    // Detailed: Send LinSendFrameRequest with GoToSleep-Frame and set LinControllerStatus::SleepPending. BusSim will trigger LinTransmission.
+    // Detailed: Send LinSendFrameRequest with GoToSleep-Frame and set LinControllerStatus::SleepPending. BusSim will trigger LinTransmission. Sleep after frame is received.
     // Trivial: Directly send LinTransmission with GoToSleep-Frame and call GoToSleepInternal() on this controller.
     _simulationBehavior.GoToSleep();
-
-    _controllerStatus = LinControllerStatus::Sleep;
 }
 
 void LinController::GoToSleepInternal()
@@ -784,10 +782,18 @@ void LinController::ReceiveMsg(const IServiceEndpoint* from, const LinTransmissi
     // Dispatch GoToSleep frames to dedicated handlers
     if (isGoToSleepFrame)
     {
-        // only call GoToSleepHandlers for slaves, i.e., not for the master that issued the GoToSleep command.
         if (_controllerMode == LinControllerMode::Slave)
         {
+            // Only call GoToSleepHandlers for slaves, i.e., not for the master that issued the GoToSleep command.
             CallHandlers(LinGoToSleepEvent{msg.timestamp});
+        }
+        // Detailed: Go to sleep after go-to-sleep frame was received by master
+        else if (_controllerMode == LinControllerMode::Master)
+        {
+            if (_controllerStatus == LinControllerStatus::SleepPending)
+            {
+                _controllerStatus = LinControllerStatus::Sleep;
+            }
         }
     }
 }

--- a/docs/changelog/versions/latest.md
+++ b/docs/changelog/versions/latest.md
@@ -1,5 +1,10 @@
 # [5.0.5] - UNRELEASED
 
+## Fixed
+
+- `lin`: fixed missing reception of the Go-To-Sleep frame by the master after `GoToSleep()` in detailed simulation
+
+
 ## Changed
 
 - `cmake`: merged almost all internal CMake `INTERFACE` libraries into `I_SilKit`


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2023 Vector Informatik GmbH

SPDX-License-Identifier: MIT
-->

## Subject
Fix a bug that emerged with v5.0.4: LIN master no longer receives the go-to-sleep frame, because the master is sent to sleep too early when NetSim is used (detailed simulation). With [this recent commit](https://github.com/vectorgrp/sil-kit/commit/6ed9b9c23ea603b419aa6564f7e43a57ef4aa54e), a sleeping node ignores frames. 

Self-reception of the go-to-sleep frame is required for CANoe to work correctly, regression test is failing.
Network simulator's integration test "ITestNetsimLin_DynamicResponse" is failing as well.

## Description
This change moves transitioning of a node from `SleepPending` to `Sleep` to when the go-to-sleep frame is received and dispatched.

Tickets:
- [SILKIT-1966](https://jira.vg.vector.int/browse/SILKIT-1966) LIN-Master no longer transmits go-to-sleep frame with NetSim
- [COE-114997](https://jira.vg.vector.int/browse/COE-114997) SIL Kit Regression Test TC 2.4 LIN is failing

## Instructions for review / testing

- Code review
- ITests in NetSim should succeed.
- CANoe regression test TC 2.4 should succeed.

## Developer checklist (address before review)

- [X] Changelog.md updated
- [ ] Prepared update for depending repositories
- [ ] Documentation updated (public API changes only)
- [ ] API docstrings updated (public API changes only)
- [ ] Rebase &rarr; commit history clean
- [ ] Squash and merge &rarr; proper PR title
