### PR TITLE
cleanup: remove dead mutexes, properly take lock

### DIFF
--- a/SilKit/source/services/orchestration/LifecycleService.hpp
+++ b/SilKit/source/services/orchestration/LifecycleService.hpp
@@ -148,7 +148,6 @@ private:
     std::atomic<bool> _timeSyncActive{false};
 
     // Final State Handling
-    std::mutex _finalStatePromiseMutex;
     std::unique_ptr<std::promise<ParticipantState>> _finalStatePromise;
 
     std::future<ParticipantState> _finalStateFuture;

--- a/SilKit/source/services/orchestration/TimeSyncService.hpp
+++ b/SilKit/source/services/orchestration/TimeSyncService.hpp
@@ -159,7 +159,6 @@ private:
     WatchDog _watchDog;
     bool _isCoupledToWallClock{false};
     std::thread _wallClockCouplingThread;
-    mutable std::mutex _mx;
     std::atomic<std::chrono::nanoseconds::rep> _currentWallClockSyncPointNs{0};
     double _animationFactor{0};
     std::atomic<bool> _wallClockCouplingThreadRunning{false};

--- a/SilKit/source/tracing/PcapSink.cpp
+++ b/SilKit/source/tracing/PcapSink.cpp
@@ -40,6 +40,8 @@ void PcapSink::Open(SinkType outputType, const std::string& outputPath)
         throw SilKitError("PcapSink::Open: outputPath must not be empty!");
     }
 
+    std::unique_lock<decltype(_lock)> lock{_lock};
+
     switch (outputType)
     {
     case SilKit::SinkType::PcapFile:
@@ -73,6 +75,8 @@ auto PcapSink::Name() const -> const std::string&
 
 void PcapSink::Close()
 {
+    std::unique_lock<decltype(_lock)> lock{_lock};
+
     if (_file)
     {
         _file.flush();
@@ -107,7 +111,7 @@ void PcapSink::Trace(SilKit::Services::TransmitDirection /*unused*/,
     }
     const auto& message = traceMessage.Get<Services::Ethernet::EthernetFrame>();
 
-    std::unique_lock<decltype(_lock)> lock;
+    std::unique_lock<decltype(_lock)> lock{_lock};
 
     const auto tosec = 1000'000ull;
     const auto usec = std::chrono::duration_cast<std::chrono::microseconds>(timestamp);


### PR DESCRIPTION
Sweep across the source tree, check what mutexes are not properly taken or have not been in use at all.
Triggered by #420