### PR TITLE
ci: replace msvc-dev-cmd with WIP vanilla bat

### DIFF
--- a/.github/workflows/build-win.yml
+++ b/.github/workflows/build-win.yml
@@ -43,10 +43,8 @@ jobs:
       shell: powershell
 
     - name: Prepare build env on Windows
-      uses: ilammy/msvc-dev-cmd@v1.12.0
-      with:
-        arch: x64
-        toolset: 14.20
+      run: |
+        python3 -u ./SilKit/ci/setup_msvc_env.py --arch x64 --hostarch x64 --vcvars_ver 14.2
 
     - uses: ./.github/actions/build-cmake-preset
       with:
@@ -78,10 +76,9 @@ jobs:
       shell: powershell
 
     - name: Prepare build env on Windows
-      uses: ilammy/msvc-dev-cmd@v1.12.0
-      with:
-        arch: x86
-        toolset: 14.20
+      run: |
+        python3 -u ./SilKit/ci/setup_msvc_env.py --arch x86 --hostarch x64 --vcvars_ver 14.2
+
 
     - uses: ./.github/actions/build-cmake-preset
       with:

--- a/SilKit/ci/setup_msvc_env.py
+++ b/SilKit/ci/setup_msvc_env.py
@@ -1,0 +1,81 @@
+#! /bin/env python3
+
+# SPDX-FileCopyrightText: 2026 Vector Informatik GmbH
+#
+# SPDX-License-Identifier: MIT
+
+import subprocess
+import json
+import logging
+import os
+import argparse
+
+logger = logging.getLogger(__name__)
+handler = logging.StreamHandler()
+logger.addHandler(handler)
+logger.setLevel(logging.DEBUG)
+
+from pathlib import Path
+
+def find_VsDevCmd() -> str:
+
+    some_out = subprocess.run(
+            ["vswhere", "-latest", "-property", "InstallationPath"],
+            capture_output=True, encoding="utf-8", check=True)
+
+    print(some_out.stdout)
+
+
+    return Path(some_out.stdout.rstrip()) / r'Common7\Tools\VsDevCmd.bat'
+
+def main():
+
+    parser = argparse.ArgumentParser(prog="Microsoft Dev Env Creator",
+                                     description="Setup the development environment under Windows")
+    parser.add_argument('--arch', type=str, default='x64',
+                        help='The architecture for which to build the binary for')
+    parser.add_argument('--hostarch', type=str, default='x64',
+                        help='The architecture of the host build machine')
+    parser.add_argument('--vcvars_ver', type=str, default='14.2',
+                        help='The version of the toolset to be used')
+    args = parser.parse_args()
+
+    old_env = json.loads(json.dumps(dict(os.environ)))
+
+    vsdevcmd_path = find_VsDevCmd()
+    vsdevcmd = f'"{vsdevcmd_path}" -arch={args.arch} -host_arch={args.hostarch} -vcvars_ver={args.vcvars_ver}'
+
+    logger.debug(f"Executing cmd:\n{vsdevcmd}")
+
+    osenvcmd = '( python -c "import os, json; print(json.dumps(dict(os.environ)))" )'
+    logger.debug(f"Found at: {vsdevcmd_path}")
+    vsdevcmd_proc = subprocess.run(
+            executable=r'C:\Windows\System32\cmd.exe',
+            args=f'/S /C "( ( {vsdevcmd} >NUL 2>&1 ) && {osenvcmd} ) & exit"',
+            capture_output=True, encoding="utf-8", check=False)
+
+    new_env = vsdevcmd_proc.stdout
+    if not new_env:
+        logger.error("Could not acquire a new shell env!")
+        exit(1)
+
+    environment = json.loads(vsdevcmd_proc.stdout)
+
+    with open(os.environ['GITHUB_ENV'], 'a') as f:
+        for k, v in environment.items():
+            # Ignore CI env set by Github
+            if v.startswith(('GITHUB_', 'RUNNER_', 'CI')):
+                continue
+
+            # Ignore old values that did not change
+            if k in old_env:
+                if environment[k] == old_env[k]:
+                    continue
+
+            f.write(f"{k}={v}\n")
+            logger.debug(f"Setting: {k}={v}")
+
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Subject
redudece third party dependencies in CI


## Description
msvc-dev-cmd is the only (non github) third party  depency we have in our CI. And while not critical we want to experiment with vanilla setups for the CI

## Instructions for review / testing


## Developer checklist (address before review)

- [ ] Changelog.md updated
- [ ] Prepared update for depending repositories
- [ ] Documentation updated (public API changes only)
- [ ] API docstrings updated (public API changes only)
- [ ] Rebase &rarr; commit history clean
- [ ] Squash and merge &rarr; proper PR title
