### PR TITLE
quality: silence warning emitted from oatpp

### DIFF
--- a/ThirdParty/CMakeLists.txt
+++ b/ThirdParty/CMakeLists.txt
@@ -182,7 +182,7 @@ function(include_oatpp)
     endif ()
 
     if (CMAKE_CXX_COMPILER_ID MATCHES GNU)
-        target_compile_options(oatpp PRIVATE "-Wno-useless-cast")
+        target_compile_options(oatpp PRIVATE "-Wno-useless-cast" "-Wno-conversion")
     endif ()
 
     set_property(TARGET oatpp PROPERTY CXX_VISIBILITY_PRESET hidden)
@@ -211,5 +211,3 @@ function(silkit_add_third_party_packages)
         include_oatpp()
     endif ()
 endfunction()
-
-


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2023 Vector Informatik GmbH

SPDX-License-Identifier: MIT
-->

## Description

Apparently, when reviewing #321, I missed that gcc9.5 emits `-Wconversion` warnings when compiling oatpp. This PR adds `Wno-conversion` to the compiler flags list applied to gcc when compiling oatpp.

## Developer checklist (address before review)

- [ ] Changelog.md updated
- [x] Rebase &rarr; commit history clean
- [ ] Squash and merge &rarr; proper PR title
