### PR TITLE
Update devcontainer dockerfile ENV format

### DIFF
--- a/.devcontainer/clangformat.Dockerfile
+++ b/.devcontainer/clangformat.Dockerfile
@@ -1,8 +1,8 @@
 FROM ubuntu:24.04
-ENV TZ "Europe/Berlin"
-ENV DEBIAN_FRONTEND "noninteractive"
-ENV LC_ALL C.UTF-8
-ENV LANG C.UTF-8
+ENV TZ="Europe/Berlin"
+ENV DEBIAN_FRONTEND="noninteractive"
+ENV LC_ALL=C.UTF-8
+ENV LANG=C.UTF-8
 
 RUN \
     apt-get update \


### PR DESCRIPTION
As pointed out in https://github.com/vectorgrp/sil-kit/issues/342:
Use `ENV key=value` syntax instead of depricated `ENV key value` which produces a warning.