### PR TITLE
tests: make system monitor use time sync again

### DIFF
--- a/SilKit/IntegrationTests/ITestFixture.hpp
+++ b/SilKit/IntegrationTests/ITestFixture.hpp
@@ -27,11 +27,18 @@ protected: //CTor and operators
         return *_simTestHarness;
     }
 
-    void SetupFromParticipantList(std::vector<std::string> participantNames)
+    void SetupFromParticipantList(std::vector<std::string> participantNames,
+                                  bool enableInternalSystemMonitorTimeSync = true)
     {
         // create test harness with deferred participant creation.
         // Will only create the SIL Kit Registry and tell the SystemController the participantNames
-        _simTestHarness = std::make_unique<SimTestHarness>(participantNames, "silkit://localhost:0", true);
+        SimTestHarnessArgs args{};
+        args.syncParticipantNames = std::move(participantNames);
+        args.registry.listenUri = "silkit://localhost:0";
+        args.deferParticipantCreation = true;
+        args.enableInternalSystemMonitorTimeSync = enableInternalSystemMonitorTimeSync;
+
+        _simTestHarness = std::make_unique<SimTestHarness>(args);
         _registryUri = _simTestHarness->GetRegistryUri();
     }
 

--- a/SilKit/IntegrationTests/ITest_AsyncSimTask.cpp
+++ b/SilKit/IntegrationTests/ITest_AsyncSimTask.cpp
@@ -302,12 +302,11 @@ auto MakeCompletionThread(SimParticipant* p, ParticipantData* d) -> std::thread
 
 TEST(ITest_AsyncSimTask, test_async_simtask_other_simulation_steps_completed_handler)
 {
-    SimTestHarness testHarness({"A", "B", "C", "D"}, "silkit://localhost:0");
+    SimTestHarness testHarness({"A", "B", "C"}, "silkit://localhost:0");
 
     const auto a = testHarness.GetParticipant("A");
     const auto b = testHarness.GetParticipant("B");
     const auto c = testHarness.GetParticipant("C");
-    const auto d = testHarness.GetParticipant("D");
 
     ParticipantData ad, bd, cd;
 
@@ -316,8 +315,6 @@ TEST(ITest_AsyncSimTask, test_async_simtask_other_simulation_steps_completed_han
     a->GetOrCreateLifecycleService()->SetStopHandler([&ad] { ad.running = false; });
     b->GetOrCreateLifecycleService()->SetStopHandler([&bd] { bd.running = false; });
     c->GetOrCreateLifecycleService()->SetStopHandler([&cd] { cd.running = false; });
-
-    d->GetOrCreateTimeSyncService()->SetSimulationStepHandler([](auto, auto) {}, 1ms);
 
     const auto aLifecycleService = a->GetOrCreateLifecycleService();
 

--- a/SilKit/IntegrationTests/ITest_DynStepSizes.cpp
+++ b/SilKit/IntegrationTests/ITest_DynStepSizes.cpp
@@ -67,7 +67,9 @@ void ITest_DynStepSizes::RunTestSetup(std::vector<ParticipantParams>& participan
     {
         participantNames.push_back(participantParams.name);
     }
-    SetupFromParticipantList(participantNames);
+    // The internal system monitor must stay out of the step size negotiation, otherwise its own 1ms
+    // step would drag every ByMinimalDuration participant down to 1ms.
+    SetupFromParticipantList(participantNames, /*enableInternalSystemMonitorTimeSync=*/false);
 
     std::mutex mx;
 

--- a/SilKit/IntegrationTests/SimTestHarness/SimTestHarness.cpp
+++ b/SilKit/IntegrationTests/SimTestHarness/SimTestHarness.cpp
@@ -140,6 +140,7 @@ SimTestHarness::SimTestHarness(const std::vector<std::string>& syncParticipantNa
 SimTestHarness::SimTestHarness(const SilKit::Tests::SimTestHarnessArgs& args)
     : _syncParticipantNames{args.syncParticipantNames}
     , _asyncParticipantNames{args.asyncParticipantNames}
+    , _enableInternalSystemMonitorTimeSync{args.enableInternalSystemMonitorTimeSync}
 {
     // start registry
     _registry = SilKit::Vendor::Vector::CreateSilKitRegistry(
@@ -184,13 +185,10 @@ bool SimTestHarness::Run(std::chrono::nanoseconds testRunTimeout, const std::vec
     auto simulationFinishedFuture = simulationFinishedPromise.get_future();
     if (!_syncParticipantNames.empty())
     {
-        // Create a monitor, add it to the list of simParticipants, then start all participants.
-        // The monitor only observes SystemState; it must not create a time sync service, otherwise it
-        // would advertise an active 1ms simulation step and pollute the ByMinimalDuration negotiation
-        // of the actual sync participants (dragging their aligned step size down to 1ms).
+        // Create a monitor, add it to the list of simParticipants, then start all participants
         AddParticipant(internalSystemMonitorName, "",
                        {SilKit::Services::Orchestration::OperationMode::Coordinated},
-                       /*createTimeSyncService=*/false);
+                       _enableInternalSystemMonitorTimeSync);
         auto monitor = _simParticipants[internalSystemMonitorName]->GetOrCreateSystemMonitor();
         monitor->AddSystemStateHandler([&](auto systemState) {
             if (systemState == SilKit::Services::Orchestration::SystemState::Shutdown)

--- a/SilKit/IntegrationTests/SimTestHarness/SimTestHarness.hpp
+++ b/SilKit/IntegrationTests/SimTestHarness/SimTestHarness.hpp
@@ -81,6 +81,10 @@ struct SimTestHarnessArgs
     /// If true, the system controller is only created if CreateSystemController is called. If false, it will be created
     /// in the SimTestHarness constructor.
     bool deferSystemControllerCreation{false};
+    /// If false, the internal system monitor participant is created without a time sync service, i.e. it does not
+    /// take part in the ByMinimalDuration negotiation with its own 1ms step. Only ITest_DynStepSizes needs this;
+    /// such a monitor is not throttled by the virtual time barrier and can starve under load.
+    bool enableInternalSystemMonitorTimeSync{true};
 
     struct
     {
@@ -148,6 +152,7 @@ private:
     std::map<std::string, std::unique_ptr<SimParticipant>> _simParticipants;
     std::unique_ptr<SilKit::Vendor::Vector::ISilKitRegistry> _registry;
     const std::string internalSystemMonitorName = "InternalSystemMonitor";
+    bool _enableInternalSystemMonitorTimeSync{true};
 };
 
 


### PR DESCRIPTION
Some tests which rely on the test harness' montor run flaky on systems with heavy load.
Make sure to enable timesync in the internal monitor for tests (provides back pressure and sync between participants).