### PR TITLE
cmake: dont use internal include dirs, only the top-level

### DIFF
--- a/SilKit/source/CMakeLists.txt
+++ b/SilKit/source/CMakeLists.txt
@@ -63,49 +63,10 @@ endif()
 
 add_library(I_SilKit INTERFACE)
 
+# Internal includes are root-relative from SilKit/source (e.g. "services/can/CanController.hpp"),
+# so a single include root suffices for the whole internal build.
 target_include_directories(I_SilKit
     INTERFACE "${CMAKE_CURRENT_SOURCE_DIR}"
-    INTERFACE "${CMAKE_CURRENT_SOURCE_DIR}/capi"
-    INTERFACE "${CMAKE_CURRENT_SOURCE_DIR}/config"
-    INTERFACE "${CMAKE_CURRENT_SOURCE_DIR}/config/mock"
-    INTERFACE "${CMAKE_CURRENT_SOURCE_DIR}/core/internal"
-    INTERFACE "${CMAKE_CURRENT_SOURCE_DIR}/core/mock/nullconnection"
-    INTERFACE "${CMAKE_CURRENT_SOURCE_DIR}/core/mock/participant"
-    INTERFACE "${CMAKE_CURRENT_SOURCE_DIR}/core/participant"
-    INTERFACE "${CMAKE_CURRENT_SOURCE_DIR}/core/requests"
-    INTERFACE "${CMAKE_CURRENT_SOURCE_DIR}/core/requests/procs"
-    INTERFACE "${CMAKE_CURRENT_SOURCE_DIR}/core/service"
-    INTERFACE "${CMAKE_CURRENT_SOURCE_DIR}/core/vasio"
-    INTERFACE "${CMAKE_CURRENT_SOURCE_DIR}/core/vasio/io"
-    INTERFACE "${CMAKE_CURRENT_SOURCE_DIR}/core/vasio/io/mock"
-    INTERFACE "${CMAKE_CURRENT_SOURCE_DIR}/core/vasio/mock"
-    INTERFACE "${CMAKE_CURRENT_SOURCE_DIR}/dashboard"
-    INTERFACE "${CMAKE_CURRENT_SOURCE_DIR}/dashboard/client"
-    INTERFACE "${CMAKE_CURRENT_SOURCE_DIR}/dashboard/dto"
-    INTERFACE "${CMAKE_CURRENT_SOURCE_DIR}/dashboard/service"
-    INTERFACE "${CMAKE_CURRENT_SOURCE_DIR}/experimental"
-    INTERFACE "${CMAKE_CURRENT_SOURCE_DIR}/experimental/netsim"
-    INTERFACE "${CMAKE_CURRENT_SOURCE_DIR}/extensions"
-    INTERFACE "${CMAKE_CURRENT_SOURCE_DIR}/extensions/SilKitExtensionsImpl"
-    INTERFACE "${CMAKE_CURRENT_SOURCE_DIR}/services/can"
-    INTERFACE "${CMAKE_CURRENT_SOURCE_DIR}/services/ethernet"
-    INTERFACE "${CMAKE_CURRENT_SOURCE_DIR}/services/flexray"
-    INTERFACE "${CMAKE_CURRENT_SOURCE_DIR}/services/lin"
-    INTERFACE "${CMAKE_CURRENT_SOURCE_DIR}/services/logging"
-    INTERFACE "${CMAKE_CURRENT_SOURCE_DIR}/services/metrics"
-    INTERFACE "${CMAKE_CURRENT_SOURCE_DIR}/services/orchestration"
-    INTERFACE "${CMAKE_CURRENT_SOURCE_DIR}/services/pubsub"
-    INTERFACE "${CMAKE_CURRENT_SOURCE_DIR}/services/rpc"
-    INTERFACE "${CMAKE_CURRENT_SOURCE_DIR}/tracing"
-    INTERFACE "${CMAKE_CURRENT_SOURCE_DIR}/tracing/mock"
-    INTERFACE "${CMAKE_CURRENT_SOURCE_DIR}/util"
-    INTERFACE "${CMAKE_CURRENT_SOURCE_DIR}/wire/can"
-    INTERFACE "${CMAKE_CURRENT_SOURCE_DIR}/wire/ethernet"
-    INTERFACE "${CMAKE_CURRENT_SOURCE_DIR}/wire/flexray"
-    INTERFACE "${CMAKE_CURRENT_SOURCE_DIR}/wire/lin"
-    INTERFACE "${CMAKE_CURRENT_SOURCE_DIR}/wire/pubsub"
-    INTERFACE "${CMAKE_CURRENT_SOURCE_DIR}/wire/rpc"
-    INTERFACE "${CMAKE_CURRENT_SOURCE_DIR}/wire/util"
 )
 
 if (MSVC)

--- a/SilKit/source/config/CMakeLists.txt
+++ b/SilKit/source/config/CMakeLists.txt
@@ -31,10 +31,6 @@ target_link_libraries(O_SilKit_Config
 )
 
 
-target_include_directories(O_SilKit_Config
-    PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}
-)
-
 add_silkit_test_to_executable(SilKitUnitTests
     SOURCES Test_Validation.cpp
     LIBS O_SilKit_Config S_SilKitImpl

--- a/SilKit/source/core/vasio/CMakeLists.txt
+++ b/SilKit/source/core/vasio/CMakeLists.txt
@@ -71,11 +71,6 @@ target_compile_definitions(O_SilKit_Core_VAsio
     PRIVATE ASIO_STANDALONE
 )
 
-target_include_directories(O_SilKit_Core_VAsio
-    PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}
-    PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/io
-)
-
 if (MSVC)
     target_compile_options(O_SilKit_Core_VAsio PRIVATE "/bigobj")
 endif()

--- a/SilKit/source/dashboard/CMakeLists.txt
+++ b/SilKit/source/dashboard/CMakeLists.txt
@@ -111,10 +111,6 @@ else()
         DashboardUnavailable.cpp
     )
 
-    target_include_directories(O_SilKit_Dashboard
-        PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
-    )
-
     target_link_libraries(O_SilKit_Dashboard
         PRIVATE I_SilKit
     )

--- a/SilKit/source/tracing/CMakeLists.txt
+++ b/SilKit/source/tracing/CMakeLists.txt
@@ -34,12 +34,6 @@ add_library(O_SilKit_Tracing OBJECT
     ReplayScheduler.cpp
 )
 
-target_include_directories(O_SilKit_Tracing
-    PRIVATE
-        ${CMAKE_CURRENT_LIST_DIR}
-        detail
-)
-
 target_link_libraries(O_SilKit_Tracing
     PRIVATE I_SilKit
     PRIVATE I_SilKit_Extensions


### PR DESCRIPTION
all include paths are now relative to either public silkit/ or internal SilKit/source 