### PR TITLE
Stop also in SystemState::Stopped if not already done in SystemState::Stopping

### DIFF
--- a/SilKit/source/services/orchestration/LifecycleService.cpp
+++ b/SilKit/source/services/orchestration/LifecycleService.cpp
@@ -554,10 +554,20 @@ void LifecycleService::NewSystemState(SystemState systemState)
         if (_lifecycleManager.GetCurrentState() == _lifecycleManager.GetRunningState()
             || _lifecycleManager.GetCurrentState() == _lifecycleManager.GetPausedState())
         {
+            _stopRequestedDueToSystemStateChange = true;
             _lifecycleManager.Stop(ss.str());
         }
         break;
     case SystemState::Stopped:
+        // Due to the local calculation of SystemStates, SystemState::Stopping might have been skipped. Try to trigger a stop again in that case.
+        if (!_stopRequestedDueToSystemStateChange && 
+            (_lifecycleManager.GetCurrentState()
+                == _lifecycleManager.GetRunningState()
+            || _lifecycleManager.GetCurrentState() == _lifecycleManager.GetPausedState()))
+        {
+            _stopRequestedDueToSystemStateChange = true;
+            _lifecycleManager.Stop(ss.str());
+        }
         break;
     case SystemState::ShuttingDown:
         break;

--- a/SilKit/source/services/orchestration/LifecycleService.hpp
+++ b/SilKit/source/services/orchestration/LifecycleService.hpp
@@ -178,6 +178,9 @@ private:
     // for immediate checks (e.g., not to send out the NextSimTask after a stopping in the SimTaskHandler).
     std::atomic<bool> _stopRequested{false};
     std::atomic<bool> _pauseRequested{false};
+
+    bool _stopRequestedDueToSystemStateChange{false};
+
 };
 
 // ================================================================================


### PR DESCRIPTION
A coordintated particpant ("P2") should stop as well if another participant ("P1") calls `lifecycle->Stop()`.
For P2, this is handled by monitoring the `SystemState`. If this is calculated to be `SystemState::Stopping`, then the local stop is triggered. However, this only happens if its `ParticipantState` is `Running` or `Paused`. Further, due to the local calculation of the `SystemState`, intermediate states can be skipped, in this case `SystemState::Stopping` is not guaranteed to be triggered.

This can be reproduced by spinning on `ITest_DynStepSizes - one_participant_ByOwnDuration` (Linux Debug) with `stress-ng --cpu 64`. When additionally monitoring the `SystemState` of the internalSystemMonitor in the SimTestHarness, it can be shown that  `SystemState::Running` and `SystemState::Stopping` are never triggered.

In this PR, this is duct-taped by triggering the local stop also in `SystemState::Stopped` (if it did not already happen before).
