### PR TITLE
ci: use vendored deps on mingw64

### DIFF
--- a/.github/workflows/build-mingw64.yml
+++ b/.github/workflows/build-mingw64.yml
@@ -40,6 +40,6 @@ jobs:
       with:
         preset-name: release
         artifact-label: ${{ github.job }}-${{ matrix.builds.arch }}
-        cmake-args: -D SILKIT_BUILD_DOCS=OFF -D SILKIT_USE_SYSTEM_LIBRARIES=ON -D SILKIT_BUILD_DASHBOARD=OFF
+        cmake-args: -D SILKIT_BUILD_DOCS=OFF -D SILKIT_BUILD_DASHBOARD=OFF
         extra-path: "${{ matrix.builds.bin }}:"
         shell: C:\shells\msys2bash.cmd {0}


### PR DESCRIPTION
## Subject
Build fails with system libfmt

## Description
Check if the mingw build succeeds with the vendored dependencies

## Instructions for review / testing
If the CI succeeds, it works

## Developer checklist (address before review)

- [ ] Changelog.md updated
- [ ] Prepared update for depending repositories
- [ ] Documentation updated (public API changes only)
- [ ] API docstrings updated (public API changes only)
- [ ] Rebase &rarr; commit history clean
- [ ] Squash and merge &rarr; proper PR title
