### PR TITLE
On peer shutdown, RemovePeerFromPendingAcknowledges()

### DIFF
--- a/SilKit/source/core/vasio/VAsioConnection.cpp
+++ b/SilKit/source/core/vasio/VAsioConnection.cpp
@@ -1386,6 +1386,7 @@ void VAsioConnection::OnPeerShutdown(IVAsioPeer* peer)
 
             RemovePeerFromLinks(peer);
             RemovePeerFromConnection(peer);
+            RemovePeerFromPendingAcknowledges(peer);
         }
     }
 }
@@ -1690,6 +1691,33 @@ void VAsioConnection::RemovePendingSubscription(const PendingAcksIdentifier& ack
     if (iterPendingASync != _pendingAsyncSubscriptionAcknowledges.end())
     {
         _pendingAsyncSubscriptionAcknowledges.erase(iterPendingASync);
+        if (_pendingAsyncSubscriptionAcknowledges.empty())
+        {
+            AsyncSubscriptionsCompleted();
+        }
+    }
+}
+
+void VAsioConnection::RemovePeerFromPendingAcknowledges(IVAsioPeer* peer)
+{
+    const auto belongsToPeer = [peer](const PendingAcksIdentifier& ackId) { return ackId.first == peer; };
+
+    auto iterPendingSync = std::remove_if(_pendingSubscriptionAcknowledges.begin(),
+                                          _pendingSubscriptionAcknowledges.end(), belongsToPeer);
+    if (iterPendingSync != _pendingSubscriptionAcknowledges.end())
+    {
+        _pendingSubscriptionAcknowledges.erase(iterPendingSync, _pendingSubscriptionAcknowledges.end());
+        if (_pendingSubscriptionAcknowledges.empty())
+        {
+            SyncSubscriptionsCompleted();
+        }
+    }
+
+    auto iterPendingASync = std::remove_if(_pendingAsyncSubscriptionAcknowledges.begin(),
+                                           _pendingAsyncSubscriptionAcknowledges.end(), belongsToPeer);
+    if (iterPendingASync != _pendingAsyncSubscriptionAcknowledges.end())
+    {
+        _pendingAsyncSubscriptionAcknowledges.erase(iterPendingASync, _pendingAsyncSubscriptionAcknowledges.end());
         if (_pendingAsyncSubscriptionAcknowledges.empty())
         {
             AsyncSubscriptionsCompleted();

--- a/SilKit/source/core/vasio/VAsioConnection.hpp
+++ b/SilKit/source/core/vasio/VAsioConnection.hpp
@@ -286,6 +286,9 @@ private:
     // Unique identifier of SubscriptionAcknowledges on the subscriber
     using PendingAcksIdentifier = std::pair<IVAsioPeer*, VAsioMsgSubscriber>;
     void RemovePendingSubscription(const PendingAcksIdentifier& ackId);
+    // Drop all pending acknowledges belonging to a peer that is going away, so the
+    // pending lists can complete even though the peer will never acknowledge them.
+    void RemovePeerFromPendingAcknowledges(IVAsioPeer* peer);
 
     void SendProxyPeerShutdownNotification(IVAsioPeer* peer);
     void RemovePeerFromLinks(IVAsioPeer* peer);


### PR DESCRIPTION
## Complete pending subscription acknowledges when a peer shuts down

### Problem

When a peer disconnects while subscription acknowledges from it are still outstanding, its entries in `_pendingSubscriptionAcknowledges` / `_pendingAsyncSubscriptionAcknowledges` are never removed. The peer is gone, so it will never send the acknowledge that would clear them via `ReceiveSubscriptionAcknowledge` → `RemovePendingSubscription`.

As a result the pending lists never become empty, and the corresponding completion steps are never triggered:

- `SyncSubscriptionsCompleted()` — sets `_receivedAllSubscriptionAcknowledges`, and
- `AsyncSubscriptionsCompleted()` — invokes the async subscription completion handlers.

The subscription handshake then hangs waiting on a promise/handler that can no longer be satisfied.

### Fix

Add `VAsioConnection::RemovePeerFromPendingAcknowledges(IVAsioPeer* peer)`, which drops every pending acknowledge belonging to the departing peer from both the sync and async lists. If a list transitions to empty as a result of the removal, it fires the matching completion (`SyncSubscriptionsCompleted()` / `AsyncSubscriptionsCompleted()`), mirroring the existing guard logic in `RemovePendingSubscription`.

It is invoked from `OnPeerShutdown`, right after `RemovePeerFromLinks` / `RemovePeerFromConnection`, inside the existing `_peersLock` critical section — the same lock under which these vectors are populated in `RegisterSilKitMsgReceiver`.

### Changes

- `VAsioConnection.hpp`: declare `RemovePeerFromPendingAcknowledges(IVAsioPeer* peer)`.
- `VAsioConnection.cpp`: implement it (erase-remove of entries whose peer matches, triggering completion when a list becomes empty) and call it during peer shutdown.

### Notes

- Like the existing `RemovePendingSubscription`, completion is triggered only on the transition to an empty list, preserving the pre-existing assumption that each completion fires at most once.

### Testing

- Rebuild and run the vasio / participant-connection tests, exercising a peer that disconnects with subscription acknowledges still pending, to confirm the handshake no longer hangs.
