### PR TITLE
tests: Ffix ITest_AsyncSimTask repeatability by turning global into local variables

### DIFF
--- a/SilKit/IntegrationTests/ITest_AsyncSimTask.cpp
+++ b/SilKit/IntegrationTests/ITest_AsyncSimTask.cpp
@@ -24,10 +24,6 @@ using namespace SilKit::Tests;
 
 const std::chrono::nanoseconds expectedTime{10ms};
 
-std::mutex mx;
-int cvCounter{};
-std::condition_variable cv;
-
 TEST(ITest_AsyncSimTask, test_async_simtask_lockstep)
 {
     // Goal: have a foreign/user thread run in lockstep with the SimulationStepHandler.
@@ -35,6 +31,11 @@ TEST(ITest_AsyncSimTask, test_async_simtask_lockstep)
     // The sync participant's SimulationStepHandler will run as often as possible.
     // Async may not start a new SimTask before calling CompleteSimulationtask to complete the current one.
 
+    using MutexType = std::mutex;
+
+    MutexType mx;
+    int cvCounter{};
+    std::condition_variable cv;
 
     SimTestHarness testHarness({"Sync", "Async"}, "silkit://localhost:0");
 
@@ -66,8 +67,8 @@ TEST(ITest_AsyncSimTask, test_async_simtask_lockstep)
         }
 
         //wait until counter is even
-        std::unique_lock<decltype(mx)> lock(mx);
-        cv.wait(lock, [] { return cvCounter % 2 == 0; });
+        std::unique_lock<MutexType> lock(mx);
+        cv.wait(lock, [&] { return cvCounter % 2 == 0; });
 
         // increment so that completer thread will be notified
         cvCounter++;
@@ -86,9 +87,9 @@ TEST(ITest_AsyncSimTask, test_async_simtask_lockstep)
     auto completer = std::thread{[&]() {
         while (!done && (syncTimeNs.load() < expectedTime))
         {
-            std::unique_lock<decltype(mx)> lock(mx);
+            std::unique_lock<MutexType> lock(mx);
             //wait for odd counter
-            cv.wait(lock, [] { return cvCounter % 2 == 1; });
+            cv.wait(lock, [&] { return cvCounter % 2 == 1; });
             if (done)
             {
                 return;

--- a/SilKit/source/services/orchestration/TimeSyncService.hpp
+++ b/SilKit/source/services/orchestration/TimeSyncService.hpp
@@ -200,6 +200,10 @@ auto TimeSyncService::GetServiceDescriptor() const -> const Core::ServiceDescrip
 auto TimeSyncService::GetTimeSyncPolicy() const -> ITimeSyncPolicy*
 {
     std::unique_lock<decltype(_timeSyncPolicyMx)> lock{_timeSyncPolicyMx};
+    if (_timeSyncPolicy == nullptr)
+    {
+        throw LogicError{"TimeSyncPolicy is not set"};
+    }
     return _timeSyncPolicy.get();
 }
 


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2023 Vector Informatik GmbH

SPDX-License-Identifier: MIT
-->

## Subject
<!--
    - What kind of changes does this pull request comprise?
    - Add a label like "Bugfix", "docs", etc. to this PR to give context.
 -->

Move mx, cvCounter, and cv from file-scope globals into the test body so state doesn't leak across repeated runs, and fix the wait lambdas to capture by reference instead of silently referencing globals.

## Developer checklist (address before review)

- [ ] Changelog.md updated
- [ ] Prepared update for depending repositories
- [ ] Documentation updated (public API changes only)
- [ ] API docstrings updated (public API changes only)
- [ ] Rebase &rarr; commit history clean
- [x] Squash and merge &rarr; proper PR title
