### PR TITLE
yaml: be more robust when parsing objects vs sequences

### DIFF
--- a/SilKit/source/config/Test_YamlParser.cpp
+++ b/SilKit/source/config/Test_YamlParser.cpp
@@ -713,6 +713,23 @@ Experimental:
     }
 }
 
+TEST_F(Test_YamlParser, yaml_throw_on_stream_document_as_sequence)
+{
+    // A leading "---" wraps the document in a stream node. The document itself must be
+    // a mapping; here the whole document is a bare sequence, which is the same
+    // object-vs-list mistype and must be rejected.
+    auto streamDocAsSequence = R"(---
+- SoftResponseTimeout: 1
+)";
+
+    EXPECT_THROW(
+        {
+            auto&& cfg = Deserialize<ParticipantConfiguration>(streamDocAsSequence);
+            (void)cfg;
+        },
+        SilKit::ConfigurationError);
+}
+
 TEST_F(Test_YamlParser, yaml_healthcheck_as_map_is_accepted)
 {
     // Regression guard: the correctly-typed object must still parse.

--- a/SilKit/source/config/Test_YamlParser.cpp
+++ b/SilKit/source/config/Test_YamlParser.cpp
@@ -730,6 +730,25 @@ TEST_F(Test_YamlParser, yaml_throw_on_stream_document_as_sequence)
         SilKit::ConfigurationError);
 }
 
+TEST_F(Test_YamlParser, yaml_throw_on_multi_document_stream)
+{
+    // A configuration must be a single YAML document. Two "---"-separated documents
+    // form a multi-document stream and must be rejected rather than silently reading
+    // keys from whichever document happens to contain them.
+    auto multiDocument = R"(---
+ParticipantName: Node0
+---
+ParticipantName: Node1
+)";
+
+    EXPECT_THROW(
+        {
+            auto&& cfg = Deserialize<ParticipantConfiguration>(multiDocument);
+            (void)cfg;
+        },
+        SilKit::ConfigurationError);
+}
+
 TEST_F(Test_YamlParser, yaml_healthcheck_as_map_is_accepted)
 {
     // Regression guard: the correctly-typed object must still parse.

--- a/SilKit/source/config/Test_YamlParser.cpp
+++ b/SilKit/source/config/Test_YamlParser.cpp
@@ -643,10 +643,7 @@ FlexrayControllers:
 
 TEST_F(Test_YamlParser, yaml_throw_on_healthcheck_as_sequence)
 {
-    // HealthCheck is an object with SoftResponseTimeout/HardResponseTimeout members.
-    // Here it is mistyped as a sequence (a list with a single element). The parser
-    // must reject the type mismatch instead of silently descending into the list and
-    // picking up the value from the contained map.
+    // HealthCheck is a mapping; the leading "- " mistypes it as a single-element list.
     auto healthCheckAsSequence = R"(
 HealthCheck:
   - SoftResponseTimeout: 1
@@ -659,17 +656,10 @@ HealthCheck:
         SilKit::ConfigurationError);
 }
 
-// A YAML sequence where a map/object is expected is a type mismatch. The generalized
-// check lives in the parser (GetChildSafe), so it applies to every object, not just
-// HealthCheck. The following cases exercise the edges of that generalization.
-
 TEST_F(Test_YamlParser, yaml_throw_on_object_as_sequence)
 {
-    // Each of these mistypes a mapping as a single-element sequence at a different
-    // nesting level (top-level object, deeply nested object, object inside a list
-    // element). All must be rejected.
+    // A mapping mistyped as a sequence must be rejected at every nesting level.
     const std::initializer_list<const char*> mistypedConfigurations = {
-        // top-level object as sequence
         R"(
 HealthCheck:
   - SoftResponseTimeout: 1
@@ -687,14 +677,12 @@ Experimental:
   - Metrics:
       CollectFromRemote: true
 )",
-        // nested object (a controller's Replay) as sequence
         R"(
 CanControllers:
 - Name: CAN1
   Replay:
     - UseTraceSource: Source1
 )",
-        // object nested inside Experimental as sequence
         R"(
 Experimental:
   Metrics:
@@ -715,9 +703,7 @@ Experimental:
 
 TEST_F(Test_YamlParser, yaml_throw_on_stream_document_as_sequence)
 {
-    // A leading "---" wraps the document in a stream node. The document itself must be
-    // a mapping; here the whole document is a bare sequence, which is the same
-    // object-vs-list mistype and must be rejected.
+    // A single "---" document that is itself a bare sequence is the same mistype.
     auto streamDocAsSequence = R"(---
 - SoftResponseTimeout: 1
 )";
@@ -732,9 +718,7 @@ TEST_F(Test_YamlParser, yaml_throw_on_stream_document_as_sequence)
 
 TEST_F(Test_YamlParser, yaml_throw_on_multi_document_stream)
 {
-    // A configuration must be a single YAML document. Two "---"-separated documents
-    // form a multi-document stream and must be rejected rather than silently reading
-    // keys from whichever document happens to contain them.
+    // A configuration must be a single YAML document; two "---" documents are rejected.
     auto multiDocument = R"(---
 ParticipantName: Node0
 ---
@@ -766,8 +750,7 @@ HealthCheck:
 
 TEST_F(Test_YamlParser, yaml_empty_object_keeps_defaults)
 {
-    // An object left empty (null node) is not a type mismatch: it keeps its defaults
-    // and must not throw. This guards the generalized check against over-rejecting.
+    // An empty object (null node) keeps its defaults and must not throw.
     ParticipantConfiguration defaults{};
 
     auto config = Deserialize<ParticipantConfiguration>(R"(
@@ -780,8 +763,7 @@ HealthCheck:
 
 TEST_F(Test_YamlParser, yaml_sequence_typed_fields_still_parse)
 {
-    // Fields that are genuinely sequences (lists of objects) must keep working after
-    // the object-vs-sequence check was tightened.
+    // Genuinely sequence-typed fields (lists of objects) must keep working.
     auto config = Deserialize<ParticipantConfiguration>(R"(
 CanControllers:
 - Name: CAN1

--- a/SilKit/source/config/Test_YamlParser.cpp
+++ b/SilKit/source/config/Test_YamlParser.cpp
@@ -641,4 +641,127 @@ FlexrayControllers:
         SilKit::ConfigurationError);
 }
 
+TEST_F(Test_YamlParser, yaml_throw_on_healthcheck_as_sequence)
+{
+    // HealthCheck is an object with SoftResponseTimeout/HardResponseTimeout members.
+    // Here it is mistyped as a sequence (a list with a single element). The parser
+    // must reject the type mismatch instead of silently descending into the list and
+    // picking up the value from the contained map.
+    auto healthCheckAsSequence = R"(
+HealthCheck:
+  - SoftResponseTimeout: 1
+)";
+
+    EXPECT_THROW(
+        {
+            auto cfg = Deserialize<ParticipantConfiguration>(healthCheckAsSequence);
+        },
+        SilKit::ConfigurationError);
+}
+
+// A YAML sequence where a map/object is expected is a type mismatch. The generalized
+// check lives in the parser (GetChildSafe), so it applies to every object, not just
+// HealthCheck. The following cases exercise the edges of that generalization.
+
+TEST_F(Test_YamlParser, yaml_throw_on_object_as_sequence)
+{
+    // Each of these mistypes a mapping as a single-element sequence at a different
+    // nesting level (top-level object, deeply nested object, object inside a list
+    // element). All must be rejected.
+    const std::initializer_list<const char*> mistypedConfigurations = {
+        // top-level object as sequence
+        R"(
+HealthCheck:
+  - SoftResponseTimeout: 1
+)",
+        R"(
+Logging:
+  - FlushLevel: Critical
+)",
+        R"(
+Middleware:
+  - RegistryUri: silkit://localhost:8500
+)",
+        R"(
+Experimental:
+  - Metrics:
+      CollectFromRemote: true
+)",
+        // nested object (a controller's Replay) as sequence
+        R"(
+CanControllers:
+- Name: CAN1
+  Replay:
+    - UseTraceSource: Source1
+)",
+        // object nested inside Experimental as sequence
+        R"(
+Experimental:
+  Metrics:
+    - CollectFromRemote: true
+)",
+    };
+
+    for (const auto configuration : mistypedConfigurations)
+    {
+        EXPECT_THROW(
+            {
+                auto&& cfg = Deserialize<ParticipantConfiguration>(configuration);
+                (void)cfg;
+            },
+            SilKit::ConfigurationError);
+    }
+}
+
+TEST_F(Test_YamlParser, yaml_healthcheck_as_map_is_accepted)
+{
+    // Regression guard: the correctly-typed object must still parse.
+    auto config = Deserialize<ParticipantConfiguration>(R"(
+HealthCheck:
+  SoftResponseTimeout: 1
+  HardResponseTimeout: 2
+)");
+
+    ASSERT_TRUE(config.healthCheck.softResponseTimeout.has_value());
+    ASSERT_TRUE(config.healthCheck.hardResponseTimeout.has_value());
+    EXPECT_EQ(config.healthCheck.softResponseTimeout.value(), 1ms);
+    EXPECT_EQ(config.healthCheck.hardResponseTimeout.value(), 2ms);
+}
+
+TEST_F(Test_YamlParser, yaml_empty_object_keeps_defaults)
+{
+    // An object left empty (null node) is not a type mismatch: it keeps its defaults
+    // and must not throw. This guards the generalized check against over-rejecting.
+    ParticipantConfiguration defaults{};
+
+    auto config = Deserialize<ParticipantConfiguration>(R"(
+HealthCheck:
+)");
+
+    EXPECT_EQ(config.healthCheck.softResponseTimeout, defaults.healthCheck.softResponseTimeout);
+    EXPECT_EQ(config.healthCheck.hardResponseTimeout, defaults.healthCheck.hardResponseTimeout);
+}
+
+TEST_F(Test_YamlParser, yaml_sequence_typed_fields_still_parse)
+{
+    // Fields that are genuinely sequences (lists of objects) must keep working after
+    // the object-vs-sequence check was tightened.
+    auto config = Deserialize<ParticipantConfiguration>(R"(
+CanControllers:
+- Name: CAN1
+  Network: CAN2
+- Name: CAN2
+LinControllers:
+- Name: LIN1
+)");
+
+    ASSERT_EQ(config.canControllers.size(), 2u);
+    EXPECT_EQ(config.canControllers.at(0).name, "CAN1");
+    ASSERT_TRUE(config.canControllers.at(0).network.has_value());
+    EXPECT_EQ(config.canControllers.at(0).network.value(), "CAN2");
+    EXPECT_EQ(config.canControllers.at(1).name, "CAN2");
+    ASSERT_EQ(config.linControllers.size(), 1u);
+    EXPECT_EQ(config.linControllers.at(0).name, "LIN1");
+}
+
 } // anonymous namespace

--- a/SilKit/source/config/Test_YamlValidator.cpp
+++ b/SilKit/source/config/Test_YamlValidator.cpp
@@ -40,6 +40,38 @@ TEST_F(Test_YamlValidator, validate_without_warnings)
     EXPECT_TRUE(warnings.empty()) << "Warnings: " << warnings;
 }
 
+TEST_F(Test_YamlValidator, validate_rejects_multi_document_stream)
+{
+    // A stray "---" mid-config splits it into two documents; the validator must reject it.
+    auto yamlString = R"yaml(Description: Log to Stdout with Level Info
+Logging:
+---
+  Sinks:
+    - Level: Info
+      Type: Stdout
+)yaml";
+
+    std::stringstream warnings;
+    bool yamlValid = ValidateWithSchema(yamlString, warnings);
+    EXPECT_FALSE(yamlValid) << "A multi-document stream must not validate";
+    EXPECT_THAT(warnings.str(), testing::HasSubstr("one YAML document"));
+}
+
+TEST_F(Test_YamlValidator, validate_accepts_single_leading_document_marker)
+{
+    // A single leading "---" is one document and stays valid.
+    auto yamlString = R"yaml(---
+schemaVersion: 1
+ParticipantName: CanDemoParticipant
+)yaml";
+
+    std::stringstream warnings;
+    bool yamlValid = ValidateWithSchema(yamlString, warnings);
+    EXPECT_TRUE(yamlValid) << "A single leading '---' document must validate. Warnings: "
+                           << warnings.str();
+    EXPECT_TRUE(warnings.str().empty()) << "Warnings: " << warnings.str();
+}
+
 TEST_F(Test_YamlValidator, validate_unknown_toplevel)
 {
     auto yamlString = R"yaml(

--- a/SilKit/source/config/YamlParser.hpp
+++ b/SilKit/source/config/YamlParser.hpp
@@ -46,6 +46,8 @@ auto Deserialize(const std::string& input) -> T
         // Extract a reference to the root node of the document tree.
         auto root = tree.crootref();
 
+        VSilKit::EnsureSingleDocument(root);
+
         R reader{parser, root};
         T result{};
         reader.Read(result);

--- a/SilKit/source/config/YamlParserUtils.cpp
+++ b/SilKit/source/config/YamlParserUtils.cpp
@@ -69,6 +69,16 @@ auto GetRapidyamlCallbacks() -> ryml::Callbacks
     return ryml::Callbacks{nullptr, RapidyamlAllocate, RapidyamlFree, RapidyamlError};
 }
 
+void EnsureSingleDocument(ryml::ConstNodeRef root)
+{
+    if (root.is_stream() && root.num_children() > 1)
+    {
+        throw SilKit::ConfigurationError{
+            "configuration must contain exactly one YAML document, but multiple "
+            "\"---\"-separated documents were found"};
+    }
+}
+
 } // namespace VSilKit
 
 

--- a/SilKit/source/config/YamlParserUtils.hpp
+++ b/SilKit/source/config/YamlParserUtils.hpp
@@ -21,4 +21,7 @@ auto MakeConfigurationError(ryml::Location location, const std::string_view mess
 
 auto GetRapidyamlCallbacks() -> ryml::Callbacks;
 
+// Throws unless the configuration is a single YAML document.
+void EnsureSingleDocument(ryml::ConstNodeRef root);
+
 } // namespace VSilKit

--- a/SilKit/source/config/YamlReader.hpp
+++ b/SilKit/source/config/YamlReader.hpp
@@ -227,13 +227,15 @@ protected:
 
     auto GetChildSafe(const std::string& name) const -> Impl
     {
-        if (HasKey(name))
+        if (IsMap())
         {
             return MakeImpl(_node.find_child(ryml::to_csubstr(name)));
         }
 
-        if (IsSequence())
+        if (_node.is_stream())
         {
+            // A leading "---" makes the document root a stream (a sequence of
+            // documents). Transparently descend into the document(s) to find the key.
             for (const auto& child : _node.cchildren())
             {
                 if (child.is_container() && HasKey(child, name))
@@ -241,8 +243,23 @@ protected:
                     return MakeImpl(child.find_child(ryml::to_csubstr(name)));
                 }
             }
+            return MakeImpl({});
         }
 
+        if (IsSequence())
+        {
+            // A YAML sequence (list) was provided where an object with named keys is
+            // expected. Reject the type mismatch instead of silently searching the
+            // list's elements for the key. This catches mistyped configuration such as
+            // "HealthCheck:\n  - SoftResponseTimeout: 1", where the leading "- " turns
+            // an object into a single-element list.
+            std::ostringstream s;
+            s << "expected a mapping with key \"" << name << "\", but got a sequence";
+            throw MakeConfigurationError(s.str());
+        }
+
+        // Not a container (absent, null or empty node): treat the key as not present so
+        // that objects left empty keep their default values.
         return MakeImpl({});
     }
 

--- a/SilKit/source/config/YamlReader.hpp
+++ b/SilKit/source/config/YamlReader.hpp
@@ -236,11 +236,21 @@ protected:
         {
             // A leading "---" makes the document root a stream (a sequence of
             // documents). Transparently descend into the document(s) to find the key.
-            for (const auto& child : _node.cchildren())
+            // A document must itself be a mapping; a document that is a bare sequence
+            // is the same object-vs-list mistype we reject below.
+            for (const auto& doc : _node.cchildren())
             {
-                if (child.is_container() && HasKey(child, name))
+                if (doc.is_seq())
                 {
-                    return MakeImpl(child.find_child(ryml::to_csubstr(name)));
+                    ThrowExpectedMapping(name);
+                }
+                if (doc.is_map())
+                {
+                    auto&& found = doc.find_child(ryml::to_csubstr(name));
+                    if (!found.invalid())
+                    {
+                        return MakeImpl(found);
+                    }
                 }
             }
             return MakeImpl({});
@@ -253,14 +263,19 @@ protected:
             // list's elements for the key. This catches mistyped configuration such as
             // "HealthCheck:\n  - SoftResponseTimeout: 1", where the leading "- " turns
             // an object into a single-element list.
-            std::ostringstream s;
-            s << "expected a mapping with key \"" << name << "\", but got a sequence";
-            throw MakeConfigurationError(s.str());
+            ThrowExpectedMapping(name);
         }
 
         // Not a container (absent, null or empty node): treat the key as not present so
         // that objects left empty keep their default values.
         return MakeImpl({});
+    }
+
+    [[noreturn]] void ThrowExpectedMapping(const std::string& name) const
+    {
+        std::ostringstream s;
+        s << "expected a mapping with key \"" << name << "\", but got a sequence";
+        throw MakeConfigurationError(s.str());
     }
 
     auto MakeImpl(ryml::ConstNodeRef node_) const -> Impl

--- a/SilKit/source/config/YamlReader.hpp
+++ b/SilKit/source/config/YamlReader.hpp
@@ -235,9 +235,18 @@ protected:
         if (_node.is_stream())
         {
             // A leading "---" makes the document root a stream (a sequence of
-            // documents). Transparently descend into the document(s) to find the key.
-            // A document must itself be a mapping; a document that is a bare sequence
-            // is the same object-vs-list mistype we reject below.
+            // documents). Only a single document is a valid configuration; reject a
+            // multi-document stream ("---"-separated documents) outright.
+            if (_node.num_children() > 1)
+            {
+                throw MakeConfigurationError(
+                    "expected a single YAML document, but the configuration contains multiple "
+                    "\"---\"-separated documents");
+            }
+
+            // Transparently descend into the document to find the key. The document
+            // must itself be a mapping; a document that is a bare sequence is the same
+            // object-vs-list mistype we reject below.
             for (const auto& doc : _node.cchildren())
             {
                 if (doc.is_seq())

--- a/SilKit/source/config/YamlReader.hpp
+++ b/SilKit/source/config/YamlReader.hpp
@@ -234,19 +234,8 @@ protected:
 
         if (_node.is_stream())
         {
-            // A leading "---" makes the document root a stream (a sequence of
-            // documents). Only a single document is a valid configuration; reject a
-            // multi-document stream ("---"-separated documents) outright.
-            if (_node.num_children() > 1)
-            {
-                throw MakeConfigurationError(
-                    "expected a single YAML document, but the configuration contains multiple "
-                    "\"---\"-separated documents");
-            }
-
-            // Transparently descend into the document to find the key. The document
-            // must itself be a mapping; a document that is a bare sequence is the same
-            // object-vs-list mistype we reject below.
+            // Single-document stream (leading "---"): descend into the document. A
+            // document that is a bare sequence is the same mistype rejected below.
             for (const auto& doc : _node.cchildren())
             {
                 if (doc.is_seq())
@@ -267,16 +256,10 @@ protected:
 
         if (IsSequence())
         {
-            // A YAML sequence (list) was provided where an object with named keys is
-            // expected. Reject the type mismatch instead of silently searching the
-            // list's elements for the key. This catches mistyped configuration such as
-            // "HealthCheck:\n  - SoftResponseTimeout: 1", where the leading "- " turns
-            // an object into a single-element list.
             ThrowExpectedMapping(name);
         }
 
-        // Not a container (absent, null or empty node): treat the key as not present so
-        // that objects left empty keep their default values.
+        // Absent, null or empty node: treat the key as not present.
         return MakeImpl({});
     }
 

--- a/SilKit/source/config/YamlValidator.cpp
+++ b/SilKit/source/config/YamlValidator.cpp
@@ -630,6 +630,9 @@ bool ValidateWithSchema(const std::string& yamlString, std::ostream& warnings)
         auto tree = ryml::parse_in_arena(&parser, cinput);
 
         auto root = tree.crootref();
+
+        VSilKit::EnsureSingleDocument(root);
+
         if (root.is_doc() && (root.is_map() || root.is_seq()))
         {
             std::string version;

--- a/docs/changelog/versions/latest.md
+++ b/docs/changelog/versions/latest.md
@@ -4,3 +4,8 @@
 
 - `config`: default format of file logging is set to JSON. Set "Format: Simple" in the sink to get previous behaviour.
 - `docs`: added description of the logging "Format".
+
+## Fixed
+
+- `config`: a mapping that is mistyped as a YAML sequence (e.g. a stray leading `- ` turning `HealthCheck` into a list) is now rejected with a clear error instead of being silently accepted.
+- `config`: a configuration containing multiple `---`-separated YAML documents is now rejected with a clear error. A single leading `---` remains valid.

--- a/docs/configuration/configuration.rst
+++ b/docs/configuration/configuration.rst
@@ -67,9 +67,17 @@ This gives users the ability to run a simulation with multiple instances of a pa
 
     Many IDEs automatically support participant configuration schema support when the participant configuration file ends with the suffix ``.silkit.json/yaml``.
 
-A participant configuration file is written in YAML syntax according to a specified schema. 
-It starts with the ``SchemaVersion``, the ``Description`` for the configuration and the ``ParticipantName``. 
+A participant configuration file is written in YAML syntax according to a specified schema.
+It starts with the ``SchemaVersion``, the ``Description`` for the configuration and the ``ParticipantName``.
 This is followed by further sections for ``Includes``, ``Middleware``, ``Logging``, ``HealthCheck``, ``Tracing``, ``Extentions`` and sections for the different services of the |ProductName|.
+
+.. admonition:: Note
+
+    A configuration must be a single YAML document.
+    A single leading document marker (``---``) is allowed, but a configuration that
+    contains multiple ``---``-separated documents is rejected with an error.
+    This most commonly happens when a stray ``---`` is placed in the middle of a file.
+
 The outline of a participant configuration file is as follows:
 
 .. code-block:: yaml


### PR DESCRIPTION
This makes the parsing of objects more robust.
the following was silently accepted:
```
HealthCheck:   
  - SoftResponseTimeout: 1
```
which should be invalid, but is silently accepted (because HealthCheck is a map and not a container for a sequence).