### PR TITLE
logger: revert the extension api back to using `ILogger`

### DIFF
--- a/SilKit/source/extensions/SilKitExtensionImpl/CreateMdf4Tracing.cpp
+++ b/SilKit/source/extensions/SilKitExtensionImpl/CreateMdf4Tracing.cpp
@@ -24,14 +24,14 @@ auto CreateMdf4Tracing(Config::ParticipantConfiguration config, SilKit::Services
                        const std::string& sinkName) -> std::unique_ptr<ITraceMessageSink>
 {
     auto& factory = SilKitExtensionLoader<ITraceMessageSinkFactory>(logger, "SilKitExtension_Mdf", config.extensions);
-    return factory.Create(std::move(config), logger, participantName, sinkName);
+    return factory.Create(std::move(config), logger->AsILogger(), participantName, sinkName);
 }
 
 auto CreateMdf4Replay(Config::ParticipantConfiguration config, SilKit::Services::Logging::ILoggerInternal* logger,
                       const std::string& fileName) -> std::shared_ptr<IReplayFile>
 {
     auto& factory = SilKitExtensionLoader<IReplayDataProvider>(logger, "SilKitExtension_Mdf", config.extensions);
-    return factory.OpenFile(config, fileName, logger);
+    return factory.OpenFile(config, fileName, logger->AsILogger());
 }
 
 

--- a/SilKit/source/services/logging/MockLogger.hpp
+++ b/SilKit/source/services/logging/MockLogger.hpp
@@ -30,7 +30,7 @@ inline auto ALoggerMessageWith(SilKit::Services::Logging::Level level)
 }
 
 
-class MockLogger : public ::SilKit::Services::Logging::ILoggerInternal
+class MockLogger : public ::SilKit::Services::Logging::ILoggerInternal, SilKit::Services::Logging::ILogger
 {
     using Level = ::SilKit::Services::Logging::Level;
     using LoggerMessage = ::SilKit::Services::Logging::LoggerMessage;
@@ -48,7 +48,7 @@ public:
 
     SilKit::Services::Logging::ILogger* AsILogger() override
     {
-        throw SilKit::SilKitError("Not implemented!");
+        return this;
     }
 
     bool IsTopicEnabled(Topic topic) const
@@ -80,6 +80,42 @@ public:
         return LoggerMessage(this, level, topic);
     }
     MOCK_METHOD(SilKit::Services::Logging::Level, GetLogLevel, (), (const, override));
+
+public:
+    void Log(Level level, const std::string& msg) override
+    {
+        Log(level, Topic::None, msg);
+    }
+
+    void Trace(const std::string& msg) override
+    {
+        Log(Level::Trace, msg);
+    }
+
+    void Debug(const std::string& msg) override
+    {
+        Log(Level::Debug, msg);
+    }
+
+    void Info(const std::string& msg) override
+    {
+        Log(Level::Info, msg);
+    }
+
+    void Warn(const std::string& msg) override
+    {
+        Log(Level::Warn, msg);
+    }
+
+    void Error(const std::string& msg) override
+    {
+        Log(Level::Error, msg);
+    }
+
+    void Critical(const std::string& msg) override
+    {
+        Log(Level::Critical, msg);
+    }
 };
 
 

--- a/SilKit/source/tracing/IReplay.hpp
+++ b/SilKit/source/tracing/IReplay.hpp
@@ -21,12 +21,6 @@
 
 namespace SilKit {
 
-namespace Services {
-namespace Logging {
-struct ILoggerInternal;
-} // namespace Logging
-} // namespace Services
-
 //forwards
 class IReplayMessage;
 class IReplayChannel;
@@ -40,7 +34,7 @@ public:
     //!< Pass the config (containing search path hints), the actual file to open
     //   and a logger to the extension.
     virtual auto OpenFile(const SilKit::Config::ParticipantConfiguration& config, const std::string& filePath,
-                          SilKit::Services::Logging::ILoggerInternal* logger) -> std::shared_ptr<IReplayFile> = 0;
+                          SilKit::Services::Logging::ILogger* logger) -> std::shared_ptr<IReplayFile> = 0;
 };
 
 class IReplayFile

--- a/SilKit/source/tracing/ITraceMessageSink.hpp
+++ b/SilKit/source/tracing/ITraceMessageSink.hpp
@@ -35,7 +35,7 @@ public:
 
     virtual void Open(SinkType type, const std::string& outputPath) = 0;
     virtual void Close() = 0;
-    virtual auto GetLogger() const -> Services::Logging::ILoggerInternal* = 0;
+    virtual auto GetLogger() const -> Services::Logging::ILogger* = 0;
     virtual auto Name() const -> const std::string& = 0;
 
     virtual void Trace(
@@ -50,7 +50,7 @@ class ITraceMessageSinkFactory
 public:
     virtual ~ITraceMessageSinkFactory() = default;
     virtual auto Create(SilKit::Config::ParticipantConfiguration config,
-                        SilKit::Services::Logging::ILoggerInternal* logger,
+                        SilKit::Services::Logging::ILogger* logger,
                         std::string participantName, std::string sinkName) -> std::unique_ptr<ITraceMessageSink> = 0;
 };
 

--- a/SilKit/source/tracing/PcapReader.cpp
+++ b/SilKit/source/tracing/PcapReader.cpp
@@ -72,13 +72,13 @@ auto PcapMessage::Type() const -> TraceMessageType
 // PcapReader
 //////////////////////////////////////////////////////////////////////
 
-PcapReader::PcapReader(std::istream* stream, SilKit::Services::Logging::ILoggerInternal* logger)
+PcapReader::PcapReader(std::istream* stream, SilKit::Services::Logging::ILogger* logger)
     : _stream{stream}
     , _log{logger}
 {
     Reset();
 }
-PcapReader::PcapReader(const std::string& filePath, ILoggerInternal* logger)
+PcapReader::PcapReader(const std::string& filePath, ILogger* logger)
     : _filePath{filePath}
     , _log{logger}
 {
@@ -102,9 +102,7 @@ void PcapReader::Reset()
 {
     if (_filePath.empty() && _stream == nullptr)
     {
-        _log->MakeMessage(Level::Error, TopicOf(*this))
-            .SetMessage("PcapReader::Reset(): no input file or stream pointer given!")
-            .Dispatch();
+        _log->Error("PcapReader::Reset(): no input file or stream pointer given!");
         throw SilKitError("PcapReader::Reset(): no input file or stream pointer given!");
     }
 
@@ -117,9 +115,7 @@ void PcapReader::Reset()
         }
         if (!_file.good())
         {
-            _log->MakeMessage(Level::Error, TopicOf(*this))
-                .SetMessage("Cannot open file {}", _filePath)
-                .Dispatch();
+            _log->Error(fmt::format("Cannot open file {}", _filePath));
             throw SilKitError("Cannot open file " + _filePath);
         }
     }
@@ -180,9 +176,7 @@ bool PcapReader::Seek(size_t messageNumber)
         _stream->read(buf.data(), buf.size());
         if (!_stream->good())
         {
-            _log->MakeMessage(Level::Warn, TopicOf(*this))
-                .SetMessage("PCAP file: {}: short read on packet header.", _filePath)
-                .Dispatch();
+            _log->Warn(fmt::format("PCAP file: {}: short read on packet header.", _filePath));
             return false;
         }
         auto msg = std::make_shared<PcapMessage>();
@@ -194,9 +188,7 @@ bool PcapReader::Seek(size_t messageNumber)
         _stream->read(reinterpret_cast<char*>(msgBuf.data()), hdr->incl_len);
         if (!_stream->good())
         {
-            _log->MakeMessage(Level::Warn, TopicOf(*this))
-                .SetMessage("PCAP file: {}: Cannot read packet at offset {}", _filePath, std::to_string(_stream->tellg()))
-                .Dispatch();
+            _log->Warn(fmt::format("PCAP file: {}: Cannot read packet at offset {}", _filePath, std::to_string(_stream->tellg())));
             return false;
         }
         msg->raw = std::move(msgBuf);

--- a/SilKit/source/tracing/PcapReader.hpp
+++ b/SilKit/source/tracing/PcapReader.hpp
@@ -17,9 +17,9 @@ class PcapReader final : public SilKit::IReplayChannelReader
 {
 public:
     // Constructors
-    PcapReader(const std::string& filePath, SilKit::Services::Logging::ILoggerInternal* logger);
+    PcapReader(const std::string& filePath, SilKit::Services::Logging::ILogger* logger);
     //This CTor is for testing purposes only:
-    PcapReader(std::istream* stream, SilKit::Services::Logging::ILoggerInternal* logger);
+    PcapReader(std::istream* stream, SilKit::Services::Logging::ILogger* logger);
     PcapReader(PcapReader& other);
 
 public:
@@ -46,7 +46,7 @@ private:
     std::map<std::string, std::string> _metaInfos;
     std::shared_ptr<IReplayMessage> _currentMessage;
     uint64_t _numMessages{0};
-    SilKit::Services::Logging::ILoggerInternal* _log{nullptr};
+    SilKit::Services::Logging::ILogger* _log{nullptr};
     std::chrono::nanoseconds _startTime{0};
     std::chrono::nanoseconds _endTime{0};
 };

--- a/SilKit/source/tracing/PcapReplay.cpp
+++ b/SilKit/source/tracing/PcapReplay.cpp
@@ -24,7 +24,7 @@ using namespace SilKit::Tracing;
 class ReplayPcapChannel : public SilKit::IReplayChannel
 {
 public:
-    ReplayPcapChannel(const std::string& filePath, ILoggerInternal* logger)
+    ReplayPcapChannel(const std::string& filePath, ILogger* logger)
         : _reader{filePath, logger}
     {
     }
@@ -72,7 +72,7 @@ private:
 class ReplayPcapFile : public SilKit::IReplayFile
 {
 public:
-    ReplayPcapFile(std::string filePath, SilKit::Services::Logging::ILoggerInternal* logger)
+    ReplayPcapFile(std::string filePath, SilKit::Services::Logging::ILogger* logger)
         : _filePath{std::move(filePath)}
     {
         auto channel = std::make_shared<ReplayPcapChannel>(_filePath, logger);
@@ -113,7 +113,7 @@ namespace SilKit {
 namespace Tracing {
 
 auto PcapReplay::OpenFile(const SilKit::Config::ParticipantConfiguration&, const std::string& filePath,
-                          SilKit::Services::Logging::ILoggerInternal* logger) -> std::shared_ptr<IReplayFile>
+                          SilKit::Services::Logging::ILogger* logger) -> std::shared_ptr<IReplayFile>
 {
     return std::make_shared<ReplayPcapFile>(filePath, logger);
 }

--- a/SilKit/source/tracing/PcapReplay.hpp
+++ b/SilKit/source/tracing/PcapReplay.hpp
@@ -16,7 +16,7 @@ class PcapReplay : public IReplayDataProvider
 {
 public:
     auto OpenFile(const SilKit::Config::ParticipantConfiguration&, const std::string& filePath,
-                  SilKit::Services::Logging::ILoggerInternal* logger) -> std::shared_ptr<IReplayFile> override;
+                  SilKit::Services::Logging::ILogger* logger) -> std::shared_ptr<IReplayFile> override;
 };
 
 } // namespace Tracing

--- a/SilKit/source/tracing/PcapSink.cpp
+++ b/SilKit/source/tracing/PcapSink.cpp
@@ -61,9 +61,9 @@ void PcapSink::Open(SinkType outputType, const std::string& outputPath)
     }
 }
 
-auto PcapSink::GetLogger() const -> Services::Logging::ILoggerInternal*
+auto PcapSink::GetLogger() const -> Services::Logging::ILogger*
 {
-    return _logger;
+    return _logger->AsILogger();
 }
 
 auto PcapSink::Name() const -> const std::string&

--- a/SilKit/source/tracing/PcapSink.hpp
+++ b/SilKit/source/tracing/PcapSink.hpp
@@ -36,7 +36,7 @@ public:
     void Trace(SilKit::Services::TransmitDirection txRx, const Core::ServiceDescriptor& id,
                std::chrono::nanoseconds timestamp, const TraceMessage& msg) override;
 
-    auto GetLogger() const -> Services::Logging::ILoggerInternal* override;
+    auto GetLogger() const -> Services::Logging::ILogger* override;
 
     auto Name() const -> const std::string& override;
 

--- a/SilKit/source/tracing/Test_Pcap.cpp
+++ b/SilKit/source/tracing/Test_Pcap.cpp
@@ -66,7 +66,7 @@ TEST(Test_Pcap, read_from_pcap)
     auto raw = MakePcapTestData(testInput, 10);
     ss.write(reinterpret_cast<char*>(raw.data()), raw.size());
 
-    PcapReader reader{&ss, &log};
+    PcapReader reader{&ss, log.AsILogger()};
 
     auto numMessages = 0u;
     while (true)

--- a/SilKit/source/tracing/Tracing.cpp
+++ b/SilKit/source/tracing/Tracing.cpp
@@ -117,7 +117,7 @@ auto CreateReplayFiles(Services::Logging::ILoggerInternal* logger, const Config:
         case Config::TraceSource::Type::PcapFile:
         {
             PcapReplay provider{};
-            auto file = provider.OpenFile(participantConfig, source.inputPath, logger);
+            auto file = provider.OpenFile(participantConfig, source.inputPath, logger->AsILogger());
             replayFiles.insert({source.name, std::move(file)});
             break;
         }

--- a/SilKit/source/tracing/mock/MockTraceSink.hpp
+++ b/SilKit/source/tracing/mock/MockTraceSink.hpp
@@ -57,7 +57,7 @@ public:
     }
 
 
-    auto GetLogger() const -> Services::Logging::ILoggerInternal* override
+    auto GetLogger() const -> Services::Logging::ILogger* override
     {
         return nullptr;
     }


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2023 Vector Informatik GmbH

SPDX-License-Identifier: MIT
-->

## Subject
<!--
    - What kind of changes does this pull request comprise?
    - Add a label like "Bugfix", "docs", etc. to this PR to give context.
 -->

Part one of two: revert the extension API back to using `ILogger` (from `ILoggerInternal`). The second part will refactor the extension API such that a function object is passed to implementation.

## Developer checklist (address before review)

- [ ] Changelog.md updated
- [ ] Prepared update for depending repositories
- [ ] Documentation updated (public API changes only)
- [ ] API docstrings updated (public API changes only)
- [ ] Rebase &rarr; commit history clean
- [x] Squash and merge &rarr; proper PR title
