### PR TITLE
ci: update upload-artifact in our action.yml

### DIFF
--- a/.github/actions/build-cmake-preset/action.yml
+++ b/.github/actions/build-cmake-preset/action.yml
@@ -70,7 +70,7 @@ runs:
       shell: ${{ inputs.shell }}
 
     - name: stash test reports ${{ inputs.preset-name }}
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: "${{ inputs.artifact-label }}-test-results"
         path: '_build/**/*gtestresults.xml'
@@ -87,7 +87,7 @@ runs:
       shell: ${{ inputs.shell }}
 
     - name: upload package ${{ inputs.preset-name }}
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: ${{ steps.cmake-package.outputs.package-name }}
         path: ${{ steps.cmake-package.outputs.package-path }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,13 +1,13 @@
 # compile commands for clangd  support
 compile_commands.json
 # ignore cmake-generated path directories
-build*/
-_build*/
-install*/
-_install*/
+/build*/
+/_build*/
+/install*/
+/_install*/
 .vscode
 .vs
-out
+/out
 
 # ignore CLion files
 .idea/
@@ -24,7 +24,7 @@ Products/*
 *__pycache__*
 
 # ci/build_all generates a lot of build directories
-_build_*/
+/_build_*/
 
 # ignore cmake CMakeUserPresets
 CMakeUserPresets.json


### PR DESCRIPTION
* Update the Github action
* Fix the wrong path for build directories in .gitignore (responsible for not catching the old upload-artifact)

<!--
SPDX-FileCopyrightText: 2023 Vector Informatik GmbH

SPDX-License-Identifier: MIT
-->

## Subject
ci: update upload-artifact in our action.yml

## Description
Missed an occurence of upload-artifact. Thx my own wrong path in .gitignore and fzf/rg defaults 👍 

## Instructions for review / testing


## Developer checklist (address before review)

- [ ] Changelog.md updated
- [ ] Prepared update for depending repositories
- [ ] Documentation updated (public API changes only)
- [ ] API docstrings updated (public API changes only)
- [ ] Rebase &rarr; commit history clean
- [ ] Squash and merge &rarr; proper PR title
