### PR TITLE
docs: add deprecation warning for Ubuntu 20.04

### DIFF
--- a/docs/changelog/versions/latest.md
+++ b/docs/changelog/versions/latest.md
@@ -20,6 +20,7 @@
 
 - `config`: default format of file logging is set to JSON. Set "Format: Simple" in the sink to get previous behaviour.
 - `docs`: added description of the logging "Format".
+- `docs`: added deprecation warning for Ubuntu 20.04
 - `build`: the CMake targets only expose the top-level include directory instead of internal include directories.
 
 ## Fixed

--- a/docs/for-developers/developers.rst
+++ b/docs/for-developers/developers.rst
@@ -211,7 +211,7 @@ Essential targets. Automatically tested and provided as official binary packages
      - GCC 13
    * - Ubuntu 20.04
      - amd64
-     - Clang 10, `.deb`
+     - Clang 10, `.deb`, will be deprecated in a future release
    * - Ubuntu 22.04
      - ARM64
      - Clang 14, `.deb`


### PR DESCRIPTION

## Subject
Add deprecation warning to the platform support table in the docs

## Description


## Instructions for review / testing

## Developer checklist (address before review)

- [ x] Changelog.md updated
- [ ] Prepared update for depending repositories
- [ ] Documentation updated (public API changes only)
- [ ] API docstrings updated (public API changes only)
- [ ] Rebase &rarr; commit history clean
- [ ] Squash and merge &rarr; proper PR title
