### PR TITLE
log: fix missing arguments in timesync

### DIFF
--- a/SilKit/source/services/orchestration/Test_TimeSyncService.cpp
+++ b/SilKit/source/services/orchestration/Test_TimeSyncService.cpp
@@ -3,7 +3,9 @@
 // SPDX-License-Identifier: MIT
 
 #include <chrono>
+#include <condition_variable>
 #include <functional>
+#include <mutex>
 #include <string>
 
 #include "gmock/gmock.h"
@@ -59,6 +61,16 @@ protected: // CTor
                 [this](const SilKit::Core::IServiceEndpoint* /* from */,
                        const Services::Orchestration::NextSimTask& msg) { sentNextSimTasks.emplace_back(msg); });
 
+        CreateServices();
+    }
+
+protected: // Methods
+    //! Recreate the services under test, e.g. after changing healthCheckConfig.
+    void CreateServices()
+    {
+        timeSyncService.reset(); // holds a raw pointer to the lifecycle service
+        lifecycleService.reset();
+
         // this CTor calls CreateTimeSyncService implicitly
         lifecycleService = std::make_unique<LifecycleService>(&participant);
         lifecycleService->SetLifecycleConfiguration(LifecycleConfiguration{OperationMode::Coordinated});
@@ -67,7 +79,6 @@ protected: // CTor
         lifecycleService->SetTimeSyncService(timeSyncService.get());
     }
 
-protected: // Methods
     void PrepareLifecycle()
     {
         lifecycleService->SetTimeSyncActive(true);
@@ -329,6 +340,51 @@ TEST_F(Test_TimeSyncService, dynamic_step_driver_enables_without_peers)
     // Explicit true enables locally regardless of peers (and also advertises to them).
     timeSyncService->ConfigureDynamicStepSize(true);
     EXPECT_TRUE(timeSyncService->GetTimeConfiguration()->IsDynamicStepSizeEnabled());
+}
+
+TEST_F(Test_TimeSyncService, soft_time_limit_warning_reports_the_measured_timeout)
+{
+    healthCheckConfig.softResponseTimeout = 10ms;
+    CreateServices();
+
+    std::mutex mutex;
+    std::condition_variable warningArrived;
+    std::string warning;
+
+    // The watchdog warns from its own thread while the simulation step handler below is still running.
+    auto captureWarning = [&](const Services::Logging::LoggerMessage& msg) {
+        if (msg.GetLevel() != Services::Logging::Level::Warn)
+        {
+            return;
+        }
+
+        std::unique_lock<std::mutex> lock{mutex};
+        warning = msg.GetMsgString();
+        warningArrived.notify_all();
+    };
+    ON_CALL(participant.logger, ProcessLoggerMessage(_)).WillByDefault(captureWarning);
+
+    auto simulationStep = [&](std::chrono::nanoseconds, std::chrono::nanoseconds) {
+        std::unique_lock<std::mutex> lock{mutex};
+        warningArrived.wait_for(lock, 30s, [&] { return !warning.empty(); });
+    };
+    timeSyncService->SetSimulationStepHandler(simulationStep, 1ms);
+
+    PrepareLifecycle();
+    timeSyncService->ReceiveMsg(&endpoint, {0ms});
+
+    std::unique_lock<std::mutex> lock{mutex};
+    ASSERT_FALSE(warning.empty()) << "the watchdog should have warned about the exceeded soft time limit";
+    EXPECT_THAT(warning, HasSubstr("soft time limit"));
+    EXPECT_THAT(warning, Not(HasSubstr("{}"))) << "the timeout must be formatted into the message";
+
+    const std::string prefix{"after "};
+    const auto timeoutPos = warning.find(prefix);
+    ASSERT_NE(timeoutPos, std::string::npos) << warning;
+
+    double timeoutMs{-1.0};
+    ASSERT_NO_THROW(timeoutMs = std::stod(warning.substr(timeoutPos + prefix.size()))) << warning;
+    EXPECT_GT(timeoutMs, 0.0);
 }
 
 } // namespace

--- a/SilKit/source/services/orchestration/TimeSyncService.cpp
+++ b/SilKit/source/services/orchestration/TimeSyncService.cpp
@@ -308,9 +308,9 @@ TimeSyncService::TimeSyncService(Core::IParticipantInternal* participant, ITimeP
     if (_isCoupledToWallClock)
     {
         _logger->MakeMessage(Logging::Level::Debug, TopicOf(*this))
-            .SetMessage("Coupled to the local wall clock with animation factor")
-            .AddKeyValue(Logging::Keys::animationFactor, _animationFactor)
-            .Dispatch();
+        .SetMessage("Coupled to the local wall clock with animation factor")
+        .AddKeyValue(Logging::Keys::animationFactor, _animationFactor)
+        .Dispatch();
     }
 
     _watchDog.SetWarnHandler([logger = _logger, type = this](std::chrono::milliseconds timeout) {
@@ -393,8 +393,7 @@ TimeSyncService::TimeSyncService(Core::IParticipantInternal* participant, ITimeP
                             // At this point, the late-joiner will receive it because its TimeSyncPolicy is configured when the
                             // discovery arrives that triggered this handler.
                             _logger->MakeMessage(Logging::Level::Debug, TopicOf(*this))
-                                .SetMessage(
-                                    "Participant is joining an already running simulation. Resending our NextSimTask.")
+                                .SetMessage("Participant is joining an already running simulation. Resending our NextSimTask.")
                                 .Dispatch();
 
                             if (GetTimeSyncPolicy()->IsExecutingSimStep())
@@ -418,9 +417,8 @@ TimeSyncService::TimeSyncService(Core::IParticipantInternal* participant, ITimeP
                         // Other participant hopped off
                         if (_timeConfiguration.RemoveSynchronizedParticipant(descriptorParticipantName))
                         {
-                            _logger->MakeMessage(Logging::Level::Debug, TopicOf(*this))
-                                .SetMessage("TimeSyncService: Participant is no longer part of the distributed time "
-                                            "synchronization.")
+                             _logger->MakeMessage(Logging::Level::Debug, TopicOf(*this))
+                                .SetMessage("TimeSyncService: Participant is no longer part of the distributed time synchronization.")
                                 .AddKeyValue(Logging::Keys::participantName, descriptorParticipantName)
                                 .Dispatch();
 
@@ -539,8 +537,7 @@ void TimeSyncService::ExecuteSimStep(std::chrono::nanoseconds timePoint, std::ch
 
     _logger->MakeMessage(Logging::Level::Trace, TopicOf(*this))
         .SetMessage("Starting next Simulation Step.")
-        .AddKeyValue(Logging::Keys::waitingTime,
-                     std::chrono::duration_cast<DoubleMSecs>(_waitTimeMonitor.CurrentDuration()).count())
+        .AddKeyValue(Logging::Keys::waitingTime, std::chrono::duration_cast<DoubleMSecs>(_waitTimeMonitor.CurrentDuration()).count())
         .AddKeyValue(Logging::Keys::virtualTimeNS, timePoint.count())
         .Dispatch();
 
@@ -580,7 +577,7 @@ void TimeSyncService::ExecuteSimStep(std::chrono::nanoseconds timePoint, std::ch
 void TimeSyncService::LogicalSimStepCompleted(std::chrono::duration<double, std::milli> logicalSimStepTimeMs)
 {
     _simStepCounterMetric->Add(1);
-
+ 
     _logger->MakeMessage(Logging::Level::Trace, TopicOf(*this))
         .SetMessage("Finished Simulation Step.")
         .AddKeyValue(Logging::Keys::executionTime, logicalSimStepTimeMs.count())
@@ -604,7 +601,9 @@ void TimeSyncService::CompleteSimulationStep()
     }
     else
     {
-        _logger->MakeMessage(Logging::Level::Debug, TopicOf(*this)).SetMessage("CompleteSimulationStep()").Dispatch();
+        _logger->MakeMessage(Logging::Level::Debug, TopicOf(*this))
+            .SetMessage("CompleteSimulationStep()")
+            .Dispatch();
     }
 
     _participant->ExecuteDeferred([this] {
@@ -662,7 +661,9 @@ void TimeSyncService::InitializeTimeSyncPolicy(bool isSynchronizingVirtualTime)
     }
     catch (const std::exception& e)
     {
-        _logger->MakeMessage(Logging::Level::Critical, TopicOf(*this)).SetMessage(e.what()).Dispatch();
+        _logger->MakeMessage(Logging::Level::Critical, TopicOf(*this))
+            .SetMessage(e.what())
+            .Dispatch();
         throw;
     }
 }
@@ -732,12 +733,11 @@ bool TimeSyncService::ParticipantHasAutonomousSynchronousCapability(const std::s
         // We are a participant with autonomous lifecycle and virtual time sync.
         // The remote participant must support this, otherwise Hop-On / Hop-Off will fail.
 
-        _logger->MakeMessage(Logging::Level::Error, TopicOf(*this))
-            .SetMessage(
-                "This participant does not support simulations with participants that use an autonomous lifecycle "
+            _logger->MakeMessage(Logging::Level::Error, TopicOf(*this))
+                .SetMessage( "This participant does not support simulations with participants that use an autonomous lifecycle "
                 "and virtual time synchronization. Please consider upgrading Participant. Aborting simulation...")
-            .AddKeyValue(Logging::Keys::participantName, participantName)
-            .Dispatch();
+                .AddKeyValue(Logging::Keys::participantName, participantName)
+                .Dispatch();
         return false;
     }
     return true;
@@ -750,9 +750,8 @@ bool TimeSyncService::AbortHopOnForCoordinatedParticipants() const
         if (_lifecycleService->GetOperationMode() == OperationMode::Coordinated)
         {
             _logger->MakeMessage(Logging::Level::Error, TopicOf(*this))
-                .SetMessage("This participant is running with a coordinated lifecycle and virtual time synchronization "
-                            "and wants "
-                            "to join an already running simulation. This is not allowed, aborting simulation...")
+                .SetMessage("This participant is running with a coordinated lifecycle and virtual time synchronization and wants "
+                "to join an already running simulation. This is not allowed, aborting simulation...")
                 .AddKeyValue(Logging::Keys::participantName, _participant->GetParticipantName())
                 .Dispatch();
             _participant->GetSystemController()->AbortSimulation();

--- a/SilKit/source/services/orchestration/TimeSyncService.cpp
+++ b/SilKit/source/services/orchestration/TimeSyncService.cpp
@@ -308,16 +308,17 @@ TimeSyncService::TimeSyncService(Core::IParticipantInternal* participant, ITimeP
     if (_isCoupledToWallClock)
     {
         _logger->MakeMessage(Logging::Level::Debug, TopicOf(*this))
-        .SetMessage("Coupled to the local wall clock with animation factor")
-        .AddKeyValue(Logging::Keys::animationFactor, _animationFactor)
-        .Dispatch();
+            .SetMessage("Coupled to the local wall clock with animation factor")
+            .AddKeyValue(Logging::Keys::animationFactor, _animationFactor)
+            .Dispatch();
     }
 
     _watchDog.SetWarnHandler([logger = _logger, type = this](std::chrono::milliseconds timeout) {
+        const auto timeoutMs = std::chrono::duration_cast<std::chrono::duration<double, std::milli>>(timeout).count();
 
         logger->MakeMessage(Logging::Level::Warn, TopicOf(*type))
-            .SetMessage("SimStep did not finish within soft time limit. Timeout detected after {} ms")
-            .AddKeyValue(Logging::Keys::timeoutTime, std::chrono::duration_cast<std::chrono::duration<double, std::milli>>(timeout).count())
+            .SetMessage("SimStep did not finish within soft time limit. Timeout detected after {} ms", timeoutMs)
+            .AddKeyValue(Logging::Keys::timeoutTime, timeoutMs)
             .Dispatch();
     });
     _watchDog.SetErrorHandler([this](std::chrono::milliseconds timeout) {
@@ -392,7 +393,8 @@ TimeSyncService::TimeSyncService(Core::IParticipantInternal* participant, ITimeP
                             // At this point, the late-joiner will receive it because its TimeSyncPolicy is configured when the
                             // discovery arrives that triggered this handler.
                             _logger->MakeMessage(Logging::Level::Debug, TopicOf(*this))
-                                .SetMessage("Participant is joining an already running simulation. Resending our NextSimTask.")
+                                .SetMessage(
+                                    "Participant is joining an already running simulation. Resending our NextSimTask.")
                                 .Dispatch();
 
                             if (GetTimeSyncPolicy()->IsExecutingSimStep())
@@ -416,8 +418,9 @@ TimeSyncService::TimeSyncService(Core::IParticipantInternal* participant, ITimeP
                         // Other participant hopped off
                         if (_timeConfiguration.RemoveSynchronizedParticipant(descriptorParticipantName))
                         {
-                             _logger->MakeMessage(Logging::Level::Debug, TopicOf(*this))
-                                .SetMessage("TimeSyncService: Participant is no longer part of the distributed time synchronization.")
+                            _logger->MakeMessage(Logging::Level::Debug, TopicOf(*this))
+                                .SetMessage("TimeSyncService: Participant is no longer part of the distributed time "
+                                            "synchronization.")
                                 .AddKeyValue(Logging::Keys::participantName, descriptorParticipantName)
                                 .Dispatch();
 
@@ -514,9 +517,12 @@ void TimeSyncService::ReceiveMsg(const IServiceEndpoint* from, const NextSimTask
     }
     else
     {
+        const auto& participantName = from->GetServiceDescriptor().GetParticipantName();
+
         _logger->MakeMessage(Logging::Level::Trace, TopicOf(*this))
-            .SetMessage("Received NextSimTask from participant \'{}\' but TimeSyncPolicy is not yet configured")
-            .AddKeyValue(Logging::Keys::participantName, from->GetServiceDescriptor().GetParticipantName())
+            .SetMessage("Received NextSimTask from participant \'{}\' but TimeSyncPolicy is not yet configured",
+                        participantName)
+            .AddKeyValue(Logging::Keys::participantName, participantName)
             .Dispatch();
     }
 }
@@ -533,7 +539,8 @@ void TimeSyncService::ExecuteSimStep(std::chrono::nanoseconds timePoint, std::ch
 
     _logger->MakeMessage(Logging::Level::Trace, TopicOf(*this))
         .SetMessage("Starting next Simulation Step.")
-        .AddKeyValue(Logging::Keys::waitingTime, std::chrono::duration_cast<DoubleMSecs>(_waitTimeMonitor.CurrentDuration()).count())
+        .AddKeyValue(Logging::Keys::waitingTime,
+                     std::chrono::duration_cast<DoubleMSecs>(_waitTimeMonitor.CurrentDuration()).count())
         .AddKeyValue(Logging::Keys::virtualTimeNS, timePoint.count())
         .Dispatch();
 
@@ -573,7 +580,7 @@ void TimeSyncService::ExecuteSimStep(std::chrono::nanoseconds timePoint, std::ch
 void TimeSyncService::LogicalSimStepCompleted(std::chrono::duration<double, std::milli> logicalSimStepTimeMs)
 {
     _simStepCounterMetric->Add(1);
- 
+
     _logger->MakeMessage(Logging::Level::Trace, TopicOf(*this))
         .SetMessage("Finished Simulation Step.")
         .AddKeyValue(Logging::Keys::executionTime, logicalSimStepTimeMs.count())
@@ -597,9 +604,7 @@ void TimeSyncService::CompleteSimulationStep()
     }
     else
     {
-        _logger->MakeMessage(Logging::Level::Debug, TopicOf(*this))
-            .SetMessage("CompleteSimulationStep()")
-            .Dispatch();
+        _logger->MakeMessage(Logging::Level::Debug, TopicOf(*this)).SetMessage("CompleteSimulationStep()").Dispatch();
     }
 
     _participant->ExecuteDeferred([this] {
@@ -657,9 +662,7 @@ void TimeSyncService::InitializeTimeSyncPolicy(bool isSynchronizingVirtualTime)
     }
     catch (const std::exception& e)
     {
-        _logger->MakeMessage(Logging::Level::Critical, TopicOf(*this))
-            .SetMessage(e.what())
-            .Dispatch();
+        _logger->MakeMessage(Logging::Level::Critical, TopicOf(*this)).SetMessage(e.what()).Dispatch();
         throw;
     }
 }
@@ -729,11 +732,12 @@ bool TimeSyncService::ParticipantHasAutonomousSynchronousCapability(const std::s
         // We are a participant with autonomous lifecycle and virtual time sync.
         // The remote participant must support this, otherwise Hop-On / Hop-Off will fail.
 
-            _logger->MakeMessage(Logging::Level::Error, TopicOf(*this))
-                .SetMessage( "This participant does not support simulations with participants that use an autonomous lifecycle "
+        _logger->MakeMessage(Logging::Level::Error, TopicOf(*this))
+            .SetMessage(
+                "This participant does not support simulations with participants that use an autonomous lifecycle "
                 "and virtual time synchronization. Please consider upgrading Participant. Aborting simulation...")
-                .AddKeyValue(Logging::Keys::participantName, participantName)
-                .Dispatch();
+            .AddKeyValue(Logging::Keys::participantName, participantName)
+            .Dispatch();
         return false;
     }
     return true;
@@ -746,8 +750,9 @@ bool TimeSyncService::AbortHopOnForCoordinatedParticipants() const
         if (_lifecycleService->GetOperationMode() == OperationMode::Coordinated)
         {
             _logger->MakeMessage(Logging::Level::Error, TopicOf(*this))
-                .SetMessage("This participant is running with a coordinated lifecycle and virtual time synchronization and wants "
-                "to join an already running simulation. This is not allowed, aborting simulation...")
+                .SetMessage("This participant is running with a coordinated lifecycle and virtual time synchronization "
+                            "and wants "
+                            "to join an already running simulation. This is not allowed, aborting simulation...")
                 .AddKeyValue(Logging::Keys::participantName, _participant->GetParticipantName())
                 .Dispatch();
             _participant->GetSystemController()->AbortSimulation();

--- a/docs/changelog/versions/latest.md
+++ b/docs/changelog/versions/latest.md
@@ -8,6 +8,8 @@
 ## Fixed
 
 - Fix ITest_AsyncSimTask (test failed when run repeatedly)
+- Fix the `TimeSyncService` warning about an exceeded soft time limit, which showed a literal `{}` instead of the
+  measured timeout in milliseconds
 
 ## Changed
 


### PR DESCRIPTION
fix log messages with missing argument in timesync service.