### PR TITLE
ci: update Github actions

### DIFF
--- a/.github/workflows/build-linux-arm64.yml
+++ b/.github/workflows/build-linux-arm64.yml
@@ -22,7 +22,7 @@ jobs:
       image: ghcr.io/vectorgrp/sil-kit-docker-build/sil-kit-ci-public-runner:main
     if: (inputs.run_build == true) || (github.event_name == 'push')
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           submodules: true
       - uses: ./.github/actions/build-cmake-preset

--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -22,7 +22,7 @@ jobs:
       image: ghcr.io/vectorgrp/sil-kit-docker-build/sil-kit-ci-public-runner:main
     if: (inputs.run_build == true) || (github.event_name == 'push')
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           submodules: true
       - uses: ./.github/actions/build-cmake-preset

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -16,7 +16,7 @@ jobs:
     if: (inputs.run_build == true) || (github.event_name == 'push') || (github.event_name == 'workflow_dispatch')
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
       with:
         submodules: true
 

--- a/.github/workflows/build-mingw64.yml
+++ b/.github/workflows/build-mingw64.yml
@@ -32,7 +32,7 @@ jobs:
         pacman -S ${{ matrix.builds.arch }}-gcc ${{ matrix.builds.arch }}-cmake ${{ matrix.builds.arch }}-ninja ${{ matrix.builds.arch }}-yaml-cpp ${{ matrix.builds.arch }}-fmt ${{ matrix.builds.arch }}-gtest  ${{matrix.builds.arch}}-asio ${{matrix.builds.arch}}-spdlog --noconfirm
 
 
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
       with:
         submodules: true
 

--- a/.github/workflows/build-win.yml
+++ b/.github/workflows/build-win.yml
@@ -24,7 +24,7 @@ jobs:
 
     if: (inputs.run_build == true) || (github.event_name == 'push')
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
       with:
         submodules: true
 
@@ -59,7 +59,7 @@ jobs:
 
     if: inputs.run_build == true
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
       with:
         submodules: true
 

--- a/.github/workflows/linux-asan.yml
+++ b/.github/workflows/linux-asan.yml
@@ -16,7 +16,7 @@ jobs:
       image: ghcr.io/vectorgrp/sil-kit-docker-build/sil-kit-ci-public-runner:main
     if: (inputs.run_build == true) || (github.event_name == 'push')
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           submodules: true
       - uses: ./.github/actions/build-cmake-preset

--- a/.github/workflows/linux-tsan.yml
+++ b/.github/workflows/linux-tsan.yml
@@ -18,7 +18,7 @@ jobs:
       image: ghcr.io/vectorgrp/sil-kit-docker-build/sil-kit-ci-public-runner:main
     if: (inputs.run_build == true) || (github.event_name == 'push')
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           submodules: true
       - uses: ./.github/actions/build-cmake-preset

--- a/.github/workflows/linux-ubsan.yml
+++ b/.github/workflows/linux-ubsan.yml
@@ -17,7 +17,7 @@ jobs:
       image: ghcr.io/vectorgrp/sil-kit-docker-build/sil-kit-ci-public-runner:main
     if: (inputs.run_build == true) || (github.event_name == 'push')
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           submodules: true
       - uses: ./.github/actions/build-cmake-preset

--- a/.github/workflows/sil-kit-ci.yml
+++ b/.github/workflows/sil-kit-ci.yml
@@ -14,7 +14,7 @@ jobs:
     name: License checks for SIL Kit sources
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           submodules: false
       - name: Install Dependencies
@@ -33,7 +33,7 @@ jobs:
     outputs:
       run_builds: ${{ steps.build_check.outputs.run_builds }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           submodules: false
 
@@ -50,7 +50,7 @@ jobs:
     name: 🦙 DCO Signing Check
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           submodules: false
 
@@ -62,7 +62,7 @@ jobs:
     name: Format checks for SIL Kit sources
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           submodules: false
       - name: Check Formatting
@@ -76,7 +76,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [check-run-builds, check-dco-signed]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           submodules: true
       - name: Run clang-tidy
@@ -90,7 +90,7 @@ jobs:
 
       - name: Artifact
         id: artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: clang_tidy_reports
           path: |


### PR DESCRIPTION
Due to the Github deprecation of Node20 we need to update all Github actions. See:
https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/

## Subject
Github Action Node20 deprecation


## Description
Due to the Github deprecation of Node20 we need to update all Github actions. See:
https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/

## Instructions for review / testing
Check if there are any Node20 deprecation warnings in the CI runs of this PR

## Developer checklist (address before review)

- [ ] Changelog.md updated
- [ ] Prepared update for depending repositories
- [ ] Documentation updated (public API changes only)
- [ ] API docstrings updated (public API changes only)
- [ ] Rebase &rarr; commit history clean
- [ ] Squash and merge &rarr; proper PR title
