### PR TITLE
docs: fix section title underline

### DIFF
--- a/docs/overview/overview.rst
+++ b/docs/overview/overview.rst
@@ -81,7 +81,7 @@ As a result, an application that works in the |fastBus| use case also works when
 The :ref:`sec:api-services` section describes how to configure and use the vehicle network services (valid for both modes).
 
 Choosing the Right Simulation Mode
-~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 As a practical default, start with |fastBus| unless the need for detailed network simulation is clear.
 Switch to |accurateBus| when timing fidelity or protocol-level effects are required.


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2023 Vector Informatik GmbH

SPDX-License-Identifier: MIT
-->

## Subject
<!--
    - What kind of changes does this pull request comprise?
    - Add a label like "Bugfix", "docs", etc. to this PR to give context.
 -->

Fixes a invlaid title underline that causes a warning during the documentation build.

## Developer checklist (address before review)

- [ ] Changelog.md updated
- [ ] Prepared update for depending repositories
- [ ] Documentation updated (public API changes only)
- [ ] API docstrings updated (public API changes only)
- [ ] Rebase &rarr; commit history clean
- [ ] Squash and merge &rarr; proper PR title
