### PR TITLE
cmake: remove unnecessary link libraries from unit tests

### DIFF
--- a/SilKit/source/config/CMakeLists.txt
+++ b/SilKit/source/config/CMakeLists.txt
@@ -69,12 +69,12 @@ add_silkit_test_to_executable(SilKitUnitTests
 
 add_silkit_test_to_executable(SilKitUnitTests
     SOURCES Test_YamlParser.cpp
-    LIBS O_SilKit_Config rapidyaml
+    LIBS O_SilKit_Config
 )
 
 add_silkit_test_to_executable(SilKitUnitTests
     SOURCES Test_YamlValidator.cpp
-    LIBS O_SilKit_Config rapidyaml
+    LIBS O_SilKit_Config
 )
 
 set(ParticipantTestCanConfigs

--- a/Utilities/SilKitRegistry/config/CMakeLists.txt
+++ b/Utilities/SilKitRegistry/config/CMakeLists.txt
@@ -12,8 +12,6 @@ target_include_directories(O_SilKitRegistry_Config
 
 target_link_libraries(O_SilKitRegistry_Config
     PRIVATE I_SilKit
-    PRIVATE fmt::fmt
-    PRIVATE rapidyaml
 )
 
 


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2023 Vector Informatik GmbH

SPDX-License-Identifier: MIT
-->

## Subject
<!--
    - What kind of changes does this pull request comprise?
    - Add a label like "Bugfix", "docs", etc. to this PR to give context.
 -->

Remove unnecessary link libraries from unit tests. These are already added transitively.

## Developer checklist (address before review)

- [ ] Changelog.md updated
- [ ] Prepared update for depending repositories
- [ ] Documentation updated (public API changes only)
- [ ] API docstrings updated (public API changes only)
- [ ] Rebase &rarr; commit history clean
- [x] Squash and merge &rarr; proper PR title
